### PR TITLE
Fix undefined offset/variable notices on index and in widgets.

### DIFF
--- a/home-part-sticky-posts.php
+++ b/home-part-sticky-posts.php
@@ -1,6 +1,5 @@
 <?php
 global $ids;
-$sticky = get_option( 'sticky_posts' );
 //$query = new WP_Query( 'p=' . $sticky[0] );
 
 $sticky = get_option( 'sticky_posts' );
@@ -13,7 +12,7 @@ $query = new WP_Query( $args );
 
 if ( $query->have_posts() ) {
 	while ( $query->have_posts() ) : $query->the_post();
-		if ( $sticky[0] && ! is_paged() ) {
+		if ( $sticky && $sticky[0] && ! is_paged() ) {
 ?>
 
 			<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix sticky '); ?>>

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -24,7 +24,7 @@ function twitter_url_to_username ($url) {
 if ( ! function_exists( 'largo_opengraph' ) ) {
 	function largo_opengraph() {
 
-		global $current_url;
+		global $current_url, $post;
 
 		// set a default thumbnail, if a post has a featured image use that instead
 		$thumbnailURL = of_get_option( 'logo_thumbnail_sq' );

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -52,6 +52,7 @@ if ( ! function_exists( 'largo_author' ) ) {
  */
 if ( ! function_exists( 'largo_author_link' ) ) {
 	function largo_author_link( $echo = true ) {
+		global $post;
 		$values = get_post_custom( $post->ID );
 		$byline_text = isset( $values['largo_byline_text'] ) ? esc_attr( $values['largo_byline_text'][0] ) : '';
 		$byline_link = isset( $values['largo_byline_link'] ) ? esc_url( $values['largo_byline_link'][0] ) : '';
@@ -361,14 +362,16 @@ function largo_trim_sentences( $input, $sentences, $echo = false ) {
 
 	$strings = preg_split( $re, strip_tags( strip_shortcodes( $input ) ), -1, PREG_SPLIT_NO_EMPTY);
 
-	for ( $i = 0; $i < $sentences; $i++ ) {
+	$output = '';
+
+	for ( $i = 0; $i < $sentences && $i < count($strings); $i++ ) {
 		if ( $strings[$i] != '' )
 			$output .= $strings[$i] . ' ';
 	}
 
 	if ( $echo )
 		echo $output;
-
+	
 	return $output;
 }
 


### PR DESCRIPTION
A couple were just undeclared globals, but the undefined offsets in /inc/post-tags.php stemmed from `largo_trim_sentences()` always assuming any post would have at least the specified number of sentences (default 5).
