### PR TITLE
Add proper sanitization to `largo_meta_box_save()`

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -582,7 +582,7 @@ class Largo_Related {
 	public function ids() {
 
 		//see if this post has manually set related posts
-		$post_ids = get_post_meta( $this->post_id, '_largo_custom_related_posts', true );
+		$post_ids = get_post_meta( $this->post_id, 'largo_custom_related_posts', true );
 		if ( ! empty( $post_ids ) ) {
 			$this->post_ids = explode( ",", $post_ids );
 			if ( count( $this->post_ids ) >= $number ) {


### PR DESCRIPTION
`largo_meta_box_save()` is missing proper sanitization:

```
$mydata = array(
        '_wp_post_template' => $_POST['_wp_post_template'],
        'custom_sidebar'    => $_POST['custom_sidebar'],
        'largo_byline_text' => $_POST['largo_byline_text'],
        'largo_byline_link' => $_POST['largo_byline_link'],
        'youtube_url'       => $_POST['youtube_url']
    );
```
