### PR TITLE
Deprecate $use_more and $more_link args for largo_excerpt

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -403,7 +403,6 @@ if ( ! function_exists( 'largo_excerpt' ) ) {
 		if ( $strip_tags && $strip_shortcodes ) {
 			$output .= strip_tags( strip_shortcodes ( $content ) );
 		} else if ( $strip_tags ) {
-			echo 'foo';
 			$output .= strip_tags( $content );
 		} else if ( $strip_shortcodes ) {
 			$output .= strip_shortcodes( $content );

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -370,7 +370,12 @@ if ( ! function_exists( 'largo_custom_wp_link_pages' ) ) {
  * @since 0.3
  */
 if ( ! function_exists( 'largo_excerpt' ) ) {
-	function largo_excerpt( $the_post=null, $sentence_count = 5, $use_more = true, $more_link = '', $echo = true, $strip_tags = true, $strip_shortcodes = true ) {
+	function largo_excerpt( $the_post=null, $sentence_count = 5, $use_more, $more_link, $echo = true, $strip_tags = true, $strip_shortcodes = true ) {
+		if (!empty($use_more))
+			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $use_more is deprecated.');
+		if (!empty($more_link))
+			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $more_link is deprecated.');
+
 		$the_post = get_post($the_post); // Normalize it into a post object
 
 		// Save the global $post object and then push our current post object so that certain functions (get_the_content) will work
@@ -378,27 +383,17 @@ if ( ! function_exists( 'largo_excerpt' ) ) {
 		$_post = $post;
 		$post = $the_post;
 
-		// handle annoying WP default '(more...' added to the end of excerpts
-		if ( !$use_more || !$more_link )
-			$more_link = '';
-
 		// if a post has a custom excerpt set, we'll use that
 		if ( $the_post->post_excerpt ) {
-			if ( !$use_more ) {
 				$content = apply_filters( 'get_the_excerpt', $the_post->post_excerpt );
-			} else {
-				$content = apply_filters( 'get_the_excerpt', $the_post->post_excerpt ) . ' <a href="' . get_permalink( $the_post->ID ) . '">' . $more_link . '</a>';
-			}
 
 		// if we're on the homepage and the post has a more tag, use that
 		} else if ( is_home() && strpos( $the_post->post_content, '<!--more-->' ) ) {
-			$content = get_the_content( $more_link );
+			$content = get_the_content( '' );
 
 		// otherwise we'll just do our best and make the prettiest excerpt we can muster
 		} else {
 			$content = largo_trim_sentences( $the_post->post_content, $sentence_count );
-			if ( $use_more )
-				$content .= '<a href="' . get_permalink( $the_post->ID ) . '">' . $more_link . '</a>';
 		}
 
 		$post = $_post; // Set it back

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -378,40 +378,30 @@ if ( ! function_exists( 'largo_excerpt' ) ) {
 
 		$the_post = get_post($the_post); // Normalize it into a post object
 
-		// Save the global $post object and then push our current post object so that certain functions (get_the_content) will work
-		global $post;
-		$_post = $post;
-		$post = $the_post;
-
-		// if a post has a custom excerpt set, we'll use that
-		if ( $the_post->post_excerpt ) {
-				$content = apply_filters( 'get_the_excerpt', $the_post->post_excerpt );
-
-		// if we're on the homepage and the post has a more tag, use that
-		} else if ( is_home() && strpos( $the_post->post_content, '<!--more-->' ) ) {
-			$content = get_the_content( '' );
-
-		// otherwise we'll just do our best and make the prettiest excerpt we can muster
+		if (!empty($the_post->post_excerpt)) {
+			// if a post has a custom excerpt set, we'll use that
+			$content = apply_filters('get_the_excerpt', $the_post->post_excerpt);
+		} else if (is_home() && preg_match('/<!--more(.*?)?-->/', $the_post->post_content, $matches) > 0) {
+			// if we're on the homepage and the post has a more tag, use that
+			$parts = explode($matches[0], $the_post->post_content, 2);
+			$content = $parts[0];
 		} else {
-			$content = largo_trim_sentences( $the_post->post_content, $sentence_count );
+			// otherwise we'll just do our best and make the prettiest excerpt we can muster
+			$content = largo_trim_sentences($the_post->post_content, $sentence_count);
 		}
 
-		$post = $_post; // Set it back
-
-		// optionally strip shortcodes and html, wrap everything in <p> tags
-		$output = '<p>';
-		if ( $strip_tags && $strip_shortcodes ) {
+		// optionally strip shortcodes and html
+		$output = '';
+		if ( $strip_tags && $strip_shortcodes )
 			$output .= strip_tags( strip_shortcodes ( $content ) );
-		} else if ( $strip_tags ) {
+		else if ( $strip_tags )
 			$output .= strip_tags( $content );
-		} else if ( $strip_shortcodes ) {
+		else if ( $strip_shortcodes )
 			$output .= strip_shortcodes( $content );
-		} else {
+		else
 			$output .= $content;
-		}
-		$output .= '</p>';
 
-		$output = apply_filters( 'the_content', $output );
+		$output = apply_filters('the_content', $output);
 
 		if ( $echo )
 			echo $output;

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -4,6 +4,14 @@ class PostTagsTestFunctions extends WP_UnitTestCase {
 
 	function setUp() {
 		parent::setUp();
+
+		$this->post_excerpt = <<<EOT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque cursus purus id pharetra dapibus.
+EOT;
+
+		$this->post_id = $this->factory->post->create(array(
+			'post_excerpt' => $this->post_excerpt,
+		));
 	}
 
 	function test_largo_time() {
@@ -122,7 +130,8 @@ class PostTagsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_excerpt() {
-		$this->markTestIncomplete("This test has not yet been implemented.");
+		$result = largo_excerpt($this->post_id, 5, false, false, false);
+		$this->assertTrue(strpos($result, $this->post_excerpt) >= 0);
 	}
 
 	function test_largo_trim_sentences() {

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -129,9 +129,75 @@ EOT;
 		$this->markTestIncomplete("This test has not yet been implemented.");
 	}
 
+	/**
+	 * @expectedDeprecated largo_excerpt
+	 */
 	function test_largo_excerpt() {
-		$result = largo_excerpt($this->post_id, 5, false, false, false);
-		$this->assertTrue(strpos($result, $this->post_excerpt) >= 0);
+		$this->expectDeprecated();
+
+		$id = $this->factory->post->create(array(
+			'post_content' => '<span class="first-letter"><b>S</span>entence</b> <i>one<i>. Sentence two. Sentence three. Sentence four. Sentence five. Sentence six. Sentence seven. Sentence eight. Sentence nine. Sentence ten. <!--more--> This should never display.',
+			// Start with nothing because we want to make sure
+			// largo_excerpt generates something acceptable
+			'post_excerpt' => false
+		));
+
+		/**
+		 * Test that the echo variable is respected
+		 */
+		ob_start();
+		$ret = largo_excerpt($id, 5,true, '', true);
+		$echo = ob_get_clean();
+		$this->assertTrue(!empty($ret)); // The $output is always returned
+		$this->assertTrue(!empty($echo)); // We want to make sure that it all works
+
+		ob_start();
+		$ret = largo_excerpt($id, 5, true, '', false);
+		$echo = ob_get_clean();
+		$this->assertTrue(!empty($ret));
+		$this->assertTrue(empty($echo)); // With echo to false, this should not have anything in it
+
+		/**
+		 *  Test the sentence count output.
+		 */
+		$ret = largo_excerpt($id, 1, null, null, false);
+		$this->assertEquals(
+			"<p>Sentence one. </p>\n", $ret,
+			"Only one sentence should be output when the count of sentences is 1.");
+
+		$ret = largo_excerpt($id, 5, null, null, false);
+		$this->assertEquals(
+			"<p>Sentence one. Sentence two. Sentence three. Sentence four. Sentence five. </p>\n", $ret,
+			"Only five sentences should be output when the count of sentences is 5.");
+
+		$ret = largo_excerpt($id, 11, null, null, false);
+		$this->assertEquals(
+			"<p>Sentence one. Sentence two. Sentence three. Sentence four. Sentence five. Sentence six. Sentence seven. Sentence eight. Sentence nine. Sentence ten. This should never display. </p>\n", $ret,
+			"11 sentences should be output when the count of sentences is 11.");
+
+		/**
+		 * Test that if we're on the homepage and the post has a more tag, that gets used if there is no post excerpt
+		 */
+		$this->go_to('/'); // Go home
+		$ret = largo_excerpt($id, 1, null, null, false);
+		$this->assertEquals(
+			"<p>Sentence one. Sentence two. Sentence three. Sentence four. Sentence five. Sentence six. Sentence seven. Sentence eight. Sentence nine. Sentence ten. </p>\n", $ret,
+			"Always obey the <!-- more --> tag for excerpts on the home page.");
+
+		// And now with an excerpt
+		wp_update_post(
+			array(
+				'ID' => $id,
+				'post_content' => '<span class="first-letter"><b>S</span>entence</b> <i>one<i>. Sentence two. Sentence three. Sentence four. Sentence five. Sentence six. Sentence seven. Sentence eight. Sentence nine. Sentence ten. <!--more--> This should never display.',
+				'post_excerpt' => 'Custom post excerpt!'
+			)
+		);
+
+		$this->go_to('/'); // Go home
+		$ret = largo_excerpt($id, 1, null, null, false);
+		$this->assertEquals(
+			"<p>Custom post excerpt!</p>\n", $ret,
+			"Custom post excerpt did not output.");
 	}
 
 	function test_largo_trim_sentences() {


### PR DESCRIPTION
This effectively removes the "more..." or "continue reading" links from the ends of excerpts. Fixes #52.