### PR TITLE
Fixing invalid CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2473,7 +2473,7 @@ li.home-link:hover i {
     padding: 0;
   }
   .navbar .toggle-nav-bar {
-    display: static;
+    display: block;
   }
   .navbar .nav-shelf {
     position: absolute;

--- a/less/inc/navbar.less
+++ b/less/inc/navbar.less
@@ -451,7 +451,7 @@ li.home-link:hover i {
     padding: 0;
   }
   .navbar .toggle-nav-bar {
-    display: static;
+    display: block;
   }
   .navbar .nav-shelf {
     position: absolute;


### PR DESCRIPTION
Because "display: static" isn't syntactically valid CSS... "position: static" is and so is "display: block" though.
