### PR TITLE
Added 'email' vCard metadata to <a> tag

### DIFF
--- a/partials/author-bio-social-links.php
+++ b/partials/author-bio-social-links.php
@@ -13,7 +13,7 @@
 
 	<?php if ( $email = $author_obj->user_email ) { ?>
 		<li class="email">
-			<a href="mailto:<?php echo esc_attr( $email ); ?>" title="e-mail <?php echo esc_attr( $author_obj->display_name ); ?>"><i class="icon-mail"></i></a>
+			<a class="email" href="mailto:<?php echo esc_attr( $email ); ?>" title="e-mail <?php echo esc_attr( $author_obj->display_name ); ?>"><i class="icon-mail"></i></a>
 		</li>
 	<?php } ?>
 


### PR DESCRIPTION
Hello. 

I'm at [a news archiving conference in Charlotte](http://educopia.org/events/dmh). During a group discussion of adoption of structured metadata by news publishers we audited article pages from a small number of sites. 

[According to Google's validator](https://developers.google.com/structured-data/testing-tool?url=http%253A%252F%252Fwisconsinwatch.org%252F2015%252F05%252Fhave-john-does-probes-trashed-rule-of-law-in-wisconsin%252F), your base template does very well. But Google doesn't like the ``email`` identifier in the "social bio" for article authors. 

![1431445210 44](https://cloud.githubusercontent.com/assets/9993/7595388/876026c2-f89b-11e4-9492-36976421e762.png)

In an effort to bring your code closer to compliance with [the hCard standard](http://microformats.org/wiki/hcard) I made the small change attached to this pull request.