### PR TITLE
Make Largo Related Posts Widget use largo_excerpt instead of $post->post_excerpt

### DIFF
--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -52,11 +52,7 @@ class largo_related_posts_widget extends WP_Widget {
 					<time class="entry-date updated dtstamp pubdate" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php largo_time(); ?></time>
 				</h5>
 				<?php // post excerpt/summary
-				if ($post->post_excerpt) {
-					echo '<p>' . $post->post_excerpt . '</p>';
-				} else {
-					echo '<p>' . largo_trim_sentences($post->post_content, 2) . '</p>';
-				}
+				largo_excerpt(get_the_ID(), 2, false, '', true);
 		 		echo '</li>';
 	 		}
 


### PR DESCRIPTION
## Changes:

- Largo Related Posts Widget now uses [largo_excerpt](https://github.com/INN/Largo/blob/0e73daf4b9e6238f248d947458da600662c9b018/inc/post-tags.php#L369) for post text generation

## Why

- Largo Related Posts Widget will now have [all the excerpt fallbacks](https://github.com/INN/Largo/blob/0e73daf4b9e6238f248d947458da600662c9b018/inc/post-tags.php#L377-L398) of largo_related
- The excerpt in the related posts widget will be able to be filtered by child themes