### PR TITLE
Single post social icon checkbox for #326

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -101,7 +101,7 @@ class Largo_Customizer {
 				'sanitize_callback'     => 'sanitize_key',
 				),
 			// Single
-			'[social_icons_display]' => array(
+			'[single_social_icons]' => array(
 				'type'                  => 'option',
 				'sanitize_callback'     => 'sanitize_key',
 				),
@@ -217,17 +217,11 @@ class Largo_Customizer {
 				'print'          => __( 'Print', 'largo' ),
 				),
 			) ) );
-		$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'largo_social_icons_display', array(
-			'label'              => __( 'Social Icons Position', 'largo' ),
+		$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'largo_single_social_icons', array(
+			'label'              => __( 'Display Social Icons', 'largo' ),
 			'section'            => 'largo_single_post',
-			'settings'           => $this->get_setting_key( '[social_icons_display]' ),
-			'type'               => 'select',
-			'choices'            => array(
-				'top'            => __( 'Top', 'largo' ),
-				'btm'            => __( 'Bottom', 'largo' ),
-				'both'           => __( 'Both', 'largo' ),
-				'none'           => __( 'None', 'largo' ),
-				),
+			'settings'           => $this->get_setting_key( '[single_social_icons]' ),
+			'type'               => 'checkbox',
 			) ) );
 		$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'largo_fb_verb', array(
 			'label'              => __( 'Facebook Button Text', 'largo' ),

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'largo_enqueue_js' ) ) {
 		//only load sharethis on single pages and load jquery tabs for the related content box if it's active
 		if ( is_single() ) {
 			$utilities = of_get_option( 'article_utilities' );
-			if ( of_get_option( 'single_social_icons' ) != 'none' && ( $utilities['sharethis'] === '1' || $utilities['email'] === '1' ) )
+			if ( of_get_option( 'single_social_icons' ) == '1' && ( $utilities['sharethis'] === '1' || $utilities['email'] === '1' ) )
 				wp_enqueue_script( 'sharethis', get_template_directory_uri() . '/js/st_buttons.js', array( 'jquery' ), '1.0', true );
 			wp_enqueue_script( 'idTabs', get_template_directory_uri() . '/js/jquery.idTabs.js', array( 'jquery' ), '1.0', true );
 		}

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'largo_enqueue_js' ) ) {
 		//only load sharethis on single pages and load jquery tabs for the related content box if it's active
 		if ( is_single() ) {
 			$utilities = of_get_option( 'article_utilities' );
-			if ( of_get_option( 'social_icons_display' ) != 'none' && ( $utilities['sharethis'] === '1' || $utilities['email'] === '1' ) )
+			if ( of_get_option( 'single_social_icons' ) != 'none' && ( $utilities['sharethis'] === '1' || $utilities['email'] === '1' ) )
 				wp_enqueue_script( 'sharethis', get_template_directory_uri() . '/js/st_buttons.js', array( 'jquery' ), '1.0', true );
 			wp_enqueue_script( 'idTabs', get_template_directory_uri() . '/js/jquery.idTabs.js', array( 'jquery' ), '1.0', true );
 		}

--- a/lib/options-framework/css/optionsframework.css
+++ b/lib/options-framework/css/optionsframework.css
@@ -269,28 +269,19 @@
 }
 #optionsframework #section-show_next_prev_nav_single,
 #optionsframework #section-tag_limit,
-#optionsframework #section-article_utilities,
-#optionsframework #section-social_icons_display {
+#optionsframework #section-article_utilities {
 	margin-bottom:20px;
 }
 
 #optionsframework #section-article_utilities .explain,
-#optionsframework #section-fb_verb .explain,
-#optionsframework #section-social_icons_display .explain {
+#optionsframework #section-fb_verb .explain {
 	float:left;
 	width:30%;
 }
-#optionsframework #section-social_icons_display .explain {
-	width:65%;
-}
 #optionsframework #section-article_utilities .controls,
-#optionsframework #section-fb_verb .controls,
-#optionsframework #section-social_icons_display .controls  {
+#optionsframework #section-fb_verb .controls {
 	float:right;
 	width:65%;
-}
-#optionsframework #section-social_icons_display .controls {
-	width:30%;
 }
 #optionsframework #section-article_utilities input,
 #optionsframework #section-article_utilities label {

--- a/options.php
+++ b/options.php
@@ -36,11 +36,6 @@ function optionsframework_options() {
 		}
 	}
 
-	$display_options = array(
-		'top' 	=> __('Top', 'largo'),
-		'none' 	=> __('None', 'largo')
-	);
-
 	$tag_display_options = array(
 		'top' 	=> __('Single Tag Above', 'largo'),
 		'btm' 	=> __('List Below', 'largo'),
@@ -251,12 +246,11 @@ function optionsframework_options() {
 		'type' 	=> 'info');
 
 	$options[] = array(
-		'desc' 		=> __('<strong>Where would you like to display share icons on single posts?</strong> By default social icons appear at the top of single posts but you can choose to not show them at all.', 'largo'),
-		'id' 		=> 'social_icons_display',
-		'std' 		=> 'top',
-		'type' 		=> 'select',
-		'class'		=> 'mini',
-		'options' 	=> $display_options);
+		'desc' 		=> __('<strong>Would you like to display share icons on single posts?</strong> By default social icons appear at the top of single posts but you can choose to not show them at all.', 'largo'),
+		'id' 		=> 'single_social_icons',
+		'std' 		=> '1',
+		'type' 		=> 'checkbox',
+		'class'		=> 'mini');
 
 	$options[] = array(
 		'desc' 		=> __('Select the <strong>share icons</strong> to display on single posts.', 'largo'),

--- a/options.php
+++ b/options.php
@@ -249,8 +249,7 @@ function optionsframework_options() {
 		'desc' 		=> __('<strong>Would you like to display share icons on single posts?</strong> By default social icons appear at the top of single posts but you can choose to not show them at all.', 'largo'),
 		'id' 		=> 'single_social_icons',
 		'std' 		=> '1',
-		'type' 		=> 'checkbox',
-		'class'		=> 'mini');
+		'type' 		=> 'checkbox',);
 
 	$options[] = array(
 		'desc' 		=> __('Select the <strong>share icons</strong> to display on single posts.', 'largo'),

--- a/partials/content-single-classic.php
+++ b/partials/content-single-classic.php
@@ -14,7 +14,7 @@
  		<h5 class="byline"><?php largo_byline(); ?></h5>
 
  		<?php
- 			if ( of_get_option( 'social_icons_display' ) === 'top') {
+ 			if ( !of_get_option( 'single_social_icons' ) == false ) {
  				largo_post_social_links();
  			}
  		?>

--- a/tests/inc/test-enqueue.php
+++ b/tests/inc/test-enqueue.php
@@ -1,0 +1,38 @@
+<?php
+
+class EnqueueTestFunctions extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+	}
+
+	function test_largo_enqueue_js() {
+	// Modernizr
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	// the jquery plugins
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	// our main JS file
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	// only load sharethis on single pages and load jquery tabs for the related content box if it's active
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	// Load the child theme's style.css if we're actually running a child theme of Largo
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_largo_enqueue_admin_scripts() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_largo_header_js() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_largo_footer_js() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function largo_google_analytics() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+}


### PR DESCRIPTION
This uses a different slug, `single_social_icons`, so it shouldn't conflict with the old `social_icons_display` drop-down option.