### PR TITLE
Options for the sticky footer social media buttons

### DIFF
--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -839,25 +839,33 @@ body.normal.page .article-bottom .largo-disclaimer {
 .post-social span.facebook {
   top: -7px;
 }
-.post-social span.print {
+.post-social span.print,
+.post-social span.email {
   font-family: Verdana, Helvetica, sans-serif;
   font-size: 11px;
   top: 1px;
+  margin-left: 10px;
 }
-.post-social span.print i.icon-print {
+.post-social span.print i,
+.post-social span.email i,
+.post-social span.print::before,
+.post-social span.email::before {
   font-size: 18px;
   margin: 0 -3px 0 2px;
   position: relative;
   top: 2px;
 }
-.post-social span.print:hover {
+.post-social span.print:hover,
+.post-social span.email:hover {
   opacity: 0.85;
   filter: alpha(opacity=85);
 }
-.post-social span.print a {
+.post-social span.print a,
+.post-social span.email a {
   color: black;
 }
-.post-social span.print a:hover {
+.post-social span.print a:hover,
+.post-social span.email a:hover {
   text-decoration: none;
 }
 /* 2.3 - Post pagination */

--- a/css/style.css
+++ b/css/style.css
@@ -3362,25 +3362,33 @@ body.normal.page .article-bottom .largo-disclaimer {
 .post-social span.facebook {
   top: -7px;
 }
-.post-social span.print {
+.post-social span.print,
+.post-social span.email {
   font-family: Verdana, Helvetica, sans-serif;
   font-size: 11px;
   top: 1px;
+  margin-left: 10px;
 }
-.post-social span.print i.icon-print {
+.post-social span.print i,
+.post-social span.email i,
+.post-social span.print::before,
+.post-social span.email::before {
   font-size: 18px;
   margin: 0 -3px 0 2px;
   position: relative;
   top: 2px;
 }
-.post-social span.print:hover {
+.post-social span.print:hover,
+.post-social span.email:hover {
   opacity: 0.85;
   filter: alpha(opacity=85);
 }
-.post-social span.print a {
+.post-social span.print a,
+.post-social span.email a {
   color: black;
 }
-.post-social span.print a:hover {
+.post-social span.print a:hover,
+.post-social span.email a:hover {
   text-decoration: none;
 }
 /* 2.3 - Post pagination */

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -181,6 +181,10 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 			$output .= '<span class="print"><a href="#" onclick="window.print()" title="' . esc_attr( __( 'Print this article', 'largo' ) ) . '" rel="nofollow"><i class="icon-print"></i> ' . esc_attr( __( 'Print', 'largo' ) ) . '</a></span>';
 		}
 
+		if ($utilities['email'] === '1' ) {
+			$output .= '<span data-service="email" class="email custom-share-button icon-mail share-button"> Email</span>';
+		}
+
 		$output .= '</div></div>';
 
 		if ( $echo ) {

--- a/less/inc/single.less
+++ b/less/inc/single.less
@@ -229,11 +229,13 @@ body.normal.page {
   span.facebook {
     top: -7px;
   }
-  span.print {
+  span.print,
+  span.email {
     font-family: Verdana, Helvetica, sans-serif;
     font-size: 11px;
     top: 1px;
-    i.icon-print {
+    margin-left: 10px;
+    i, &::before {
 	  font-size: @baseFontSize + 2;
 	  margin: 0 -3px 0 2px;
 	  position: relative;

--- a/lib/options-framework/css/optionsframework.css
+++ b/lib/options-framework/css/optionsframework.css
@@ -269,27 +269,34 @@
 }
 #optionsframework #section-show_next_prev_nav_single,
 #optionsframework #section-tag_limit,
-#optionsframework #section-article_utilities {
+#optionsframework #section-article_utilities,
+#optionsframework #section-footer_utilities {
 	margin-bottom:20px;
 }
 
 #optionsframework #section-article_utilities .explain,
+#optionsframework #section-footer_utilities .explain,
 #optionsframework #section-fb_verb .explain {
 	float:left;
 	width:30%;
 }
 #optionsframework #section-article_utilities .controls,
+#optionsframework #section-footer_utilities .controls,
 #optionsframework #section-fb_verb .controls {
 	float:right;
 	width:65%;
 }
 #optionsframework #section-article_utilities input,
-#optionsframework #section-article_utilities label {
+#optionsframework #section-article_utilities label,
+#optionsframework #section-footer_utilities input,
+#optionsframework #section-footer_utilities label {
 	clear:none;
 }
-#optionsframework #section-article_utilities input {
+#optionsframework #section-article_utilities input,
+#optionsframework #section-footer_utilities input {
 	width: 22px;
 }
-#optionsframework #section-article_utilities label {
+#optionsframework #section-article_utilities label,
+#optionsframework #section-footer_utilities label {
 	margin-right:20px;
 }

--- a/options.php
+++ b/options.php
@@ -45,13 +45,27 @@ function optionsframework_options() {
 	$article_utility_buttons = array(
 		'facebook' 	=> __('Facebook', 'largo'),
 		'twitter' 	=> __('Twitter', 'largo'),
-		'print' 	=> __('Print', 'largo')
+		'print' 	=> __('Print', 'largo'),
+		'email' 	=> __('Email', 'largo')
 	);
 
 	$article_utility_buttons_defaults = array(
-		'facebook' 	=> '1',
-		'twitter' 	=> '1',
-		'print' 	=> '1'
+		'facebook' => '1',
+		'twitter'  => '1',
+		'email'    => '1',
+		'print'    => '1'
+	);
+
+	$footer_utility_buttons = array(
+		'ffacebook' => __('Facebook', 'largo'),
+		'ftwitter'  => __('Twitter', 'largo'),
+		'femail'    => __('Email', 'largo')
+	);
+
+	$footer_utility_buttons_defaults = array(
+		'ffacebook' => '1',
+		'ftwitter'  => '1',
+		'femail'    => '1'
 	);
 
 	$fb_verbs = array(
@@ -242,17 +256,30 @@ function optionsframework_options() {
 		'type' 	=> 'info');
 
 	$options[] = array(
-		'desc' 		=> __('<strong>Would you like to display share icons on single posts?</strong> By default social icons appear at the top of single posts but you can choose to not show them at all.', 'largo'),
+		'desc' 		=> __('<strong>Would you like to display share icons at the top of single posts?</strong> By default social icons appear at the top of single posts but you can choose to not show them at all.', 'largo'),
 		'id' 		=> 'single_social_icons',
 		'std' 		=> '1',
 		'type' 		=> 'checkbox',);
 
 	$options[] = array(
-		'desc' 		=> __('Select the <strong>share icons</strong> to display on single posts.', 'largo'),
+		'desc' 		=> __('Select the <strong>share icons</strong> to display at the top of single posts.', 'largo'),
 		'id' 		=> 'article_utilities',
 		'std' 		=> $article_utility_buttons_defaults,
 		'type' 		=> 'multicheck',
 		'options' 	=> $article_utility_buttons);
+
+	$options[] = array(
+		'desc' 		=> __('<strong>Would you like to display share icons in the footer of single posts?</strong> By default social icons appear in the sticky footer of single posts but you can choose to not show them at all.', 'largo'),
+		'id' 		=> 'single_social_icons_footer',
+		'std' 		=> '1',
+		'type' 		=> 'checkbox',);
+
+	$options[] = array(
+		'desc' 		=> __('Select the <strong>share icons</strong> to display in the single post sticky footer.', 'largo'),
+		'id' 		=> 'footer_utilities',
+		'std' 		=> $footer_utility_buttons_defaults,
+		'type' 		=> 'multicheck',
+		'options' 	=> $footer_utility_buttons);
 
 	$options[] = array(
 		'desc' 		=> __('<strong>Use "like" or "recommend"</strong> for Facebook buttons?', 'largo'),

--- a/partials/footer-sticky.php
+++ b/partials/footer-sticky.php
@@ -2,18 +2,28 @@
 <div class="sticky-footer-holder">
 	<div class="sticky-footer-container social-icons">
 
-		<?php // Share the post using the ShareThis API. The class *_custom gives us a blank slate. ?>
-		<div class="share">
-			<h4><?php _e('Share', 'largo'); ?></h4>
-			<span data-service="facebook" class="custom-share-button icon-facebook share-button"></span>
-			<span data-service="twitter" class="custom-share-button icon-twitter share-button"></span>
-			<span data-service="email" class="custom-share-button icon-mail share-button"></span>
-			<?php
+		<?php // Share the post using the ShareThis API. The class *_custom gives us a blank slate.
+
+		if ( of_get_option('single_social_icons_footer' ) == '1' ) {
+			$utilities = of_get_option('footer_utilities');
+			echo '<div class="share">';
+			echo '<h4>' . __('Share', 'largo') . '</h4>';
+				if ($utilities['ffacebook']) { ?>
+					<span data-service="facebook" class="custom-share-button icon-facebook share-button"></span>
+				<?php }
+				if ($utilities['ftwitter']) { ?>
+					<span data-service="twitter" class="custom-share-button icon-twitter share-button"></span>
+				<?php }
+				if ($utilities['femail']) { ?>
+					<span data-service="email" class="custom-share-button icon-mail share-button"></span>
+				<?php }
 			/*
 			<span data-service="googleplus" class="custom-share-button icon-gplus share-button"></span>
 			<span data-service="linkedin" class="custom-share-button icon-linkedin share-button"></span>
-			*/ ?>
-		</div>
+			*/
+			echo '</div>';
+		}
+		?>
 
 		<?php // Comment link ?>
 		<?php if ( comments_open() ): ?>

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -1,0 +1,74 @@
+<?php
+
+class PostTagsTestFunctions extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+	}
+
+	function test_largo_time() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_author() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_author_link() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_byline() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_post_social_links() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_has_avatar() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_my_queryvars() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_custom_wp_link_pages() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_excerpt() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_trim_sentences() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_content_nav() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_comment() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_post_type_icon() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_hero_class() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_hero_with_caption() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_largo_post_metadata() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+}

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -24,7 +24,65 @@ class PostTagsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_post_social_links() {
-		$this->markTestIncomplete("This test has not yet been implemented.");
+		// Create a post, go to it.
+		$id = $this->factory->post->create();
+		$this->go_to('/?p=' . $id);
+
+		// Test the output of this when no options are set
+		$this->assertFalse(of_get_option('article_utilities'));
+
+		ob_start();
+		largo_post_social_links();
+		$ret = ob_get_clean();
+		$this->assertRegExp('/post-social/', $ret, "The .post-social class was not in the output");
+		$this->assertRegExp('/left/', $ret, "The .left class was not in the output");
+		$this->assertRegExp('/right/', $ret, "The .right class was not in the output");
+		unset($ret);
+
+		// Test that this outputs the expected data for each of the button types
+
+		// Twitter
+		of_set_option('article_utilities', array('twitter' => '1', 'facebook' => false, 'print' => false, 'email' => false));
+		of_set_option('twitter_link', 'foo');
+		of_set_option('show_twitter_count', false);
+		ob_start();
+		largo_post_social_links();
+		$ret = ob_get_clean();
+		$this->assertRegExp('/' . preg_quote(of_get_option('twitter_link'), '/') . '/' , $ret, "The Twitter link did not appear in the output");
+		// @TODO: insert a test for the get_the_author_meta test here
+		// This is just a test for make sure that it outputs the data-count when show_twitter_count == 0,; needs another go-round for '1'
+		$this->assertRegExp('/' . __('Tweet', 'largo') . '/', $ret, "The translation of 'Tweet' was not in the Twitter output");
+		unset($ret);
+		of_reset_options();
+
+		// Facebook
+		of_set_option('article_utilities', array('facebook' => '1', 'twitter' => false, 'print' => false, 'email' => false));
+		ob_start();
+		largo_post_social_links();
+		$ret = ob_get_clean();
+		$this->assertRegExp('/' . preg_quote(esc_attr( of_get_option( 'fb_verb' ) ), '/' ) . '/', $ret, "The Facebook Verb was not in the Facebook output");
+		$this->assertRegExp('/' . preg_quote(get_permalink(), '/') . '/', $ret, "The permalink was not in the Facebook output");
+		unset($ret);
+		of_reset_options();
+
+		// Print
+		of_set_option('article_utilities', array('print' => '1', 'twitter' => '1', 'facebook' => false, 'email' => false));
+		ob_start();
+		largo_post_social_links();
+		$ret = ob_get_clean();
+		$this->assertRegExp('/print/', $ret, "The Print output did not include a print class");
+		unset($ret);
+		of_reset_options();
+
+		// Email
+		of_set_option('article_utilities', array('email' => '1', 'twitter' => false, 'facebook' => false, 'print' => false));
+		ob_start();
+		largo_post_social_links();
+		$ret = ob_get_clean();
+		$this->assertRegExp('/email/', $ret, "The Email output did not include an email class");
+		unset($ret);
+		of_reset_options();
+
 	}
 
 	function test_largo_has_avatar() {


### PR DESCRIPTION
For #434:

- Sticky footer social media buttons are now their own general toggle, and each button can be toggled independently
- Half of a test for largo_post_social_links
- Re-added the email button to the post-top social media buttons using the footer-style email button