### PR TITLE
Use before-queries in addition to after-queries to find related posts in series and terms

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -481,7 +481,7 @@ class Largo_Related {
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
-						'before' => $this->post->post_date,
+						'after' => $this->post->post_date,
 					),
 				);
 
@@ -514,6 +514,22 @@ class Largo_Related {
 				// build the query with the sort defined
 				$series_query = new WP_Query( $args );
 
+				// If not enough posts were added from after this post, look before this post
+				if ( count($series_query->posts) < $this->number ) {
+
+					// Store the returned posts from the after query
+					$this->add_from_query( $series_query );
+
+					// Change it to look backwards
+					$args['date_query'] = array(
+						'before' => $this->post->post_date,
+					);
+
+					// rerun the query
+					$series_query = new WP_Query( $args );
+				}
+
+				// Store the posts
 				if ( $series_query->have_posts() ) {
 					$this->add_from_query( $series_query );
 					if ( $this->have_enough_posts() ) {
@@ -549,13 +565,29 @@ class Largo_Related {
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
-						'before' => $this->post->post_date,
+						'after' => $this->post->post_date,
 					),
 				);
 
 				// run the query
 				$term_query = new WP_Query( $args );
 
+				// If not enough posts were added from after this post, look before this post
+				if ( count($term_query->posts) < $this->number ) {
+
+					// Store the returned posts from the after query
+					$this->add_from_query( $term_query );
+
+					// Change it to look backwards
+					$args['date_query'] = array(
+						'before' => $this->post->post_date,
+					);
+
+					// rerun the query
+					$term_query = new WP_Query( $args );
+				}
+
+				// Store the returned posts
 				if ( $term_query->have_posts() ) {
 					$this->add_from_query( $term_query );
 					if ( $this->have_enough_posts() ) {

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -481,7 +481,7 @@ class Largo_Related {
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
-						'after' => $this->post->post_date,
+						'before' => $this->post->post_date,
 					),
 				);
 
@@ -549,7 +549,7 @@ class Largo_Related {
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
-						'after' => $this->post->post_date,
+						'before' => $this->post->post_date,
 					),
 				);
 


### PR DESCRIPTION
## Changes

This brings back some of the pre #676 functionality of Largo_Related.

The current behavior of Largo_Related's `get_series_posts()` and `get_term_posts()` methods is to look for posts published after the current post, using a `date_query` argument. This doesn't work if the current post is the most-recently-published post in the post's taxonomies.

Under this PR, those two methods will first run with the `after` argument in `date_query`. Then, if not enough posts are returned, they will rerun the query with `before`, before progressing to the next method in the Largo_Related query stack.

This is a slight performance hit, in that the number of queries can increase, but it brings back the before-and-after functionality without loading the entire taxonomy term's worth of posts into memory. (See #680.)

## Why

For #782:

> We should definitely not make the assumption that only a newer post in the category/tag/term would be a valid match before it falls through to just most recent. I'd say at least looking for one previous post in the category/tag/term would be the desired behavior.