### PR TITLE
#465 - fix for erroneous addslash() in caption.

### DIFF
--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -152,7 +152,7 @@ class Navis_Media_Credit {
             $align = 'none';
 
         $shcode = '[caption id="' . $id . '" align="align' . $align .
-            '" width="' . $width . '" caption="' . addslashes( $caption ) . '"';
+            '" width="' . $width . '" caption="' . $caption . '"';
         global $tinymce_version;
         if ( -1 === version_compare( $tinymce_version, '4018-20140303' ) ) {
             $shcode .= ' credit="' . addslashes( $creditor->to_string() ) . '"';


### PR DESCRIPTION
One line fix for extra slashes being added in the caption field when media is sent to the visual editor from the media library. Should close #465 and associated current.org help desk ticket.