### PR TITLE
Implementing custom sidebar chooser for categories and tags

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -69,6 +69,7 @@ $includes = array(
 	'/inc/nav-menus.php',			// register nav menus
 	'/inc/taxonomies.php',			// add our custom taxonomies
 	'/inc/term-icons.php',			// add our custom taxonomies
+	'/inc/term-sidebars.php',			// add our custom taxonomies
 	'/inc/images.php',				// setup custom image sizes
 	'/inc/editor.php',				// add tinymce customizations and shortcodes
 	'/inc/post-meta.php',			// add post meta boxes

--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -140,15 +140,24 @@ function largo_make_slug($string, $maxLength = 63) {
  * @since 1.0
  */
 if( !function_exists( 'custom_sidebars_dropdown' ) ) {
-	function custom_sidebars_dropdown( $selected = '', $skip_default = false ) {
+	function custom_sidebars_dropdown( $selected = '', $skip_default = false, $post_id = NULL ) {
 		global $wp_registered_sidebars, $post;
-		$custom = ( $selected ) ? $selected : get_post_meta( $post->ID, 'custom_sidebar', true );
-		$val = ( $custom ) ? $custom : 'none';
+		$the_id = ( $post_id ) ? $post_id : $post->ID ;
+		$custom = ( $selected ) ? $selected : get_post_meta( $the_id, 'custom_sidebar', true );
+		$val = ( $custom ) ? $custom : 'default';
+		echo "banana";
 
 		// Add a default option
 		if ( ! $skip_default ) {
-			$output .= '<option value="default" '.selected('default',$val).'>' . __( 'Default', 'largo' ) . '</option>';
+			$output .= '<option value="default" ';
+			$output .= selected( 'default', $val, false );
+			$output .= '>' . __( 'Default', 'largo' ) . '</option>';
 		}
+
+		// Add a 'none' option
+		$output .= '<option value="none" ';
+		$output .= selected( 'none', $val, false );
+		$output .= '>' . __( 'None', 'largo' ) . '</option>';
 
 		// Filter list of sidebars to exclude those we don't want users to choose
 		$excluded = array(
@@ -161,7 +170,7 @@ if( !function_exists( 'custom_sidebars_dropdown' ) ) {
 			//check if excluded
 			if ( in_array( $sidebar_id, $excluded ) || in_array( $sidebar['name'], $excluded ) ) continue;
 
-			$output .= '<option value="' . $sidebar_id . '" ' . selected($sidebar_id, $val) . '>' . $sidebar['name'] . '</option>';
+			$output .= '<option value="' . $sidebar_id . '" ' . selected($sidebar_id, $val, false) . '>' . $sidebar['name'] . '</option>';
 		}
 
 		echo $output;

--- a/inc/term-sidebars.php
+++ b/inc/term-sidebars.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Display the fields for selecting icons for terms in the "post-type" taxonomy
+ */
+class Largo_Term_Sidebars {
+
+	function __construct() {
+		add_action( 'edit_category_form_fields', array( $this, 'display_fields' ) );
+		add_action( 'edit_tag_form_fields', array( $this, 'display_fields' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts') );
+		add_action( 'edit_terms', array( $this, 'edit_terms' ) );
+		add_action( 'create_term', array( $this, 'edit_terms' ) );
+	}
+
+	/**
+	 *
+	 */
+	function get_sidebar_taxonomies() {
+		if ( empty($this->_sidebar_taxonomies) ) {
+			$this->_sidebar_taxonomies = apply_filters( 'largo_get_sidebar_taxonomies', array( 'category', 'post_tag' ) );
+		}
+		return $this->_sidebar_taxonomies;
+	}
+
+	/**
+	 * Renders the form fields on the term edit page
+	 */
+	function display_fields( $term ) {
+		if ( !in_array( $term->taxonomy, $this->get_sidebar_taxonomies() ) ) {
+			// abort if the term doesn't belong to the taxonomies to have icons
+			return;
+		}
+
+		//get the proxy post id
+		$post_id = largo_get_term_meta_post( $term->taxonomy, $term->term_id );
+		$current_value = largo_get_term_meta( $term->taxonomy, $term->term_id, 'custom_sidebar', true );
+		?>
+		<tr class="form-field">
+			<th scope="row" valign="top"><label for="custom_sidebar"><?php _e('Archive Sidebar', 'largo'); ?></label></th>
+			<td>
+				<select name="custom_sidebar" id="custom_sidebar" style="min-width: 300px;">
+					<?php custom_sidebars_dropdown( $current_value, false, $post_id ); //get the options ?>
+				</select>
+				<br/>
+				<p class="description"><?php _e("The sidebar to display on this term's archive page.", 'largo'); ?></p>
+				<?php
+				wp_nonce_field( 'custom_sidebar-'.$term->term_id, '_custom_sidebar_nonce' );
+				?>
+			</td>
+		</tr>
+		<?php
+	}
+
+	function display_add_new_field( $taxonomy ) {
+		?>
+		<div class="form-field">
+			<label for="custom_sidebar"><?php _e('Archive Sidebar', 'largo'); ?></label>
+			<select name="custom_sidebar" id="custom_sidebar" style="min-width: 300px;">
+				<?php custom_sidebars_dropdown( '', false, 0 ); //get the options ?>
+			</select>
+			<p class="description"><?php _e('The sidebar to show on this term\'s archive.', 'largo'); ?></p>
+			<?php wp_nonce_field( 'custom_sidebar-new', '_custom_sidebar_nonce' ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Attach the Javascript and Stylesheets to the term edit page
+	 */
+	function admin_enqueue_scripts( $hook_suffix ) {
+
+		if ( $hook_suffix == 'edit-tags.php' && !empty($_REQUEST['taxonomy']) ) {
+			if ( !in_array( $_REQUEST['taxonomy'], $this->get_sidebar_taxonomies() ) ) {
+				// abort if the term doesn't belong to the taxonomies to have icons
+				return;
+			}
+
+			add_action( $_REQUEST['taxonomy'].'_add_form_fields', array( $this, 'display_add_new_field' ) );
+		}
+	}
+
+	/**
+	 * Save the results from the term edit page
+	 */
+	function edit_terms( $term_id ) {
+		$nonce_action = $_POST['action'] == 'add-tag' ? 'custom_sidebar-new' : 'custom_sidebar-'.$term_id ;
+
+		if ( isset($_POST['_custom_sidebar_nonce']) && wp_verify_nonce($_POST['_custom_sidebar_nonce'], $nonce_action ) ) {
+			$taxonomy = $_REQUEST['taxonomy'];
+			largo_update_term_meta( $taxonomy, $term_id, 'custom_sidebar', $_POST['custom_sidebar'] );
+		}
+	}
+}
+
+$largo['term-sidebars'] = new Largo_Term_Sidebars();

--- a/sidebar.php
+++ b/sidebar.php
@@ -10,10 +10,18 @@ do_action('largo_before_sidebar');
 	<div class="widget-area<?php if ( is_single() && of_get_option( 'showey-hidey' ) ) echo ' showey-hidey'; ?>" role="complementary">
 		<?php
 			do_action('largo_before_sidebar_widgets');
-			$custom_sidebar = get_post_meta(get_the_ID(), 'custom_sidebar', true);
+
+			$custom_sidebar = false;
+			//get a custom sidebar if appropriate
+			if ( is_singular() ) {
+				$custom_sidebar = get_post_meta(get_the_ID(), 'custom_sidebar', true);
+			} else if ( is_archive() ) {
+				$term = get_queried_object();
+				$custom_sidebar = largo_get_term_meta( $term->taxonomy, $term->term_id, 'custom_sidebar', true );
+			}
 
 			//load custom sidebar if appropriate
-			if ( is_singular() && $custom_sidebar && $custom_sidebar !== 'default') {
+			if ( $custom_sidebar && $custom_sidebar !== 'default') {
 				dynamic_sidebar($custom_sidebar);
 
 			//load single-post sidebar if it has things


### PR DESCRIPTION
This latest bit leans on the term-meta architecture already built for term icons to allow users to select sidebars to show on category/tag archive pages.

Because this uses that term-meta architecture, which is in the feature/homepages branch, I'm requesting a pull into that branch (rather than master). 
