### PR TITLE
Add `nocontent` class to sidebar, article-bottom, and footer widget zones.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -25,7 +25,7 @@
 	do_action( 'largo_before_footer' );
 ?>
 
-<div class="footer-bg clearfix">
+<div class="footer-bg clearfix nocontent">
 	<footer id="site-footer">
 
 		<?php

--- a/partials/footer-before-footer-widget-area.php
+++ b/partials/footer-before-footer-widget-area.php
@@ -1,4 +1,4 @@
-<div class="before-footer-wrapper">
+<div class="before-footer-wrapper nocontent">
 	<div id="before-footer">
 		<?php dynamic_sidebar( 'before-footer' ); ?>
 	</div>

--- a/sidebar.php
+++ b/sidebar.php
@@ -7,7 +7,7 @@ $showey_hidey_class = (of_get_option('showey-hidey'))? 'showey-hidey':'';
 $span_class = largo_sidebar_span_class();
 
 do_action('largo_before_sidebar'); ?>
-<aside id="sidebar" class="<?php echo $span_class; ?>">
+<aside id="sidebar" class="<?php echo $span_class; ?> nocontent">
 	<?php do_action('largo_before_sidebar_content'); ?>
 	<div class="widget-area <?php echo $showey_hidey_class ?>" role="complementary">
 		<?php

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -24,7 +24,7 @@ get_header();
 
 					do_action( 'largo_before_post_bottom_widget_area' );
 
-					echo '<div class="article-bottom">';
+					echo '<div class="article-bottom nocontent">';
 					dynamic_sidebar( 'article-bottom' );
 					echo '</div>';
 

--- a/single-two-column.php
+++ b/single-two-column.php
@@ -27,7 +27,7 @@ get_header();
 
 					do_action( 'largo_before_post_bottom_widget_area' );
 
-					echo '<div class="article-bottom">';
+					echo '<div class="article-bottom nocontent">';
 					dynamic_sidebar( 'article-bottom' );
 					echo '</div>';
 


### PR DESCRIPTION
### Changes

Adds `nocontent` class to the following areas:

- The footer
- The before-footer widget area
- The sidebar on article pages
- The article-bottom widget area (used for next/previous story buttons and similar)

The `nocontent` class does not have any styles. [Here's how Google interprets it.](https://support.google.com/customsearch/answer/2364585?hl=en)

### Why

Google Custom Search Engine results were showing results from pages where the only relevant content was a blurb in the sidebar or the footer.

Reported in YT-24, Largo issue #664