### PR TITLE
Less/css enhancements

### DIFF
--- a/inc/custom-less-variables.php
+++ b/inc/custom-less-variables.php
@@ -472,11 +472,11 @@ class Largo_Custom_Less_Variables {
 		<ol>
 			<li>
 				<?php if ( empty($current_revision) ): ?>
-					<strong><?php echo mysql2date( 'j F, Y @ H:m:s', $post->post_date ); ?></strong>
+					<strong><?php echo mysql2date( 'j F, Y @ H:m:s', $post->post_modified ); ?></strong>
 				<?php else: ?>
 					<a href="themes.php?page=largo_custom_less_variables"><?php echo mysql2date( 'j F, Y @ H:m:s', $post->post_date ); ?></a>
 				<?php endif; ?>
-				<?php _e( '[Active]', 'largo' ); ?>
+				<?php _e( '[Live]', 'largo' ); ?>
 			</li>
 
 			<?php foreach ( $revisions as $revision ): ?>


### PR DESCRIPTION
Revamp of the LESS management system!

As you'll recall, it was creating a new post in the DB when a user saved their settings, resulting in big DB issues.

Now on save, it overrides the existing post (it's a special type of post), which allows us to also leverage WP's revisions system. It saves up to 5 revisions, listed in the sidebar of the admin page. 

These post revisions just store a JSON string of variables, rather than the compiled CSS. The compiled CSS lives in a postmeta field and is kept only for the active revision. 
