### PR TITLE
Make inc/updates.php cleaner to prepare for future update functions

### DIFF
--- a/inc/update.php
+++ b/inc/update.php
@@ -3,41 +3,23 @@
  * Contains functions and tools for transitioning between Largo 0.3 and Largo 0.4
  */
 
-/**
- * Returns current version of largo
- */
-function largo_version() {
-	$theme = wp_get_theme();
-	$parent = $theme->parent();
-	if (!empty($parent))
-		return $parent->get('Version');
-	return $theme->get('Version');
-}
+
+
+/** --------------------------------------------------------
+ * Start updates and helpers
+ * ------------------------------------------------------ */
 
 /**
- * Checks if widgets need to be placed by checking old theme settings
- */
-function largo_need_updates() {
-	// try to figure out which versions of the options are stored. Implemented in 0.3
-	if (of_get_option('largo_version')) {
-		$compare = version_compare(largo_version(), of_get_option('largo_version'));
-		if ($compare == 1)
-			return true;
-		else
-			return false;
-	}
-
-	// if 'largo_version' isn't present, the settings are old!
-	return true;
-}
-
-/**
- * Performs various database updates upon Largo version change.
+ * Performs various update functions and set a new verion number.
  *
+ * This acts as a main() for applying database updates when the update ajax is
+ * called. 
+ * 
  * @since 0.3
  */
 function largo_perform_update() {
 	if (largo_need_updates()) {
+
 		// Run when updating from pre-0.4
 		if (version_compare(of_get_option('largo_version'), '0.4') < 0) {
 			largo_home_transition();
@@ -56,6 +38,7 @@ function largo_perform_update() {
 		largo_update_custom_less_variables();
 		largo_check_deprecated_widgets();
 
+		// Set version.
 		of_set_option('largo_version', largo_version());
 	}
 
@@ -63,13 +46,56 @@ function largo_perform_update() {
 }
 
 /**
- * Upgrades for moving from 0.3 to 0.4
+ * Returns current version of largo as set in stylesheet.
+ * 
+ * @since 0.3
+ */
+function largo_version() {
+	$theme = wp_get_theme();
+	$parent = $theme->parent();
+	if (!empty($parent))
+		return $parent->get('Version');
+	return $theme->get('Version');
+}
+
+
+/**
+ * Checks if updates need to be run.
+ * 
+ * @since 0.3
+ * 
+ * @return boolean if updates need to be run
+ */
+function largo_need_updates() {
+	// try to figure out which versions of the options are stored. Implemented in 0.3
+	if (of_get_option('largo_version')) {
+		$compare = version_compare(largo_version(), of_get_option('largo_version'));
+		if ($compare == 1)
+			return true;
+		else
+			return false;
+	}
+
+	// if 'largo_version' isn't present, the settings are old!
+	return true;
+}
+
+
+
+
+
+
+/** --------------------------------------------------------
+ * Upgrades for moving from 0.3 -> 0.4
+ * 
  * In which many theme options became widgets
  * And homepage templates are implemented
- */
+ * ------------------------------------------------------ */
 
 /**
  * Convert old theme option of 'homepage_top' to new option of 'home_template'
+ * 
+ * @since 0.4
  */
 function largo_home_transition() {
 	$old_regime = of_get_option('homepage_top', 0);
@@ -97,6 +123,8 @@ function largo_home_transition() {
 
 /**
  * Puts new widgets into sidebars as appropriate based on old theme options
+ * 
+ * @since 0.4
  */
 function largo_update_widgets() {
 
@@ -158,119 +186,12 @@ function largo_update_widgets() {
 			}
 		}
 	}
-}
-
-/**
- * Checks to see if a given widget is in a given region already
- */
-function largo_widget_in_region( $widget_name, $region = 'article-bottom' ) {
-
-	$widgets = get_option( 'sidebars_widgets ');
-
-	if ( !isset( $widgets[$region] ) ) {
-		return new WP_Error( 'region-missing', __('Invalid region specified.', 'largo' ) );
-	}
-
-	foreach( $widgets[$region] as $key => $widget ) {
-		if ( stripos( $widget, $widget_name ) === 0 ) return true;	//we found a copy of this widget! Note this may return a false positive if the widget we're checking is the same name (but shorter) as another kind of widget
-	}
-	return false;	// the widget wasn't there
 
 }
 
 /**
- * Inserts a widget programmatically.
- * This is slightly dangerous as it makes some assumptions about existing plugins
- * if $instance_settings are wrong, bad things might happen
+ * @since 0.4
  */
-function largo_instantiate_widget( $kind, $instance_settings, $region ) {
-
-	$defaults = array(
-		'widget_class' => 'default',
-		'hidden_desktop' => 0,
-		'hidden_tablet' => 0,
-		'hidden_phone' => 0,
-		'title_link' => ''
-	);
-
-	$instance_id = 2; 	// default, not sure why it always seems to start at 2
-	$full_kind = 'widget_' . str_replace("_", "-", $kind) . '-widget';
-
-	// step 1: add the widget instance to the database and get the ID
-	$widget_instances = get_option( $kind );
-
-	// no instances of this exist, yay
-	if ( !$widget_instances ) {
-		update_option( $full_kind,
-			array(
-				2 => wp_parse_args( $instance_settings, $defaults ),
-				'_multiwidget' => 1,
-			)
-		);
-
-	} else {
-		//figure out what ID we're creating. Don't just use count() as things might get deleted or something...
-		//there's probably a smarter way to do this...
-		while ( array_key_exists( $instance_id, $widget_instances) ) {
-			$instance_id++;
-		}
-
-		//pop off _multiwidget, add our element to the end, then add _multiwidget back
-		$new_instances = array_pop( $widget_instances );
-		$new_instances[ $instance_id ] = wp_parse_args( $instance_settings, $defaults );
-		$new_instances[ '_multiwidget' ] = 1;
-		update_option( $full_kind, $new_instances );
-	}
-
-	// step 2: add the widget instance we just created to the region; this isn't so bad
-	$region_widgets = get_option( 'sidebars_widgets' );
-	$region_widgets[ $region ][] = $kind . '-widget-' . $instance_id;
-	update_option( 'sidebars_widgets', $region_widgets );
-
-}
-
-/**
- * Checks for use of deprecated widgets and posts an alert
- */
-function largo_check_deprecated_widgets() {
-
-	$deprecated = array(
-		'largo-footer-featured' => 'largo_deprecated_footer_widget',
-		'largo-sidebar-featured' => 'largo_deprecated_sidebar_widget'
-	);
-
-	$widgets = get_option( 'sidebars_widgets ');
-	foreach ( $widgets as $region => $widgets ) {
-		if ( $region != 'wp_inactive_widgets' && $region != 'array_version' && is_array($widgets) ) {
-			foreach ( $widgets as $widget_instance ) {
-				foreach ( $deprecated as $widget_name => $callback ) {
-					if (strpos($widget_instance, $widget_name) === 0) {
-						add_action( 'admin_notices', $callback );
-						unset( $deprecated[$widget_name] ); //no need to flag the same widget multiple times
-					}
-				}
-			}
-		}
-	}
-}
-
-/**
- * Admin notices of older widgets
- */
-function largo_deprecated_footer_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __('You are using the <strong>Largo Footer Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
-
-function largo_deprecated_sidebar_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __( 'You are using the <strong>Largo Sidebar Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
-
 function largo_transition_nav_menus() {
 	$locations = get_nav_menu_locations();
 	$main_nav = wp_get_nav_menu_object('Main Navigation');
@@ -320,50 +241,7 @@ function largo_transition_nav_menus() {
 	}
 
 	set_theme_mod('nav_menu_locations', $locations);
-}
 
-/**
- * Compares an array containing an old and new prominence term description and the appropriate slug and name to an array of current term descriptions. For each term whose current description matches the old description, the function updates the current description to the new description.
- *
- * This function contains commented-out logic that will allow you to from description to olddescription
- *
- * @param array $update The new details for the prominence tax term to be updated
- * @param array $term_descriptions Array of prominence terms, each prominence term as an associative array with keys: name, description, olddescription, slug
- * @uses var_log
- * @uses wp_update_term
- * @uses clean_term_cache
- *
- */
-function largo_update_prominence_term_description_single($update, $term_descriptions) {
-	$logarray = array();
-
-	// Toggle comment on these two lines to revert to old descriptions.
-	if (in_array($update['olddescription'], $term_descriptions)) {
-#		if (in_array($update['description'], $term_descriptions)) {
-	    $id = get_term_by('slug', $update['slug'], 'prominence', 'ARRAY_A' );
-	    // Comment out this function to avoid all prominence term updates.
-#		    /*
-	    wp_update_term(
-	        $id['term_id'], 'prominence',
-	        array(
-	            'name' => $update['name'],
-	            // Toggle comment on these two lines to revert to old descriptions.
-	            'description' => $update['description'],
-#		            'description' => $update['olddescription'],
-	            'slug' => $update['slug']
-	        )
-	    );
-#		    */
-	    $logarray[] = 'Updated description of "' . $update['name'] . '" from "'. $update['olddescription'] . '" to "' . $update['description'] . '"';
-	    // Clean the entire prominence term cache
-	    clean_term_cache( $id['term_id'], 'prominence', true );
-	}
-
-	// These are here so you can grep your server logs to see if the terms were updated.
-#	var_log($logarray);
-#	var_log("Done updating prominence terms");
-
-	return $update;
 }
 
 /**
@@ -375,6 +253,7 @@ function largo_update_prominence_term_description_single($update, $term_descript
  * This function does not touch custom prominence term descriptions, except those that are identical to the descriptions of current or 0.3 prominence term descriptions.
  *
  * @since 0.4
+ * 
  * @uses largo_update_prominence_term_description_single
  */
 function largo_update_prominence_term_descriptions() {
@@ -440,8 +319,55 @@ function largo_update_prominence_term_descriptions() {
 # add_action('init', 'largo_update_prominence_term_descriptions');
 
 /**
+ * Compares an array containing an old and new prominence term description and the appropriate slug and name to an array of current term descriptions. For each term whose current description matches the old description, the function updates the current description to the new description.
+ *
+ * This function contains commented-out logic that will allow you to from description to olddescription
+ *
+ * @since 0.4
+ * 
+ * @param array $update The new details for the prominence tax term to be updated
+ * @param array $term_descriptions Array of prominence terms, each prominence term as an associative array with keys: name, description, olddescription, slug
+ * @uses var_log
+ * @uses wp_update_term
+ * @uses clean_term_cache
+ *
+ */
+function largo_update_prominence_term_description_single($update, $term_descriptions) {
+	$logarray = array();
+
+	// Toggle comment on these two lines to revert to old descriptions.
+	if (in_array($update['olddescription'], $term_descriptions)) {
+#	if (in_array($update['description'], $term_descriptions)) {
+	    $id = get_term_by('slug', $update['slug'], 'prominence', 'ARRAY_A' );
+	    // Comment out this function call to avoid all prominence term updates.
+#		/*
+	    wp_update_term(
+	        $id['term_id'], 'prominence',
+	        array(
+	            'name' => $update['name'],
+	            // Toggle comment on these two lines to revert to old descriptions.
+	            'description' => $update['description'],
+#   	        'description' => $update['olddescription'],
+	            'slug' => $update['slug']
+	        )
+	    );
+#	    */
+	    $logarray[] = 'Updated description of "' . $update['name'] . '" from "'. $update['olddescription'] . '" to "' . $update['description'] . '"';
+	    // Clean the entire prominence term cache
+	    clean_term_cache( $id['term_id'], 'prominence', true );
+	}
+
+	// These are here so you can grep your server logs to see if the terms were updated.
+	# var_log($logarray);
+	# var_log("Done updating prominence terms");
+
+	return $update;
+}
+
+/**
  * Update miscellaneous settings
  *
+ * @since 0.4
  */
 function largo_force_settings_update() {
 	$options = array();
@@ -467,7 +393,266 @@ function largo_force_settings_update() {
 	}
 }
 
-// WP admin dashboard update workflow
+/**
+ * Enable series if series have been created.
+ * 
+ * @since 0.4
+ * 
+ * @return bool If series were enabled by this function
+ */
+function largo_enable_if_series() {
+	// assuming that some posts will be in a series if series were used
+	$terms = get_terms('series', array(
+				'hide_empty' => false,
+				'fields' => 'all'
+			));
+
+	// enable series if more than 0 terms were returned
+	if (gettype($terms) == 'array' && count($terms) > 0 ) {
+		of_set_option('series_enabled', '1');
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Enable the series taxonomy if the series landing pages are in use.
+ * 
+ * @since 0.4
+ * 
+ * @return bool If series landing pages (and series) were enabled by this function.
+ */
+function largo_enable_series_if_landing_page() {
+
+	// get a list of post types
+	$types=get_post_types('', 'names');
+
+	// Get a list of pages in the 'series' taxonomy if the landing page is registered
+	if ( isset($types['cftl-tax-landing']) ) {
+		$args = array(
+			'post_type' => 'cftl-tax-landing'
+		);
+		$pages = get_pages($args);
+		if ( $pages !== false ) {
+			// get_pages returns false if no pages found, so if it's not false then there are probably cftl-tax-landing pages
+			of_set_option('series_enabled', '1');
+			of_set_option('custom_landing_enabled', '1');
+			return true;
+		}
+		return false;
+	}
+}
+
+
+
+
+
+
+/** --------------------------------------------------------
+ * Upgrades for moving from 0.4 -> 0.5
+ *
+ * In which top stories are no registered by default.
+ * ------------------------------------------------------ */
+
+/**
+ * Remove "top-story" prominence term to avoid conflicts with homepages that will register it
+ *
+ * @return array of deleted prominence terms
+ */
+function largo_remove_topstory_prominence_term() {
+	$terms = get_terms('prominence', array(
+				'hide_empty' => false,
+				'fields' => 'all'
+			));
+
+	$del_terms = array();
+	foreach ( $terms as $term ) {
+		$term = (array)$term; // $term is originally a stdClass::__set_state(array( ... ))
+
+		// get old "Top Story", which uses the same slug 'top-story' as the new "Homepage Top Story"
+		if ( $term['name'] == 'Top Story' ) {
+			wp_update_term( $term['term_taxonomy_id'], 'prominence', array(
+				'name' => __('Homepage Top Story', 'largo'),
+				'description' => __('If you are using a "Big story" homepage layout, add this label to a post to make it the top story on the homepage', 'largo'),
+				'slug' => 'top-story',
+				'parent' => null
+			));
+		} else if ( preg_match('/top-story-/', $term['slug'], $matches) ) {
+			// get 'top-story-N' but not new 'top-story'
+			wp_delete_term( $term['term_taxonomy_id'], 'prominence' );
+			$del_terms[] = $term;
+		}
+	}
+	return $del_terms;
+}
+
+
+
+
+
+
+/** --------------------------------------------------------
+ * Always run
+ *
+ * Functions that should run any time the largo version
+ * number bumps.
+ * ------------------------------------------------------ */
+
+/**
+ * Make sure custom CSS is regenerated if we're using custom LESS variables
+ */
+function largo_update_custom_less_variables() {
+	if (Largo::is_less_enabled()) {
+		$variables = Largo_Custom_Less_Variables::get_custom_values();
+		$escaped = array();
+
+		foreach ($variables['variables'] as $key => $var)
+			$escaped[$key] = addslashes($var);
+
+		Largo_Custom_Less_Variables::update_custom_values($escaped);
+	}
+}
+
+/**
+ * Checks for use of deprecated widgets and posts an alert
+ */
+function largo_check_deprecated_widgets() {
+
+	$deprecated = array(
+		'largo-footer-featured' => 'largo_deprecated_footer_widget',
+		'largo-sidebar-featured' => 'largo_deprecated_sidebar_widget'
+	);
+
+	$widgets = get_option( 'sidebars_widgets ');
+	foreach ( $widgets as $region => $widgets ) {
+		if ( $region != 'wp_inactive_widgets' && $region != 'array_version' && is_array($widgets) ) {
+			foreach ( $widgets as $widget_instance ) {
+				foreach ( $deprecated as $widget_name => $callback ) {
+					if (strpos($widget_instance, $widget_name) === 0) {
+						add_action( 'admin_notices', $callback );
+						unset( $deprecated[$widget_name] ); //no need to flag the same widget multiple times
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Admin notices of older widgets
+ */
+function largo_deprecated_footer_widget() { ?>
+	<div class="update-nag"><p>
+	<?php printf( __('You are using the <strong>Largo Footer Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
+	</p></div>
+	<?php
+}
+
+function largo_deprecated_sidebar_widget() { ?>
+	<div class="update-nag"><p>
+	<?php printf( __( 'You are using the <strong>Largo Sidebar Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
+	</p></div>
+	<?php
+}
+
+
+
+
+
+
+/** --------------------------------------------------------
+ * Update helper functions
+ * ------------------------------------------------------ */
+
+/**
+ * Checks to see if a given widget is in a given region already
+ */
+function largo_widget_in_region( $widget_name, $region = 'article-bottom' ) {
+
+	$widgets = get_option( 'sidebars_widgets ');
+
+	if ( !isset( $widgets[$region] ) ) {
+		return new WP_Error( 'region-missing', __('Invalid region specified.', 'largo' ) );
+	}
+
+	foreach( $widgets[$region] as $key => $widget ) {
+		if ( stripos( $widget, $widget_name ) === 0 ) return true;	//we found a copy of this widget! Note this may return a false positive if the widget we're checking is the same name (but shorter) as another kind of widget
+	}
+	return false;	// the widget wasn't there
+
+}
+
+/**
+ * Inserts a widget programmatically.
+ * This is slightly dangerous as it makes some assumptions about existing plugins
+ * if $instance_settings are wrong, bad things might happen
+ * 
+ * @since 0.5
+ * 
+ * @param String $kind. Kind of widget to instantiate.
+ * @param Array $instance_settings. Settings for that array.
+ * @param String $region. Sidebar region to add to.
+ */
+function largo_instantiate_widget( $kind, $instance_settings, $region ) {
+
+	$defaults = array(
+		'widget_class' => 'default',
+		'hidden_desktop' => 0,
+		'hidden_tablet' => 0,
+		'hidden_phone' => 0,
+		'title_link' => ''
+	);
+
+	$instance_id = 2; 	// default, not sure why it always seems to start at 2
+	$full_kind = 'widget_' . str_replace("_", "-", $kind) . '-widget';
+
+	// step 1: add the widget instance to the database and get the ID
+	$widget_instances = get_option( $kind );
+
+	// no instances of this exist, yay
+	if ( !$widget_instances ) {
+		update_option( $full_kind,
+			array(
+				2 => wp_parse_args( $instance_settings, $defaults ),
+				'_multiwidget' => 1,
+			)
+		);
+
+	} else {
+		//figure out what ID we're creating. Don't just use count() as things might get deleted or something...
+		//there's probably a smarter way to do this...
+		while ( array_key_exists( $instance_id, $widget_instances) ) {
+			$instance_id++;
+		}
+
+		//pop off _multiwidget, add our element to the end, then add _multiwidget back
+		$new_instances = array_pop( $widget_instances );
+		$new_instances[ $instance_id ] = wp_parse_args( $instance_settings, $defaults );
+		$new_instances[ '_multiwidget' ] = 1;
+		update_option( $full_kind, $new_instances );
+	}
+
+	// step 2: add the widget instance we just created to the region; this isn't so bad
+	$region_widgets = get_option( 'sidebars_widgets' );
+	$region_widgets[ $region ][] = $kind . '-widget-' . $instance_id;
+	update_option( 'sidebars_widgets', $region_widgets );
+
+}
+
+
+
+
+
+
+/** --------------------------------------------------------
+ * Update.php admin page logic.
+ * ------------------------------------------------------ */
+
+/**
+ * Add an admin notice if largo needs to be updated.
+ * 
+ * @since 0.3
+ */
 function largo_update_admin_notice() {
 	if (largo_need_updates() && !(isset($_GET['page']) && $_GET['page'] == 'update-largo')) {
 ?>
@@ -479,6 +664,11 @@ function largo_update_admin_notice() {
 }
 add_action('admin_notices', 'largo_update_admin_notice');
 
+/**
+ * Register an admin page for updates.
+ * 
+ * @since 0.3
+ */
 function largo_register_update_page() {
 	$parent_slug = null;
 	$page_title = "Update Largo";
@@ -496,6 +686,11 @@ function largo_register_update_page() {
 }
 add_action('admin_menu', 'largo_register_update_page');
 
+/**
+ * DOM for admin page for updates.
+ * 
+ * @since 0.3
+ */
 function largo_update_page_view() { ?>
 	<style type="text/css">
 		.update-message {
@@ -562,6 +757,8 @@ function largo_update_page_view() { ?>
 
 /**
  * Enqueues javascript used on the Largo Update page
+ * 
+ * @since 0.3
  *
  * @global LARGO_DEBUG
  * @global $_GET
@@ -576,6 +773,14 @@ function largo_update_page_enqueue_js() {
 }
 add_action('admin_enqueue_scripts', 'largo_update_page_enqueue_js');
 
+/**
+ * Ajax handler for when update is applied from the updates page.
+ * 
+ * @since 0.3
+ *
+ * @global LARGO_DEBUG
+ * @global $_GET
+ */
 function largo_ajax_update_database() {
 	if (!current_user_can('activate_plugins')) {
 		print json_encode(array(
@@ -614,96 +819,3 @@ function largo_ajax_update_database() {
 	}
 }
 add_action('wp_ajax_largo_ajax_update_database', 'largo_ajax_update_database');
-
-/**
- * Make sure custom CSS is regenerated if we're using custom LESS variables
- */
-function largo_update_custom_less_variables() {
-	if (Largo::is_less_enabled()) {
-		$variables = Largo_Custom_Less_Variables::get_custom_values();
-		$escaped = array();
-
-		foreach ($variables['variables'] as $key => $var)
-			$escaped[$key] = addslashes($var);
-
-		Largo_Custom_Less_Variables::update_custom_values($escaped);
-	}
-}
-
-/**
- * Remove "top-story" prominence term to avoid conflicts with homepages that will register it
- *
- * @return array of deleted prominence terms
- */
-function largo_remove_topstory_prominence_term() {
-	$terms = get_terms('prominence', array(
-				'hide_empty' => false,
-				'fields' => 'all'
-			));
-
-	$del_terms = array();
-	foreach ( $terms as $term ) {
-		$term = (array)$term; // $term is originally a stdClass::__set_state(array( ... ))
-
-		// get old "Top Story", which uses the same slug 'top-story' as the new "Homepage Top Story"
-		if ( $term['name'] == 'Top Story' ) {
-			wp_update_term( $term['term_taxonomy_id'], 'prominence', array(
-				'name' => __('Homepage Top Story', 'largo'),
-				'description' => __('If you are using a "Big story" homepage layout, add this label to a post to make it the top story on the homepage', 'largo'),
-				'slug' => 'top-story',
-				'parent' => null
-			));
-		} else if ( preg_match('/top-story-/', $term['slug'], $matches) ) {
-			// get 'top-story-N' but not new 'top-story'
-			wp_delete_term( $term['term_taxonomy_id'], 'prominence' );
-			$del_terms[] = $term;
-		}
-	}
-	return $del_terms;
-}
-
-/**
- * Enable series if series have been created.
- *
- * @return bool If series were enabled by this function
- */
-function largo_enable_if_series() {
-	// assuming that some posts will be in a series if series were used
-	$terms = get_terms('series', array(
-				'hide_empty' => false,
-				'fields' => 'all'
-			));
-
-	// enable series if more than 0 terms were returned
-	if (gettype($terms) == 'array' && count($terms) > 0 ) {
-		of_set_option('series_enabled', '1');
-		return true;
-	}
-	return false;
-}
-
-/**
- * Enable the series taxonomy if the series landing pages are in use.
- *
- * @return bool If series landing pages (and series) were enabled by this function.
- */
-function largo_enable_series_if_landing_page() {
-
-	// get a list of post types
-	$types=get_post_types('', 'names');
-
-	// Get a list of pages in the 'series' taxonomy if the landing page is registered
-	if ( isset($types['cftl-tax-landing']) ) {
-		$args = array(
-			'post_type' => 'cftl-tax-landing'
-		);
-		$pages = get_pages($args);
-		if ( $pages !== false ) {
-			// get_pages returns false if no pages found, so if it's not false then there are probably cftl-tax-landing pages
-			of_set_option('series_enabled', '1');
-			of_set_option('custom_landing_enabled', '1');
-			return true;
-		}
-		return false;
-	}
-}


### PR DESCRIPTION
Functions in `inc/update.php` are totally out of order making it difficult to figure out where future update functions should live.

Functions have been organized by when they were added. No new code is included in this pull, just a lot of copy and paste.

For future version releases, we can create a new region header and group all related update functions together there. This should make it easier to keep track of.