### PR TITLE
largo_post_social_links() needs proper escaping

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -145,7 +145,7 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 		$output = '<div class="post-social clearfix"><div class="left">';
 
 		if ( $utilities['twitter'] === '1' ) {
-			$twitter_link = of_get_option( 'twitter_link' ) ? 'data-via="' . esc_url( twitter_url_to_username( of_get_option( 'twitter_link' ) ) ) . '"' : '';
+			$twitter_link = of_get_option( 'twitter_link' ) ? 'data-via="' . esc_attr( twitter_url_to_username( of_get_option( 'twitter_link' ) ) ) . '"' : '';
 			$twitter_related = get_the_author_meta( 'twitter' ) ? sprintf( __( '%s:Follow the author of this article', 'largo' ), get_the_author_meta( 'twitter' ) ) : '';
 			$twitter_count = (of_get_option( 'show_twitter_count' ) == 0) ? 'data-count="none"' : '';
 


### PR DESCRIPTION
It's outputting user data without escaping:

```
$output .= sprintf(__('<span class="twitter"><a href="http://twitter.com/share" class="twitter-share-button" data-url="%1$s" data-text="%2$s" %3$s %4$s %5$s>Tweet</a></span>', 'largo'),
                get_permalink(),
                get_the_title(),
                $twitter_link,
                $twitter_related,
                $twitter_count
            );
```
