### PR TITLE
Metabox api, revised

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -53,12 +53,12 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Load up all of the other goodies from the /inc directory
  */
 $includes = array(
+	'/largo-apis.php',	// a list of recommended plugins
 	'/inc/largo-plugin-init.php',	// a list of recommended plugins
 	'/inc/dashboard.php',			// custom dashboard widgets
 	'/inc/robots.php',				// default robots.txt config
 	'/inc/custom-feeds.php',			// create custom RSS feeds
 	'/inc/users.php',				// add custom fields for user profiles
-	'/inc/metabox-api.php',				// library-esque convenience functions for hooking into Largo meta boxen
 	'/inc/sidebars.php',				// register sidebars
 	'/inc/widgets.php',				// register widgets
 	'/inc/nav-menus.php',			// register nav menus

--- a/inc/metabox-api.php
+++ b/inc/metabox-api.php
@@ -1,9 +1,17 @@
 <?php
-
 /**
  * Contains function definitions for hooking fields and boxes into Largo
  * Relies on the global variable $largo, which feels hack-ish but creates the most convenience
  */
+
+/**
+ * First things first: check if $largo['meta'] exists
+ * If it does, then this file has already been included (likely by a child theme) and should stop.
+ * Otherwise we get function redeclarations.
+ * Since we're using include_once() this is unlikely, but possible and worth checking.
+ */
+if ( is_array($largo['meta']) ) return;
+
 $largo['meta'] = array(
 	'boxes' => array(),		// the metaboxes to generate, including callbacks for the content
 	'inputs' => array(),	// input names to process with largo_meta_box_save()

--- a/largo-apis.php
+++ b/largo-apis.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file acts as a wrapper around APIs that exist within Largo.
+ * It should be included in any Largo child themes like so:
+ * require_once( get_template_directory() . '/largo-apis.php' );
+ */
+
+$includes = array(
+	'/inc/metabox-api.php',				// library-esque convenience functions for hooking into Largo meta boxen
+);
+
+// Perform load
+foreach ( $includes as $include ) {
+	include_once( get_template_directory() . $include );
+}


### PR DESCRIPTION
Slight re-architecting of things. The metabox API itself is unchanged, but I changed how it's included. The new approach relies on a separate and new largo-apis.php file to bring in the metabox-api. This is because child themes will need to access the API in their functions.php files, but due to how WP loads parent/child files, Largo's functions.php won't have been loaded when a child's functions.php is called.

This solution allows us to separate out the metabox-api file (and any others we wind up with, such as homepage templates) so that it can be included in a child theme without loading all of the Largo functions, by putting this atop the child's functions.php:

require_once( get_template_directory() . '/largo-apis.php' );
