### PR TITLE
Fixing a notice

### DIFF
--- a/search.php
+++ b/search.php
@@ -13,7 +13,7 @@ get_header();
 			<?php
 				printf( __('Your search for <span class="search-term">%s</span> returned ', 'largo'), get_search_query() );
 				printf( _n( '%s result', '%s results', $wp_query->found_posts ), number_format_i18n( $wp_query->found_posts ) );
-				printf( '<a class="rss-link" href="%1$s"><i class="icon-rss"></i></a>', get_search_feed_link( $search_query, $feed ) );
+				printf( '<a class="rss-link" href="%1$s"><i class="icon-rss"></i></a>', get_search_feed_link() );
 			?>
 		</h3>
 


### PR DESCRIPTION
Looks like the function had just been dropped in right out of the codex sample, so it was receiving optional arguments it didn't need to be receiving.
