### PR TITLE
Documentation for Largo_Related's previous functionality.

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -637,14 +637,6 @@ class Largo_Related {
 				if ( $this->have_enough_posts() ) return;
 			}
 		}
-
-		// still here? reverse and try again
-		// NOTE: we have no idea what this is used for (4/29/2015)
-		if ( ! $reversed ) {
-			$q->posts = array_reverse($q->posts);
-			$q->rewind_posts();
-			$this->add_from_query( $q, TRUE );
-		}
 	}
 
 	/**


### PR DESCRIPTION
This commit removes the "reverse" functionality of Largo_Related::add_from_query.

The PR message and commit message add a lot of information from Ben Byrne about Largo_Related as he wrote it originally.

## The old way of doing things

The recent changes to Largo_Related were because it was consuming excessive resources when finding a related post. The reason for this was because of some huge queries, which were introduced in https://github.com/INN/Largo/commit/6fb4db3878757767cd5de83e2cae4f3293496147 by Ben Byrne. The code that he wrote was imporessive in its doggedness at finding related posts, and in ordering them. I regret having to take it out, but it was making huge queries.

Ben Byrne writes:

> get_series_posts() and get_term_posts() have posts_per_page set to -1 because we’re not actually trying to fetch posts from a standard “endpoint” of a query: the most recent, or the least recent, or whatever. We’re trying to query based around the currently-displayed post ( $this->post_id ), e.g., “show me the N most recent posts with an ID higher than $this->post_id” — this is the logic encapsulated in add_from_query(). An example is probably the best way to understand this.
>
> Let’s say there are 1000 posts, and that we are viewing post_id 500 and want to show 10 related posts. Our post_id 500, furthermore, isn’t a part of a series, but it does have a single term. What we want to show as “related” (per the requirements I was given at the time)  would thus be the 10 posts that came immediately after post_id 500 that were also assigned to that same term. For convenience’s sake lets say those are posts 501-510. But since post 500, there have been many more than 10 posts assigned to that term, let’s say all of post ID’s 900-1000 also have that term – and also posts 100-200 also used it.
>
> If we limit posts_per_page to 10, and fetch posts in our term ordered by date ASC, we’ll get post IDs 100-110; if we fetch by date DESC, we’ll get post IDs 990-1000. Neither of those is what we want.
>
> So instead, we fetch ALL the posts from the term, and start looping through them but ignoring them (see line 625). Once we finally hit the post we’re keying off of (line 621), THEN we start caring about our results (line 628) until we get to $this->number (line 630).
>
> Basically this is a big elaborate workaround for the fact that WP_Query doesn’t offer a way to say things like “fetch me the N posts that came right after post X” when working with post IDs. The workaround was to fetch them all and then only care about some of them.
>
> You could probably refactor this code to be less esoteric (and not fetch all) by using dates instead of post IDs, because WP_Query does support date-based queries using “before” and “after” — either that wasn’t available at the time I wrote this, I wasn’t aware of it, or there was some compelling reason we wanted to use IDs instead of dates, I’m not sure which.
>
> As for why get_recent_posts() fetches $this->number + 1 instead of just $this->number….. I have no idea. There was probably some weird edge case where something didn’t happen as I expected and I figured slapping one more on would fix it… but I have no clue what that case would have been or why I thought that was a good solution at the time. Sorry!

## Why it's okay to remove the "reverse"

Simply put - it doesn't do anything useful when it's not being fed the entire set of posts in a series.

Ben Byrne writes:

> To recap the scenario as it was:
> - we had a post
> - we fetched all the posts sharing that post’s term
> - we then looped thru them, ignoring them until we “hit” our current post, then we grabbed the next $this->number posts we found.
>
> Let’s say our post is kind of in the middle of the collection, and there are posts sharing its term on either side of it (both before and after). By default, the script is sorting by date, ASC so it will pick up posts that happened right after our post.
>
> But what if we want to show 10 related items, and there are only 5 posts sharing our post’s term that came after, and 50 that came before? We would have skipped the 50 that came before and would wind up only fetching the 5 that came after, leaving us to fill the remaining spots with … something else (i.e. recent posts that aren’t actually related).
>
> Enter lines 637-641 in my code: If we haven’t yet found $this->number worth of posts, we reverse the order of the array containing all the posts, and look thru it again. Thus in my hypothetical scenario, we’d fetch the 5 posts that came immediately after our post, then reverse the array and loop thru again, picking up the 5 posts that immediately preceded our given post.
>
> In your case, if you wanted to mimic this functionality now that you’re using a date_query, you’d need to make a second query with “before” instead of “after” and order DESC instead of ASC, and then you’d get posts from that IFF there weren’t enough when you looked forward in time.
>
> If you don’t want to bother with oscillating back and forth on each term hunting for posts before moving on to the next term, you could just kill lines 643-647 of your code. But I can pretty easily envision a situation where the most useful posts related to a given post are actually its precursors rather than its successors.
>
> Hope that makes sense.