### PR TITLE
Remove an unnecessary sidebar declaration from inc/sidebars.php

### DIFF
--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -69,13 +69,6 @@ function largo_register_sidebars() {
 		);
 	}
 
-	if ( of_get_option('homepage_layout') == '3col' ) {
-		$sidebars[] = array(
-			'name' 	=> __( 'Homepage Left Rail', 'largo' ),
-			'desc' 	=> __( 'An optional widget area that, when enabled, appears to the left of the main content area on the homepage.', 'largo' ),
-			'id' 	=> 'homepage-left-rail'
-		);
-	}
 	if ( of_get_option('homepage_bottom') == 'widgets' ) {
 		$sidebars[] = array(
 			'name' 	=> __( 'Homepage Bottom', 'largo' ),


### PR DESCRIPTION
We no longer need to define the "Homepage Left Rail" sidebar in `inc/sidebars.php` for a few reasons:

- The new name for the '3col' homepage layout is 'LegacyThreeColumn` and the code removed in this patch would never actually run.
- The "Homepage Left Rail" sidebar is defined in the legacy three column homepage layout.