### PR TITLE
Smarter picturefill shortcode

### DIFF
--- a/inc/images.php
+++ b/inc/images.php
@@ -68,10 +68,18 @@ add_action( 'after_setup_theme', 'largo_set_media_options' );
  */
 function largo_send_image_to_editor($html, $post_id, $caption, $title, $align, $url, $size, $alt) {
 
-	// NOTE: This functionality also bypasses the Navis-Media-Credit plugin's [caption][/caption]
-	// wrapper.
+	// Check for [caption ...] in the HTML. This is put in for compatability with 
+	// Navis-Media-Credit plugin's [caption][/caption] wrapper.
+	$matched = preg_match('#\[caption[^\]]*\]#', $html, $matches);
 
 	$shortcode = '';
+
+	if ($matched > 0 && $matches[0] != '') {
+	
+		//mixed preg_replace ( mixed $pattern , mixed $replacement , mixed $subject [, int $limit = -1 [, int &$count ]] )
+		$matches[0] = preg_replace( '/width="([0-9]+)"/', 'width="x"', $matches[0]);
+		$shortcode .= $matches[0];
+	}
 
 	$shortcode .= '[picturefill id="' . $post_id . '"';
 	if ($title){
@@ -82,9 +90,13 @@ function largo_send_image_to_editor($html, $post_id, $caption, $title, $align, $
 	}
 	$shortcode .= ' ]';
 
+	if ($matched > 0 && $matches[0] != '') {
+		$shortcode .= '[/caption]';
+	}
+
 	return $shortcode;
 }
-//add_filter('image_send_to_editor', 'largo_send_image_to_editor', 1, 8);
+add_filter('image_send_to_editor', 'largo_send_image_to_editor', 20, 8);
 
 
 function largo_picturefill_shortcode($attributes, $content = null) {


### PR DESCRIPTION
This is a revised version of the picturefill implementation that should work better with the Navis Media Credit plugin, which previously was causing problems with hard-coded <div> element widths. This new picturefill now runs after the media credit plugin, with the picturefill shortcode insertion code now looking for an existing `[caption]` in the $html that's passed to it. If it finds one, it extracts that information and wraps it around the picturefill shortcode that is inserted into the post. If there is no `[caption]` then nothing happens.

The Navis Media Credit (NMC) plugin's shortcode runs with priority 19. The picturefill shortcode insertion must run after this, so it has been changed to priority 20.
