### PR TITLE
Filter the LMP query args

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -79,7 +79,12 @@ Also passed in is an array that contains only the extra fields that were present
 ``function filter_function_name($result,$extras) {``
 ``# ... }``
 ``add_action('largo_validate_user_signup_extra_fields'``, ``'filter_function_name');``
- 
+
+**filter: largo_lmp_args**
+
+Passed in this are the arguments for the Load More Posts WP_Query. An example usage would be to check if ``is_home()`` and then restrict the posts returned by the query to those in the homepage featured prominence term.
+
+
 Template Hooks
 --------------
 

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -92,6 +92,8 @@ if (!function_exists('largo_load_more_posts')) {
 			'ignore_sticky_posts' => true,
 		), $context);
 
+		$args = apply_filters('largo_lmp_args', $args);
+
 		// num_posts_home is only relevant on the homepage
 		if ( of_get_option('num_posts_home') && $is_home )
 			$args['posts_per_page'] = of_get_option('num_posts_home');

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -92,8 +92,6 @@ if (!function_exists('largo_load_more_posts')) {
 			'ignore_sticky_posts' => true,
 		), $context);
 
-		$args = apply_filters('largo_lmp_args', $args);
-
 		// num_posts_home is only relevant on the homepage
 		if ( of_get_option('num_posts_home') && $is_home )
 			$args['posts_per_page'] = of_get_option('num_posts_home');
@@ -103,6 +101,9 @@ if (!function_exists('largo_load_more_posts')) {
 			if ( of_get_option('cats_home') )
 				$args['cat'] = of_get_option('cats_home');
 		}
+
+		$args = apply_filters('largo_lmp_args', $args);
+
 		$query = new WP_Query($args);
 
 		if ( $query->have_posts() ) {


### PR DESCRIPTION
For #802, creates a new filter `largo_lmp_args` that can be used to manipulate the arguments of the `load_more_posts` ajax call's WP_Query.