### PR TITLE
#399 custom tax in menus

### DIFF
--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -269,7 +269,7 @@ function largo_category_archive_posts( $query ) {
 }
 add_action('pre_get_posts', 'largo_category_archive_posts', 15);
 
-/*
+/**
  * Get posts marked as "Featured in category" for a given category name.
  *
  * @param string $category_name the category to retrieve featured posts for.
@@ -300,10 +300,11 @@ function largo_get_featured_posts_in_category($category_name) {
  */
 function unregister_series_taxonomy() {
 	if ( !largo_is_series_enabled() ) {
-		register_taxonomy( 'series', array() );
+		register_taxonomy( 'series', array(), array('show_in_nav_menus' => false) );
 	}
 }
 add_action( 'init', 'unregister_series_taxonomy', 999 );
+
 /**
  * If the option in Advanced Options is unchecked, unregister the "Post Types" taxonomy
  *
@@ -312,7 +313,7 @@ add_action( 'init', 'unregister_series_taxonomy', 999 );
  */
 function unregister_post_types_taxonomy() {
 	if ( of_get_option('post_types_enabled') == 0 ) {
-		register_taxonomy( 'post-type', array() );
+		register_taxonomy( 'post-type', array(), array('show_in_nav_menus' => false) );
 	}
 }
 add_action( 'init', 'unregister_post_types_taxonomy', 999 );


### PR DESCRIPTION
I did some testing and I couldn't get a largo setup that replicated #399. However, I found another bug that I believe may be the source.

If series are disabled and a user is created, the first time they visit the menu page they will get an option set to hide `add-series` and `add-post-type` on the menu page (because these taxonomies are still registered as 'ghost' taxonomies). If the series are then enabled, they'll be hidden.

The simple fix: If the series/post types are not enabled, be explicit and not allow them as a menu item.

See my comment on:
http://stackoverflow.com/a/8363082/620680

We should still keep an eye on this.