### PR TITLE
Clickable hero images in the river view, for #457

### DIFF
--- a/partials/content.php
+++ b/partials/content.php
@@ -21,7 +21,9 @@ $featured = has_term( 'homepage-featured', 'prominence' )
 					largo_youtube_iframe_from_url( $youtube_url );
 					echo '</div>';
 				} elseif( has_post_thumbnail() ){
+					echo('<a href="' . get_permalink() . '" title="' . the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ', 'echo' => false )) . '" rel="bookmark">');
 					the_post_thumbnail( 'full' );
+					echo('</a>');
 				}
 			?>
 			</div>


### PR DESCRIPTION
A small change: wraps the hero image of posts in the river with an anchor tag that uses the post's link and title.