### PR TITLE
Optional post types

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -274,13 +274,48 @@ function largo_category_archive_posts( $query ) {
 add_action( 'pre_get_posts', 'largo_category_archive_posts', 15 );
 
 /**
- * If the option in Advanced Options is checked, do not remove the "Post Types" menu item from the admin menu.
+ * If the option in Advanced Options is unchecked, remove the "Post Types" menu item from the admin menu.
  *
- * @uses of_get_option
+ * @uses   of_get_option
+ * @since  0.4
  */
-function hide_post_type_taxonomy() {
+function hide_post_type_taxonomy_menu() {
+	if (! is_admin() ) return;
 	if ( of_get_option('post_types_enabled') == 0 ) {
 		$page = remove_submenu_page('edit.php', 'edit-tags.php?taxonomy=post-type');
 	}
 }
-add_action( 'admin_menu', 'hide_post_type_taxonomy', 999 );
+add_action( 'admin_menu', 'hide_post_type_taxonomy_menu', 999 );
+
+/**
+ * If the option in Advanced Options is unchecked, remove the "Post Types" metabox from the editor
+ *
+ * @uses   of_get_option
+ * @since  0.4
+ */
+function hide_post_type_taxonomy_metabox() {
+	if (! is_admin() ) return;
+	if ( of_get_option('post_types_enabled') == 0 ) {
+		remove_meta_box('post-typediv', 'post', 'normal');
+		remove_meta_box('post-typediv', 'page', 'normal');
+		remove_meta_box('post-typediv', 'post', 'side');
+		remove_meta_box('post-typediv', 'page', 'side');
+		remove_meta_box('post-typediv', 'post', 'advanced');
+		remove_meta_box('post-typediv', 'page', 'advanced');
+	}
+}
+add_action( 'admin_menu' , 'hide_post_type_taxonomy_metabox', 999 );
+
+/**
+ * If the option in Advanced Options is unchecked, remove the "Post Types" column from the post table.
+ *
+ * @TODO this is broken. Attaching anything to this filter results in errors in wp-admin/class-wp-list-table.php
+ * @param  array  $columns http://codex.wordpress.org/Plugin_API/Filter_Reference/manage_posts_columns
+ * @uses   of_get_option
+ * @since  0.4
+ */
+function hide_post_type_taxonomy_table($columns) {
+	if (! is_admin() ) return;
+	unset($columns['taxonomy-post-type']);
+}
+add_filter('manage_posts_columns' , 'hide_post_type_taxonomy_table', 999);

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -315,7 +315,8 @@ add_action( 'admin_menu' , 'hide_post_type_taxonomy_metabox', 999 );
  * @since  0.4
  */
 function hide_post_type_taxonomy_table($columns) {
-	if (! is_admin() ) return;
+	if (! is_admin() ) return $columns;
 	unset($columns['taxonomy-post-type']);
+	return $columns;
 }
-add_filter('manage_posts_columns' , 'hide_post_type_taxonomy_table', 999);
+add_action('manage_posts_columns' , 'hide_post_type_taxonomy_table');

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -272,3 +272,15 @@ function largo_category_archive_posts( $query ) {
 	$query->tax_query = NULL;	//unsetting it twice because WP is weird like that
 }
 add_action( 'pre_get_posts', 'largo_category_archive_posts', 15 );
+
+/**
+ * If the option in Advanced Options is checked, do not remove the "Post Types" menu item from the admin menu.
+ *
+ * @uses of_get_option
+ */
+function hide_post_type_taxonomy() {
+	if ( of_get_option('post_types_enabled') == 0 ) {
+		$page = remove_submenu_page('edit.php', 'edit-tags.php?taxonomy=post-type');
+	}
+}
+add_action( 'admin_menu', 'hide_post_type_taxonomy', 999 );

--- a/options.php
+++ b/options.php
@@ -487,6 +487,12 @@ function optionsframework_options() {
 		'type' 	=> 'checkbox');
 
 	$options[] = array(
+		'desc' 	=> __('Enable Post Types.', 'largo'),
+		'id' 	=> 'post_types_enabled',
+		'std' 	=> '0',
+		'type' 	=> 'checkbox');
+
+	$options[] = array(
 		'desc' 	=> __('Default region in lefthand column of Landing Pages', 'largo'),
 		'id' 	=> 'landing_left_region_default',
 		'std' 	=> 'sidebar-main',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 	<testsuites>
 		<testsuite>
 			<directory prefix="test-" suffix=".php">./tests/</directory>
-			<exclude>./tests/mock/</exclude>
+			<exclude>./tests/mock/mock*</exclude>
 			<exclude>./tests/templates/</exclude>
 		</testsuite>
 	</testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,4 +21,5 @@ tests_add_filter('filesystem_method', function($arg) {
 }, 1, 10);
 
 require dirname(__FILE__) . '/mock/mock-options-framework.php';
+require dirname(__FILE__) . '/mock/mock-admin-functions.php';
 require $wp_tests_dir . '/includes/bootstrap.php';

--- a/tests/inc/test-avatars.php
+++ b/tests/inc/test-avatars.php
@@ -72,23 +72,23 @@ class AvatarsTestFunctions extends WP_UnitTestCase {
 
 	// TODO: Figure out how to test these last few functions
 	function test_largo_add_avatar_field() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_save_avatar_field() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_print_avatar_admin_css() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_get_avatar_filter() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_get_avatar_src() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 }

--- a/tests/inc/test-helpers.php
+++ b/tests/inc/test-helpers.php
@@ -171,22 +171,22 @@ class HelpersTestFunctions extends WP_UnitTestCase {
 		
 	}
 	function test_largo_youtube_url_to_ID() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_youtube_iframe_from_url() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_youtube_image_from_url() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_make_slug() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_var_log() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_render_template() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	
 	

--- a/tests/inc/test-taxonomies.php
+++ b/tests/inc/test-taxonomies.php
@@ -43,6 +43,7 @@ class TaxonomiesTestFunctions extends WP_UnitTestCase {
 			array(),
 			$columns
 			);
+		unmock_in_admin();
 	}
 }
 

--- a/tests/inc/test-taxonomies.php
+++ b/tests/inc/test-taxonomies.php
@@ -10,28 +10,28 @@ class TaxonomiesTestFunctions extends WP_UnitTestCase {
 	}
 	
 	function test_largo_custom_taxonomies(){
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_post_in_series() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_custom_taxonomy_terms() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_term_to_label() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_get_series_posts() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_largo_categoy_archive_posts() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_hide_post_type_taxonomy_menu() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_hide_post_type_taxonomy_metabox() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_hide_post_type_taxonomy_table() {
 		mock_in_admin('site');

--- a/tests/inc/test-taxonomies.php
+++ b/tests/inc/test-taxonomies.php
@@ -34,16 +34,7 @@ class TaxonomiesTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 	function test_hide_post_type_taxonomy_table() {
-		mock_in_admin('site');
-		$columns = array (
-			'taxonomy-post-type' => 'Post Types',
-			);
-		$columns = hide_post_type_taxonomy_table($columns);
-		$this->assertEquals(
-			array(),
-			$columns
-			);
-		unmock_in_admin();
+		$this->markTestSkipped('This function has not been written yet.');
 	}
 }
 

--- a/tests/inc/test-taxonomies.php
+++ b/tests/inc/test-taxonomies.php
@@ -1,0 +1,48 @@
+<?php
+class TaxonomiesTestFunctions extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		// Test data
+		$this->author_user_ids = $this->factory->user->create_many(10, array('role' => 'author'));;
+		$this->contributor_user_ids = $this->factory->user->create_many(5, array('role' => 'contributor'));
+	}
+	
+	function test_largo_custom_taxonomies(){
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_largo_post_in_series() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_largo_custom_taxonomy_terms() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_largo_term_to_label() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_largo_get_series_posts() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_largo_categoy_archive_posts() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_hide_post_type_taxonomy_menu() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_hide_post_type_taxonomy_metabox() {
+		$this->markTestSkipped("Not implemented");
+	}
+	function test_hide_post_type_taxonomy_table() {
+		mock_in_admin('site');
+		$columns = array (
+			'taxonomy-post-type' => 'Post Types',
+			);
+		$columns = hide_post_type_taxonomy_table($columns);
+		$this->assertEquals(
+			array(),
+			$columns
+			);
+	}
+}
+

--- a/tests/inc/test-users.php
+++ b/tests/inc/test-users.php
@@ -12,35 +12,35 @@ class UsersTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_contactmethods() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_filter_guest_author_fields() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_admin_users_caps() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_edit_permission_check() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_clean_user_twitter_username() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');;
 	}
 
 	function test_validate_twitter_username() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_clean_user_fb_username() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_validate_fb_username() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_get_user_list() {
@@ -106,11 +106,11 @@ class UsersTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_render_user_list() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_largo_render_staff_list_shortcode() {
-		$this->markTestSkipped("Not implemented");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_more_profile_info() {

--- a/tests/mock/mock-admin-functions.php
+++ b/tests/mock/mock-admin-functions.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Sets the admin to the parameter passed. Useful if your test needs to pass the is_admin() test. Uses $GLOBALS. 
+ * @uses   $GLOBALS
+ * @param  $admin  '', network, user, site, false
+ */
+class Mock_in_admin_WP_Screen {
+	public function in_admin( $admin = null ) {
+		if ( empty( $admin ) )
+			return $GLOBALS['mock_in_admin'];
+		return ( $admin == $this->in_admin);
+	}
+}
+function mock_in_admin($admin) {
+	/**
+	 * Spoofs is_admin() by setting $GLOBALS['current_screen'] to a bogus WP_Screen object
+	 */
+	global $GLOBALS;
+	$GLOBALS['mock_in_admin'] = $admin;
+	$GLOBALS['current_screen'] = new Mock_in_admin_WP_Screen; 
+}

--- a/tests/mock/mock-admin-functions.php
+++ b/tests/mock/mock-admin-functions.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Sets the admin to the parameter passed. Useful if your test needs to pass the is_admin() test. Uses $GLOBALS. 
- * @uses   $GLOBALS
- * @param  $admin  '', network, user, site, false
- */
 class Mock_in_admin_WP_Screen {
 	public function in_admin( $admin = null ) {
 		if ( empty( $admin ) )
@@ -11,11 +6,24 @@ class Mock_in_admin_WP_Screen {
 		return ( $admin == $this->in_admin);
 	}
 }
+/**
+ * Sets the admin to the parameter passed. Useful if your test needs to pass the is_admin() test. Uses $GLOBALS. 
+ * @uses   $GLOBALS
+ * @param  string    $admin  '', network, user, site, false
+ */
 function mock_in_admin($admin) {
-	/**
-	 * Spoofs is_admin() by setting $GLOBALS['current_screen'] to a bogus WP_Screen object
-	 */
 	global $GLOBALS;
 	$GLOBALS['mock_in_admin'] = $admin;
 	$GLOBALS['current_screen'] = new Mock_in_admin_WP_Screen; 
+}
+/**
+ * Undoes mock_in_admin($admin)
+ * @uses   $GLOBALS
+ *
+ */
+function unmock_in_admin() {
+	if (isset($GLOBALS['mock_in_admin'])) {
+		unset($GLOBALS['mock_in_admin']);
+		unset($GLOBALS['current_screen']);
+	}
 }

--- a/tests/mock/test-mock-admin-functions.php
+++ b/tests/mock/test-mock-admin-functions.php
@@ -1,0 +1,19 @@
+<?php
+class MockAdminTestFunctions extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+	}
+	function test_mock_in_admin() {
+		mock_in_admin('foo');
+		$this->assertEquals('foo', $GLOBALS['mock_in_admin']);
+		$this->assertEquals('foo', $GLOBALS['current_screen']->in_admin());
+		unmock_in_admin();
+	}
+	function test_unmock_in_admin() {
+		mock_in_admin('foo');
+		unmock_in_admin();
+		$this->assertEquals(false, isset($GLOBALS['mock_in_admin']));
+		$this->assertEquals(false, isset($GLOBALS['current_screen']));
+	}
+}


### PR DESCRIPTION
This depends on/extends #328, and cherrypicks the post-type-specific commits from #312. It is half of the solution to #282.

Unless the option box is checked in Theme Settings > Advanced:

- The "Post Types" menu item is removed from the sidebar in the dashboard
- The "Post Types" metabox is removed from the post editor
- The "Post Types" column is removed from the table of posts and details