### PR TITLE
Create Largo()->is_plugin_active() helper method

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -150,6 +150,9 @@ class Largo {
 			case 'ad-code-manager':
 				return (bool) class_exists( 'Ad_Code_Manager' );
 
+			case 'co-authors-plus':
+				return (bool) class_exists( 'coauthors_plus' );
+
 			default:
 				return false;
 		}

--- a/inc/post-meta.php
+++ b/inc/post-meta.php
@@ -6,7 +6,7 @@
  * @since 1.0
  */
 //
-if ( !is_plugin_active('co-authors-plus/co-authors-plus.php') ) {
+if ( ! Largo()->is_plugin_active( 'co-authors-plus' ) ) {
 	function move_author_to_publish_metabox() {
 		global $post_ID;
 		$post = get_post( $post_ID );


### PR DESCRIPTION
Reduces dependence on `is_plugin_active()`, which isn't performant and has an unnecessary dependency on plugin path
