### PR TITLE
Removing slideshow CSS image-width limitation

### DIFF
--- a/lib/navis-slideshows/css/slides.css
+++ b/lib/navis-slideshows/css/slides.css
@@ -31,7 +31,7 @@
     display: block;
 }
 
-#content .navis-slideshow img {
+.navis-slideshow img {
     display: block;
     margin: 0 auto;
     width:100%;
@@ -44,7 +44,7 @@
     font-size: 12px;
 }
 
-#content .navis-slideshow h6 {
+.navis-slideshow h6 {
     margin: 6px;
     font-weight: normal;
     font-size: 11px;
@@ -52,27 +52,27 @@
     color: #666;
 }
 
-#content .navis-slideshow h6.credit {
+.navis-slideshow h6.credit {
     text-align: right;
     float: right;
 }
 
-#content .navis-slideshow h6.permalink {
+.navis-slideshow h6.permalink {
     float: left;
     text-align: left;
 }
 
-#content .slide-permalink {
+.slide-permalink {
     font-weight: normal;
     font-style: normal;
     outline: none;
 }
 
-#content .navis-slideshow .wp-caption-text {
+.navis-slideshow .wp-caption-text {
     clear: both;
 }
 
-#content .slide-permalink:hover {
+.slide-permalink:hover {
     text-decoration: none;
     color: #666;
 }


### PR DESCRIPTION
This is so that slideshows on pages and category landing pages will have full-width images, in the event that the image is narrower than the slideshow container.

This is a fix for CUR-45, but this fix is temporary. The gallery generation code doesn't respect the [gallery option](http://codex.wordpress.org/Gallery_Shortcode#Options) `size="full"` for using larger images, and setting a larger image width in Dashboard > Settings > Media doesn't work. The new setting is reset to 771px wide.