### PR TITLE
Fixing a bug on author archive pages

### DIFF
--- a/largo-author-box.php
+++ b/largo-author-box.php
@@ -3,8 +3,10 @@
 
 if ( function_exists( 'get_coauthors' ) )
 	$authors = get_coauthors( $post->ID );
-else
+else if ( is_author() )
 	$authors[] = get_userdata( get_query_var('author') );
+else
+	$authors[] = get_userdata( get_the_author_meta( 'ID' ) );
 
 foreach( $authors as $author ) {
 ?>


### PR DESCRIPTION
CT Mirror flagged an issue with author archive pages not properly listing meta fields with values present — email would show but not Twitter, etc. After some testing I determined the author ID wasn't being fetched properly... per an example at http://codex.wordpress.org/Author_Templates I've switched the way the author ID is fetched when on an author archive page. This should probably be accepted and pushed into prod to help CT Mirror (and possibly others).
