### PR TITLE
Author info widget

### DIFF
--- a/content-single.php
+++ b/content-single.php
@@ -60,10 +60,6 @@
  			<?php endif; ?>
 
 		<?php
-		// Author bio and social links
-		if ( largo_show_author_box() )
-			get_template_part( 'largo-author-box' );
-
 		// Related posts
 		if ( of_get_option( 'show_related_content' ) )
 			get_template_part( 'largo-related-posts' );

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -34,6 +34,7 @@ function largo_widgets() {
 		'largo_taxonomy_list_widget'	=> '/inc/widgets/largo-taxonomy-list.php',
 		'largo_twitter_widget'			=> '/inc/widgets/largo-twitter.php',
 		'largo_related_posts_widget'			=> '/inc/widgets/largo-related-posts.php'
+		'largo_author_widget'			=> '/inc/widgets/largo-author-bio.php'
 	);
 	foreach ( $register as $key => $val ) {
 		require_once( get_template_directory() . $val );

--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Author Bio Widget
+ */
+class largo_author_widget extends WP_Widget {
+
+	function largo_author_widget() {
+		$widget_ops = array(
+			'classname' 	=> 'largo-author',
+			'description'	=> __('Show the author bio in a widget', 'largo')
+		);
+		$this->WP_Widget( 'largo-author-widget', __('Largo Author Bio', 'largo'), $widget_ops);
+	}
+
+	function widget( $args, $instance ) {
+		extract( $args );
+
+		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Author', 'largo') : $instance['title'], $instance, $this->id_base);
+		
+		if(is_single() && largo_show_author_box()):
+				echo $before_widget;
+				echo $before_title . $title . $after_title;
+				get_template_part( 'largo-author-box' );
+				echo $after_widget;
+		endif;
+
+	}
+
+	function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+		$instance['title'] = strip_tags( $new_instance['title'] );
+		return $instance;
+	}
+
+	function form( $instance ) {
+		$defaults = array( 'title' => __('Author', 'largo') );
+		$instance = wp_parse_args( (array) $instance, $defaults );
+		?>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e('Title:', 'largo'); ?></label>
+			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo $instance['title']; ?>" style="width:90%;" />
+		</p>
+	<?php
+	}
+}


### PR DESCRIPTION
Pretty straightforward, converting the existing author information logic into an actual widget and cleaning out the old stuff. We left largo-author-box as a separate template here to facilitate design modifications.

Disregard the crazt branch name, my previous attempts at this resulted in ugly github errors. 
