### PR TITLE
Sidebar handling, revisited

### DIFF
--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -136,6 +136,7 @@ function largo_make_slug($string, $maxLength = 63) {
 /**
  * Builds a dropdown menu of the custom sidebars
  * Used in the meta box on post/page edit screen and landing page edit screen
+ * $skip_default was deprecated in Largo 0.4
  *
  * @since 1.0
  */
@@ -144,15 +145,18 @@ if( !function_exists( 'largo_custom_sidebars_dropdown' ) ) {
 		global $wp_registered_sidebars, $post;
 		$the_id = ( $post_id ) ? $post_id : $post->ID ;
 		$custom = ( $selected ) ? $selected : get_post_meta( $the_id, 'custom_sidebar', true );
-		$val = ( $custom ) ? $custom : 'none';
 
-		// Add a default option
+		// for backwards compatibility if nothing's set or using deprecated 'default'
+		$val = 'sidebar-single';
+
+		// for new posts
+		$admin_page = get_current_screen();
+		if ( $admin_page->action == 'add' && $admin_page->base == 'post' ) $val = 'none';
+
+		// for posts with values set
+		if ( $custom ) $val = $custom;
+
 		$output = '';
-		if ( ! $skip_default ) {
-			$output .= '<option value="default" ';
-			$output .= selected( 'default', $val, false );
-			$output .= '>' . __( 'Default', 'largo' ) . '</option>';
-		}
 
 		// Add a 'none' option
 		$output .= '<option value="none" ';

--- a/sidebar.php
+++ b/sidebar.php
@@ -16,6 +16,8 @@ do_action('largo_before_sidebar');
 			//get a custom sidebar if appropriate
 			if ( is_singular() ) {
 				$custom_sidebar = get_post_meta(get_the_ID(), 'custom_sidebar', true);
+				// for backward compatibility
+				if ( $custom_sidebar == 'default' ) $custom_sidebar == 'sidebar-single';
 			} else if ( is_archive() ) {
 				$term = get_queried_object();
 				$custom_sidebar = largo_get_term_meta( $term->taxonomy, $term->term_id, 'custom_sidebar', true );
@@ -23,9 +25,12 @@ do_action('largo_before_sidebar');
 
 			//load custom sidebar if appropriate
 			if ( $custom_sidebar ) {
-				if ($custom_sidebar !== 'none' && $custom_sidebar !== 'default' ) {
-					dynamic_sidebar($custom_sidebar);
-				} else if ( is_archive() || $custom_sidebar == 'default' ) {
+				if ($custom_sidebar !== 'none' ) {	// just in case someone creates a sidebar region named 'none', we check this
+					dynamic_sidebar( $custom_sidebar );
+					if ( $custom_sidebar == 'sidebar-single' && !is_active_sidebar( $custom_sidebar ) ) {
+						dynamic_sidebar( 'sidebar-main' );
+					}
+				} else if ( is_archive() ) {
 					dynamic_sidebar( 'sidebar-main' );
 				}
 			//else load single sidebar if it has things


### PR DESCRIPTION
For posts that are really old, or posts that have a value of "default," the option in the post edit screen dropdown will be the single post sidebar. For new posts, "none" will be the pre-selected value. For other posts, they'll get whatever's stored in the database.

On the front end, if a post is set to 'default', it'll be handled as if it were set to 'sidebar-single'. Unlike other custom values, 'sidebar-single' will fall back to displaying the 'sidebar-main' region if sidebar-single is empty.  Other custom values will just try to show the custom region.

Really old posts that don't have any value set at all will behave how they always have, also getting 'sidebar-single' if active or 'sidebar-main' if not.

I _think_ this covers everything.
