### PR TITLE
Adding nocontent class to sticky nav wrapper and Largo <header> elements

### DIFF
--- a/partials/largo-header.php
+++ b/partials/largo-header.php
@@ -1,6 +1,6 @@
-<header id="site-header" class="clearfix" itemscope itemtype="http://schema.org/Organization">
+<header id="site-header" class="clearfix nocontent" itemscope itemtype="http://schema.org/Organization">
 	<?php largo_header(); ?>
 </header>
-<header class="print-header">
+<header class="print-header nocontent">
 	<p><strong><?php echo esc_html( get_bloginfo( 'name' ) ); ?></strong> (<?php echo esc_url( largo_get_current_url() ); ?>)</p>
 </header>

--- a/partials/nav-sticky.php
+++ b/partials/nav-sticky.php
@@ -1,4 +1,4 @@
-<div class="sticky-nav-wrapper">
+<div class="sticky-nav-wrapper nocontent">
 	<div class="sticky-nav-holder <?php echo (is_front_page() || is_home()) ? '' : 'show'; ?>"
 		data-hide-at-top="<?php echo (is_front_page() || is_home()) ? 'true' : 'false'; ?>">
 


### PR DESCRIPTION
For #664 and YT-24, because GCSE was indexing and delivering search results based on words in the navigation.

### Changes

Adds the `nocontent` class to:

-  `<div class="sticky-nav-wrapper"`
- `<header id="site-header"`
- `<header class="print-header"`
