### PR TITLE
Fixing bug in author bio widget where URLs were missing

### DIFF
--- a/partials/author-bio-description.php
+++ b/partials/author-bio-description.php
@@ -4,8 +4,8 @@
 if ( is_author() ) {
 	echo '<h1 class="fn n">' . $author_obj->display_name . '</h1>';
 } else {
-	printf( __( '<h3 class="widgettitle">About <span class="fn n"><a class="url" href="%1$s" rel="author" title="See all posts by %1$s">%2$s</a></span></h3>', 'largo' ),
-		get_author_posts_url($author_obj->ID),
+	printf( __( '<h3 class="widgettitle">About <span class="fn n"><a class="url" href="%1$s" rel="author" title="See all posts by %2$s">%2$s</a></span></h3>', 'largo' ),
+		get_author_posts_url( $author_obj->ID, $author_obj->user_nicename ),
 		esc_attr( $author_obj->display_name )
 	);
 }

--- a/partials/author-bio-social-links.php
+++ b/partials/author-bio-social-links.php
@@ -31,8 +31,8 @@
 
 	<?php
 		if ( !is_author() ) {
-			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by %1$s">More by %2$s</a></li>', 'largo' ),
-				get_author_posts_url($author_obj->ID),
+			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by %2$s">More by %2$s</a></li>', 'largo' ),
+				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename ),
 				esc_attr( $author_obj->first_name )
 			);
 		}


### PR DESCRIPTION
We noticed a bug in Chicago Reporter site wherein due to Co-authors Plus the bio widget wasn't properly displaying links to author archive pages. Per https://wordpress.org/support/topic/get_author_posts_url-not-working-for-guest-authors we've adjusted the calls to get_author_posts_url() to rectify the problem. 