### PR TITLE
More labels for custom taxonomies, fix #256

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -91,7 +91,7 @@ function largo_custom_taxonomies() {
 		        'labels'        => array(
 		        	'name'              => _x( 'Series', 'taxonomy general name' ),
 					'singular_name'     => _x( 'Series', 'taxonomy singular name' ),
-					'search_items'      => __( 'Search Senres' ),
+					'search_items'      => __( 'Search Series' ),
 					'all_items'         => __( 'All Series' ),
 					'parent_item'       => __( 'Parent Series' ),
 					'parent_item_colon' => __( 'Parent Series:' ),


### PR DESCRIPTION
The reason the labels on buttons were incorrect for "Series" and "Post Prominence" was because we weren't supplying [enough labels](http://codex.wordpress.org/Function_Reference/register_taxonomy#Arguments) when calling `register_taxonomy` in `inc/taxonomies.php`. 

The default labels for hierarchical custom taxonomies are the ones for categories, which is why the button said "Add New Category".
