### PR TITLE
Fixes for homepage image width and INN_MEMBER

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,12 +29,23 @@
  */
 
 /**
- * By default we'll assume the site is not for an INN member
- * set INN_MEMBER to TRUE to show an INN logo in the header
+ * By default we'll assume the site is not hosted by INN.
+ * 
+ * There should be no reason to set this. It is defined to 
+ * modify the default value of 'INN_MEMBER' below to true for 
+ * INN hosted sites.
+ */
+if ( ! defined( 'INN_HOSTED' ) )
+	define( 'INN_HOSTED', FALSE );
+
+/**
+ * By default we'll assume the site is not for an INN member.
+ * 
+ * Set INN_MEMBER to TRUE to show an INN logo in the header
  * and a widget of INN member stories in the homepage sidebar
  */
 if ( ! defined( 'INN_MEMBER' ) )
-	define( 'INN_MEMBER', FALSE );
+	define( 'INN_MEMBER', FALSE || INN_HOSTED );
 
 /**
  * Image size constants, almost 100% that you won't need to change these

--- a/homepages/assets/css/single.css
+++ b/homepages/assets/css/single.css
@@ -4,6 +4,7 @@
 }
 .home-top {
   float: left;
+  width: 100%;
 }
 #view-format {
   position: absolute;


### PR DESCRIPTION
Only around 20 lines of code here, but they fix #386 and #383.

Creating in a pull request because the following define has to be added to wp-config on production and staging:

```
define('INN_HOSTED',true);
```

This should __replace__ the `INN_MEMBER` constant defined. This leaves `INN_MEMBER` to be definable for sites & child themes hosted on our multisite, but not INN members themselves.