### PR TITLE
Hotfix/print header

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -47,9 +47,9 @@ add_shortcode( 'module', 'largo_module_shortcode' );
  */
 function largo_tinymce_config( $init ) {
 	if ( isset( $init['extended_valid_elements'] ) ) {
-		$init['extended_valid_elements'] .= ",span[!class],iframe[*]";
+		$init['extended_valid_elements'] .= "span[!class]";
 	} else {
-		$init['extended_valid_elements'] = "span[!class],iframe[*]";
+		$init['extended_valid_elements'] = "span[!class]";
 	}
 	return $init;
 }


### PR DESCRIPTION
Because variables don't carry through get_template_part(), the largo-header partial needs to explicitly get the $current_url global, otherwise it's undefined.
