### PR TITLE
Fix LMP dom on series landing pages.

### DIFF
--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -104,11 +104,12 @@ if (!function_exists('largo_load_more_posts')) {
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) : $query->the_post();
 				$partial = 'home';
-				if($_POST['is_series_landing']) {
+				if($_POST['is_series_landing'] === true || $_POST['is_series_landing'] === 1) {
 					$partial = 'series';
 					$opt = $_POST['opt'];
 				}
 				$partial = ( get_post_type() == 'argolinks' ) ? 'argolinks' : $partial;
+				echo $partial;
 				get_template_part( 'partials/content', $partial );
 			endwhile;
 		}

--- a/js/load-more-posts.js
+++ b/js/load-more-posts.js
@@ -8,7 +8,10 @@
                 data: {
                     action: 'load_more_posts',
                     paged: (LMP.paged == 0)? 1:LMP.paged,
-                    is_home: LMP.is_home
+                    is_home: LMP.is_home,
+                    is_series_landing: LMP.is_series_landing,
+                    // opt is used by partials/content-series.php to return the same type of post.
+                    opt: LMP.opt
                 },
                 type: 'POST',
                 dataType: 'html',

--- a/partials/content-series.php
+++ b/partials/content-series.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying content on a series landing page
  */
-global $opt;	//get display options for the loop
+global $opt;	// get display options for the loop
 $tags = of_get_option ('tag_display');
 
 ?>
@@ -11,7 +11,7 @@ $tags = of_get_option ('tag_display');
 
 	<header>
 
- 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] == 1 && largo_has_categories_or_tags() && $tags === 'top' ) { ?>
+ 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'top' ) { ?>
     		<h5 class="top-tag"><?php largo_top_term(); ?></h5>
     	<?php } ?>
 
@@ -19,21 +19,21 @@ $tags = of_get_option ('tag_display');
  			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
  		</h2>
 
- 		<?php if ( isset($opt['show']['byline']) && $opt['show']['byline'] == 1 ) : ?>
+ 		<?php if ( isset($opt['show']['byline']) && $opt['show']['byline'] ) : ?>
  		<h5 class="byline"><?php largo_byline(); ?></h5>
  		<?php endif; ?>
 	</header><!-- / entry header -->
 
 	<div class="entry-content">
- 		<?php if ( isset($opt['show']['image']) && $opt['show']['image'] == 1 ) : ?>
+ 		<?php if ( isset($opt['show']['image']) && $opt['show']['image'] ) : ?>
 		<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail(); ?></a>
 		<?php endif; ?>
 
- 		<?php if ( isset($opt['show']['excerpt']) && $opt['show']['excerpt'] == 1 ) :
+ 		<?php if ( isset($opt['show']['excerpt']) && $opt['show']['excerpt'] ) :
 			largo_excerpt( $post, 5, true, __('Continue&nbsp;Reading&nbsp;&rarr;', 'largo'), true, false );
 		endif; ?>
 
-		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] == 1 && largo_has_categories_or_tags() && $tags === 'btm' ) { ?>
+		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'btm' ) { ?>
     		<h5 class="tag-list"><strong><?php _e('Filed under:', 'largo'); ?></strong> <?php largo_categories_and_tags( 8 ); ?></h5>
     	<?php } ?>
 

--- a/series-landing.php
+++ b/series-landing.php
@@ -84,6 +84,8 @@ endif;
 <?php
 
 global $wp_query;
+global $post;
+$save_post = $post;
 
 // Make sure we're actually a series page, and pull posts accordingly
 if ( isset( $wp_query->query_vars['term'] )
@@ -137,6 +139,7 @@ if ( isset( $wp_query->query_vars['term'] )
 	largo_content_nav( 'nav-below' );
 
 	wp_reset_postdata();
+	$post = $save_post;
 } ?>
 
 </div><!-- /.grid_8 #content -->

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -50,6 +50,8 @@ class AjaxFunctionsTestAjaxFunctions extends WP_Ajax_UnitTestCase {
 	function test_largo_load_more_posts() {
 		$_POST['paged'] = 0;
 		$_POST['query'] = array();
+		$_POST['is_series_landing'] = true;
+		$_POST['opt'] = array();
 
 		try {
 			$this->_handleAjax("load_more_posts");
@@ -101,6 +103,9 @@ class AjaxFunctionsTestAjaxFunctions extends WP_Ajax_UnitTestCase {
 
 	function test_largo_load_more_posts_empty_query() {
 		$_POST['paged'] = 0;
+		$_POST['is_series_landing'] = true;
+		$_POST['opt'] = array();
+
 
 		try {
 			$this->_handleAjax("load_more_posts");


### PR DESCRIPTION
Landing pages were loading partials/content when
partials/content-series is used on landing pages.

 - [x] added an indicator sent with LMP data to alert the dom
generating function that this is a series landing page
 - [x] pass $opt variable that partials/content-series uses to
determine the dom to return.
 - [x] be a good person and restore global $post after the landing page
is done using it.

We can probably (in the future) overhaul the series page template to
simplify how it asks and controls dom.