### PR TITLE
Hide the .nav-shelf site name in the dropdown when the .nav-left site name is visible.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2474,6 +2474,9 @@ li.home-link:hover i {
     visibility: hidden;
     opacity: 0;
   }
+  .navbar .nav-shelf .site-name {
+    display: none;
+  }
   .navbar.open .nav-shelf {
     visibility: visible;
     opacity: 1;

--- a/less/inc/navbar.less
+++ b/less/inc/navbar.less
@@ -447,6 +447,9 @@ li.home-link:hover i {
     right: -10px;
     visibility: hidden;
     opacity: 0;
+    .site-name {
+    	display: none;
+    }
   }
   .navbar.open .nav-shelf {
     visibility: visible;


### PR DESCRIPTION
This is a small follow-up based on convo with @rnagle today, for #324.

Previous behavior on screens 768px and narrower was to show the site name in both the sticky header in `.nav-left` and in the sticky header's dropdown `.nav-shelf`. Since this would appear twice, we decided it would be better to hide it in the dropdown.

The site name was not removed from `.nav-shelf` because it's visible in the sticky header on screens wider than 768px.

![screenshot - 01092015 - 11 04 50 am](https://cloud.githubusercontent.com/assets/1754187/5684539/5d2e2f18-97ff-11e4-8212-67e45c219dde.png)

The "Largo Test Site" visible here is in `.nav-shelf`. If the `.nav-left` site name were visible, it would be to the left of the home icon.