### PR TITLE
Bugfix for IW-32, staff roster avatars master

### DIFF
--- a/inc/users.php
+++ b/inc/users.php
@@ -300,10 +300,11 @@ function largo_render_user_list($users, $show_users_with_empty_desc=false) {
 	echo '<div class="user-list">';
 	foreach ($users as $user) {
 		$desc = trim($user->description);
-		if (empty($desc) && empty($show_users_with_empty_desc))
+		if (empty($desc) && ($show_users_with_empty_desc == false))
 			continue;
 
-		if (get_user_meta($user->ID, 'hide', true))
+		$hide = get_user_meta($user->ID, 'hide', true);
+		if ($hide == 'on')
 			continue;
 
 		$ctx = array('author_obj' => $user);

--- a/tests/inc/test-users.php
+++ b/tests/inc/test-users.php
@@ -106,7 +106,56 @@ class UsersTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_render_user_list() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		// Test that a user without a description gets no output
+		$user1 = $this->factory->user->create();
+		$arg1[] = get_user_by('id', $user1);
+
+		ob_start();
+		largo_render_user_list($arg1);
+		$out1 = ob_get_clean();
+		$this->assertEquals('<div class="user-list"></div>', $out1);
+
+		// Test that a user with a description get output
+		$user2 = $this->factory->user->create();
+		update_user_meta($user2, 'description', 'foobar');
+		$arg2[] = get_user_by('id', $user2);
+
+		ob_start();
+		largo_render_user_list($arg2);
+		$out2 = ob_get_clean();
+		$this->assertRegExp('/author-box/', $out2);
+		$this->assertRegExp('/foobar/', $out2);
+
+		// Test it with a user with an avatar
+		$user3 = $this->factory->user->create();
+		$attachment = $this->factory->post->create(array('post_type' => 'attachment'));
+		update_user_meta($user3, 'description', 'foobar');
+		update_user_meta($user3, 'largo_avatar', $attachment);
+		$arg3[] = get_user_by('id', $user3);
+
+		ob_start();
+		largo_render_user_list($arg3);
+		$out3 = ob_get_clean();
+		$this->assertRegExp('/author-box/', $out3);
+		$this->assertRegExp('/foobar/', $out3);
+		$this->assertRegExp('/src/', $out3);
+
+		// Test it with all the users
+		$arg4[] = get_user_by('id', $user1);
+		$arg4[] = get_user_by('id', $user2);
+		$arg4[] = get_user_by('id', $user3);
+
+		ob_start();
+		largo_render_user_list($arg4);
+		$out4 = ob_get_clean();
+		var_log($out4);
+
+		$this->assertEquals( 2, preg_match_all('/author-box/', $out4, $matches), "There were not 2 authors with descriptions rendered.");
+		$this->assertEquals( 1, preg_match_all('/src=/', $out4, $matches), "There was not 1 author with an avatar image rendered.");
+
+
+
+
 	}
 
 	function test_largo_render_staff_list_shortcode() {

--- a/tests/inc/test-users.php
+++ b/tests/inc/test-users.php
@@ -105,6 +105,11 @@ class UsersTestFunctions extends WP_UnitTestCase {
 		unset($ids);
 	}
 
+	/**
+	 * Test the function largo_render_user_list
+	 *
+	 * Be aware: This may fail if partials/author-bio-description.php changes.
+	 */
 	function test_largo_render_user_list() {
 		/*
 		 * Test that a user without a description gets no output

--- a/tests/inc/test-users.php
+++ b/tests/inc/test-users.php
@@ -106,7 +106,9 @@ class UsersTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_render_user_list() {
-		// Test that a user without a description gets no output
+		/*
+		 * Test that a user without a description gets no output
+		 */
 		$user1 = $this->factory->user->create();
 		$arg1[] = get_user_by('id', $user1);
 
@@ -115,7 +117,9 @@ class UsersTestFunctions extends WP_UnitTestCase {
 		$out1 = ob_get_clean();
 		$this->assertEquals('<div class="user-list"></div>', $out1);
 
-		// Test that a user with a description get output
+		/*
+		 * Test that a user with a description gets output
+		 */
 		$user2 = $this->factory->user->create();
 		update_user_meta($user2, 'description', 'foobar');
 		$arg2[] = get_user_by('id', $user2);
@@ -126,7 +130,9 @@ class UsersTestFunctions extends WP_UnitTestCase {
 		$this->assertRegExp('/author-box/', $out2);
 		$this->assertRegExp('/foobar/', $out2);
 
-		// Test it with a user with an avatar
+		/*
+		 * Test that a user with an avatar has output including the avatar
+		 */
 		$user3 = $this->factory->user->create();
 		$attachment = $this->factory->post->create(array('post_type' => 'attachment'));
 		update_user_meta($user3, 'description', 'foobar');
@@ -140,7 +146,9 @@ class UsersTestFunctions extends WP_UnitTestCase {
 		$this->assertRegExp('/foobar/', $out3);
 		$this->assertRegExp('/src/', $out3);
 
-		// Test it with all the users
+		/*
+		 * Test it with all the users
+		 */
 		$arg4[] = get_user_by('id', $user1);
 		$arg4[] = get_user_by('id', $user2);
 		$arg4[] = get_user_by('id', $user3);
@@ -148,13 +156,27 @@ class UsersTestFunctions extends WP_UnitTestCase {
 		ob_start();
 		largo_render_user_list($arg4);
 		$out4 = ob_get_clean();
-		var_log($out4);
 
 		$this->assertEquals( 2, preg_match_all('/author-box/', $out4, $matches), "There were not 2 authors with descriptions rendered.");
 		$this->assertEquals( 1, preg_match_all('/src=/', $out4, $matches), "There was not 1 author with an avatar image rendered.");
 
+		/*
+		 * Test it with a user that is set to hide.
+		 */
+		$user4 = $this->factory->user->create();
+		$att4 = $this->factory->post->create(array('post_type' => 'attachment'));
+		update_user_meta($user4, 'description', 'foobar');
+		update_user_meta($user4, 'hide', 'on');
+		update_user_meta($user4, 'largo_avatar', $att4);
+		$arg4[] = get_user_by('id', $user4);
 
+		ob_start();
+		largo_render_user_list($arg4);
+		$out5 = ob_get_clean();
 
+		// Using same numbers here because the hidden user should not change these numbers.
+		$this->assertEquals( 2, preg_match_all('/author-box/', $out5, $matches), "There were not 2 authors with descriptions rendered.");
+		$this->assertEquals( 1, preg_match_all('/src=/', $out5, $matches), "There was not 1 author with an avatar image rendered.");
 
 	}
 


### PR DESCRIPTION
This PR includes tests!

### Why

Updating user metadata prevented the user from displaying in the `[roster]` shortcode.

Previously, updating a user's metadata by saving their profile changed some fields from "" to "off". The roster shortcode checked that those fields were not-empty instead of checking for their false value.

This change was [previously applied in the staff roster widget](https://github.com/INN/Largo/commit/5f77ea918da61e578bdddc0b013738c28c6ad013#diff-42dea38310facb1e34959f63770d8bb7R39), but the widget does not use `largo_render_user_list`.

