### PR TITLE
Add filter for top stories homepage template featured posts count

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -36,6 +36,19 @@ This is used in the query for the series list of posts in the same series
 as the main feature. This is the maximum number of posts that will display
 in the list.
 
+------------
+
+filter: **largo_homepage_topstories_post_count**
+
+*args: $showposts*
+
+Filter the number of posts that are displayed in the right-hand side of the
+Top Stories homepage template.
+
+This is used in the query for the list of posts in the "Homepage Featured"
+taxonomy. If more than 3 posts are found, they will display under a
+"More Headlines" heading, just as headline links.
+
 Other filters and actions
 -------------------------
 

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -53,7 +53,10 @@ global $largo, $shown_ids, $tags;
 
 	<?php if ( !is_active_sidebar('homepage-left-rail') ) { ?>
 	<div class="sub-stories span4">
-		<?php $substories = largo_get_featured_posts( array(
+		<?php
+		$showposts = 6;
+		$showposts = apply_filters('largo_homepage_topstories_post_count', $showposts);
+		$substories = largo_get_featured_posts( array(
 			'tax_query' => array(
 				array(
 					'taxonomy' 	=> 'prominence',
@@ -61,7 +64,7 @@ global $largo, $shown_ids, $tags;
 					'terms' 	=> 'homepage-featured'
 				)
 			),
-			'showposts'		=> 6,
+			'showposts'		=> $showposts,
 			'post__not_in' 	=> $shown_ids
 		) );
 		if ( $substories->have_posts() ) :


### PR DESCRIPTION
## Changes:

- Adds a filter to the Top Stories homepage template, so that the number of posts on the right-hand column can be modified without duplicating the partial.
- Docs

## Why

To prevent the need to duplicate `homepages/templates/top-stories.php` in child themes to change the display of this template. See also #775 and YT-28.