### PR TITLE
Decrease Largo_Related resource use

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -399,6 +399,7 @@ class Largo_Related {
 	var $number;
 	var $post_id;
 	var $post_ids = array();
+	var $post;
 
 	/**
 	 * Constructor.
@@ -421,6 +422,8 @@ class Largo_Related {
 		} else {
 			$this->post_id = get_the_ID();
 		}
+
+		$this->post = get_post($this->post_id);
 	}
 
 	/**
@@ -478,6 +481,9 @@ class Largo_Related {
 					'orderby' => 'date',
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
+					'date_query' => array(
+						'after' => $this->post->post_date,
+					),
 				);
 
 				// see if there's a post that has the sort order info for this series
@@ -543,16 +549,20 @@ class Largo_Related {
 					'orderby' => 'date',
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
+					'date_query' => array(
+						'after' => $this->post->post_date,
+					),
 				);
-			}
-			// run the query
-			$term_query = new WP_Query( $args );
 
-			if ( $term_query->have_posts() ) {
-				$this->add_from_query( $term_query );
-					if ( $this->have_enough_posts() ) {
-						break;
-					}
+				// run the query
+				$term_query = new WP_Query( $args );
+
+				if ( $term_query->have_posts() ) {
+					$this->add_from_query( $term_query );
+						if ( $this->have_enough_posts() ) {
+							break;
+						}
+				}
 			}
 		}
 	}
@@ -624,15 +634,8 @@ class Largo_Related {
 
 		while ( $q->have_posts() ) {
 			$q->the_post();
-			//don't show our post, but record that we've found it
-			if ( $q->post->ID == $this->post_id ) {
-				$found_ours = TRUE;
-				continue;
-			// don't add any posts until we're adding posts newer than the one being displayed
-			} else if ( ! $found_ours ) {
-				continue;
 			// add this post if it's new
-			} else if ( ! in_array( $q->post->ID, $this->post_ids ) ) {	// only add it if it wasn't already there
+			if ( ! in_array( $q->post->ID, $this->post_ids ) ) {	// only add it if it wasn't already there
 				$this->post_ids[] = $q->post->ID;
 				// stop if we have enough
 				if ( $this->have_enough_posts() ) return;

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -480,30 +480,38 @@ class Largo_Related {
           'ignore_sticky_posts' => 1,
 				);
 
-				// see if there's a post that has the sort order info for this series
-				$pq = new WP_Query( array(
-					'post_type' => 'cftl-tax-landing',
-					'series' => $term->slug,
-					'posts_per_page' => 1
-				));
+				// This seems like it would be a good case for a transient
+				// Based on this, but using variable varriables: http://www.wpbeginner.com/wp-tutorials/speed-up-your-wordpress-by-caching-custom-queries-using-transients-api/
+				$series_query_name = $this->slug . $this->number . "-cftl-tax-landing";
+				if ( false === ( $$series_query_name = get_transient( $series_query_name ) ) ) {
+					// see if there's a post that has the sort order info for this series
+					$$series_query_name = new WP_Query( array(
+						'post_type' => 'cftl-tax-landing',
+						'series' => $term->slug,
+						'posts_per_page' => 1
+					));
 
-				if ( $pq->have_posts() ) {
-					$pq->next_post();
-					$has_order = get_post_meta( $pq->post->ID, 'post_order', TRUE );
-					if ( !empty($has_order) ) {
-						switch ( $has_order ) {
-							case 'ASC':
-								$args['order'] = 'ASC';
-								break;
-							case 'custom':
-								$args['orderby'] = 'series_custom';
-								break;
-							case 'featured, DESC':
-							case 'featured, ASC':
-								$args['orderby'] = $opt['post_order'];
-								break;
+					if ( $$series_query_name->have_posts() ) {
+						$$series_query_name->next_post();
+						$has_order = get_post_meta( $$series_query_name->post->ID, 'post_order', TRUE );
+						if ( !empty($has_order) ) {
+							switch ( $has_order ) {
+								case 'ASC':
+									$args['order'] = 'ASC';
+									break;
+								case 'custom':
+									$args['orderby'] = 'series_custom';
+									break;
+								case 'featured, DESC':
+								case 'featured, ASC':
+									$args['orderby'] = $opt['post_order'];
+									break;
+							}
 						}
 					}
+
+					set_transient( $series_query_results, $$series_query_results, 60*60 );
+					unset($series_query_results);
 				}
 
 				// build the query with the sort defined

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -472,7 +472,7 @@ class Largo_Related {
 				// get the posts in this series, ordered by rank or (if missing?) date
 				$args = array(
 					'post_type'           => 'post',
-					'posts_per_page'      => -1,	//should usually be enough
+					'posts_per_page'      => $this->number,
 					'taxonomy' 			      => 'series',
 					'term'                => $term->slug,
 					'orderby'             => 'date',
@@ -534,7 +534,7 @@ class Largo_Related {
 			foreach ( $taxonomies as $term ) {
 				$args = array(
 					'post_type'           => 'post',
-					'posts_per_page'      => -1,
+					'posts_per_page'      => $this->number,
 					'taxonomy' 		 	      => $term->taxonomy,
 					'term'                => $term->slug,
 					'orderby'             => 'date',

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -470,7 +470,6 @@ class Largo_Related {
 
 			//loop thru all the series this post belongs to
 			foreach ( $series as $term ) {
-
 				//start to build our query of posts in this series
 				// get the posts in this series, ordered by rank or (if missing?) date
 				$args = array(
@@ -559,9 +558,9 @@ class Largo_Related {
 
 				if ( $term_query->have_posts() ) {
 					$this->add_from_query( $term_query );
-						if ( $this->have_enough_posts() ) {
-							break;
-						}
+					if ( $this->have_enough_posts() ) {
+						break;
+					}
 				}
 			}
 		}
@@ -583,10 +582,7 @@ class Largo_Related {
 		$posts_query = new WP_Query( $args );
 
 		if ( $posts_query->have_posts() ) {
-			while ( $posts_query->have_posts() ) {
-				$posts_query->the_post();
-				if ( !in_array($posts_query->post->ID, $this->post_ids) ) $this->post_ids[] = $posts_query->post->ID;
-			}
+			$this->add_from_query($posts_query);
 		}
 	}
 
@@ -602,7 +598,7 @@ class Largo_Related {
 		//see if this post has manually set related posts
 		$post_ids = get_post_meta( $this->post_id, 'largo_custom_related_posts', true );
 		if ( ! empty( $post_ids ) ) {
-			$this->post_ids = explode( ",", $post_ids );
+			$this->post_ids = explode( ",", str_replace(' ', '', $post_ids) );
 			if ( $this->have_enough_posts() ) {
 				return $this->cleanup_ids();
 			}
@@ -636,13 +632,14 @@ class Largo_Related {
 			$q->the_post();
 			// add this post if it's new
 			if ( ! in_array( $q->post->ID, $this->post_ids ) ) {	// only add it if it wasn't already there
-				$this->post_ids[] = $q->post->ID;
+				$this->post_ids[] = (int) trim($q->post->ID);
 				// stop if we have enough
 				if ( $this->have_enough_posts() ) return;
 			}
 		}
 
-		//still here? reverse and try again
+		// still here? reverse and try again
+		// NOTE: we have no idea what this is used for (4/29/2015)
 		if ( ! $reversed ) {
 			$q->posts = array_reverse($q->posts);
 			$q->rewind_posts();

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -491,27 +491,28 @@ class Largo_Related {
 						'posts_per_page' => 1
 					));
 
-					if ( $$series_query_name->have_posts() ) {
-						$$series_query_name->next_post();
-						$has_order = get_post_meta( $$series_query_name->post->ID, 'post_order', TRUE );
-						if ( !empty($has_order) ) {
-							switch ( $has_order ) {
-								case 'ASC':
-									$args['order'] = 'ASC';
-									break;
-								case 'custom':
-									$args['orderby'] = 'series_custom';
-									break;
-								case 'featured, DESC':
-								case 'featured, ASC':
-									$args['orderby'] = $opt['post_order'];
-									break;
-							}
-						}
-					}
 
 					set_transient( $series_query_results, $$series_query_results, 60*60 );
 					unset($series_query_results);
+				}
+
+				if ( $$series_query_name->have_posts() ) {
+					$$series_query_name->next_post();
+					$has_order = get_post_meta( $$series_query_name->post->ID, 'post_order', TRUE );
+					if ( !empty($has_order) ) {
+						switch ( $has_order ) {
+							case 'ASC':
+								$args['order'] = 'ASC';
+								break;
+							case 'custom':
+								$args['orderby'] = 'series_custom';
+								break;
+							case 'featured, DESC':
+							case 'featured, ASC':
+								$args['orderby'] = $opt['post_order'];
+								break;
+						}
+					}
 				}
 
 				// build the query with the sort defined

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -536,13 +536,13 @@ class Largo_Related {
 
 			foreach ( $taxonomies as $term ) {
 				$args = array(
-					'post_type'           => 'post',
-					'posts_per_page'      => $this->number,
-					'taxonomy' 		 	      => $term->taxonomy,
-					'term'                => $term->slug,
-					'orderby'             => 'date',
-					'order'               => 'ASC',
-          'ignore_sticky_posts' => 1,
+					'post_type' => 'post',
+					'posts_per_page' => $this->number,
+					'taxonomy' => $term->taxonomy,
+					'term' => $term->slug,
+					'orderby' => 'date',
+					'order' => 'ASC',
+					'ignore_sticky_posts' => 1,
 				);
 			}
 			// run the query
@@ -550,6 +550,9 @@ class Largo_Related {
 
 			if ( $term_query->have_posts() ) {
 				$this->add_from_query( $term_query );
+					if ( $this->have_enough_posts() ) {
+						break;
+					}
 			}
 		}
 	}
@@ -563,7 +566,7 @@ class Largo_Related {
 
 		$args = array(
 			'post_type' => 'post',
-			'posts_per_page' => $this->number + 1,
+			'posts_per_page' => $this->number,
 			'post__not_in' => array( $this->post_id ),
 		);
 
@@ -643,7 +646,6 @@ class Largo_Related {
 			$this->add_from_query( $q, TRUE );
 		}
 	}
-
 
 	/**
 	 * Counts to see if enough posts have been found

--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -23,7 +23,7 @@ class largo_author_widget extends WP_Widget {
 		if( get_post_meta( $post->ID, 'largo_byline_text' ) )
 			$byline_text = esc_attr( get_post_meta( $post->ID, 'largo_byline_text', true ) );
 
-		$is_series_landing = (function_exists('is_series_landing'))? is_series_landing() : false;
+		$is_series_landing = (function_exists('is_series_landing'))? is_series_landing($post->ID) : false;
 
 		if( (is_singular() || is_author() || $is_series_landing) && empty($byline_text) ):
 

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -1,0 +1,133 @@
+<?php
+
+// Test functions in inc/related-content.php
+
+class RelatedContentTestFunctions extends wp_UnitTestCase{
+	function setUp() {
+		parent::setUp();
+	}
+
+	function test_largo_get_related_topics_for_category() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test__tags_associated_with_category() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test__subcategories_for_category() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_get_post_related_topics() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_get_recent_posts_for_term() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_has_categories_or_tags() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_categories_and_tags() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_top_term() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_filter_get_post_related_topics() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	function test_largo_filter_get_recent_posts_for_term_query_args() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+}
+
+class LargoRelatedTestFunctions extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+	}
+
+	function test___construct() {
+		// check that Largo_Related->number equals 1 if number is not set
+		// check that Largo_Related->post_id is the value of the set post, or the value of the global post
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_popularity_sort() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+
+	}
+
+	/**
+	 * Test the function with a lot of different conditions
+	 *
+	 * - Series without organization
+	 * - Series with CFTL post with organization information
+	 *		- ASC
+	 *		- series_custom
+	 *		- DESC
+	 *		- featured, DESC
+	 *		- featured, ASC
+	 * - No series, but category
+	 * - No series, but tag
+	 * - Tags and Categories
+	 * - No series or category or tag
+	 */
+
+	function test_unorganized_series() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_series_asc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_series_series_custom() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_series_desc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_series_featured_desc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_series_featured_asc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_category() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_tags() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_category_and_tag() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_recent_posts() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+}


### PR DESCRIPTION
## Changes:

- `get_series_posts()` and `get_term_posts()` no longer query for `-1` infinite posts in every series associated with the current post, but instead query for the number of posts that will need to be outputted.
- The query for CFTL taxonomy landing pages in each series is now wrapped in a conditional that checks for a cached version of the query and uses that. If the cached query does not exist, it runs a new query and caches it. More details on how that works [here](http://www.wpbeginner.com/wp-tutorials/speed-up-your-wordpress-by-caching-custom-queries-using-transients-api/).
- Unrelated to Largo_Related, fixes a missing argument for is_series_landing() in the Largo Author Bio widget.
- Empty tests for inc/related-content.php

## Why

See #671: Largo_Related was querying for all the posts posts in every series or in every category that a post was in.



