### PR TITLE
Filter Landing Page post permalink to use Series URL

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -261,7 +261,7 @@ function largo_get_series_posts( $series_id, $number = -1 ) {
 * which attempts to use the link for ANY term from ANY taxonomy.
 * Largo really only cares about the Series taxonomy.
 *
-* @since 0.4.2
+* @since 0.5
 * @return filtered $post_link, replacing a Landing Page link with its Series link as needed
 */
 function largo_series_landing_link($post_link, $post) {


### PR DESCRIPTION
The Largo component `wp-taxonomy-landing` supports landing pages for all taxonomies. Its filter to set the landing page permalink pulls unordered taxonomies, then pulls unordered terms for each taxonomy on the filtered landing page.  This sometimes fails for the Catalyst Chicago and Chicago Reporter child themes, resulting in landing pages with the wrong links.

This change implements a Largo specific permalink filter. The filter only activates if the Custom Landing Page Theme Option is checked. The filter also only checks for terms in the Series taxonomy. (The only taxonomy Largo cares about in this context.)  Finally, the filter reliably handles situations where multiple Series terms are selected for an individual landing page, always linking to the most recently created term (determined by term ID).