### PR TITLE
Do nothing in sticky footer when custom byline is set without link

### DIFF
--- a/partials/footer-sticky.php
+++ b/partials/footer-sticky.php
@@ -64,9 +64,11 @@
 					echo $cat_feed_link;
 			} ?>
 
-			<?php if ( !empty( $byline_text ) && !empty( $byline_link ) ): ?>
+			<?php if ( !empty( $byline_text ) && !empty( $byline_link ) ) { ?>
 				<a href="<?php echo $byline_link; ?>" class="icon-link"><?php echo esc_html( $byline_text ); ?></a>
-			<?php else : ?>
+			<?php } else if ( !empty( $byline_text )) { ?>
+				<?php // do nothing - the $coauthors array is unfilled and meaningless, and there's nothing to link to ?>
+			<?php } else { ?>
 				<?php // $coauthor covers base case (1 dimensional) or where coauthors were defined. ?>
 				<?php foreach( $coauthors as $author ) : ?>
 					<div class="follow-author">
@@ -77,7 +79,7 @@
 					<a href="<?php echo get_author_posts_url( $author->ID, $author->user_nicename ); ?>"><?php echo esc_html( $author->display_name ); ?></a>
 					</div>
 				<?php endforeach; ?>
-			<?php endif; ?>
+			<?php } ?>
 
 		</div>
 

--- a/partials/footer-sticky.php
+++ b/partials/footer-sticky.php
@@ -66,9 +66,7 @@
 
 			<?php if ( !empty( $byline_text ) && !empty( $byline_link ) ) { ?>
 				<a href="<?php echo $byline_link; ?>" class="icon-link"><?php echo esc_html( $byline_text ); ?></a>
-			<?php } else if ( !empty( $byline_text )) { ?>
-				<?php // do nothing - the $coauthors array is unfilled and meaningless, and there's nothing to link to ?>
-			<?php } else { ?>
+			<?php } else if ( !empty( $coauthors )) { ?>
 				<?php // $coauthor covers base case (1 dimensional) or where coauthors were defined. ?>
 				<?php foreach( $coauthors as $author ) : ?>
 					<div class="follow-author">


### PR DESCRIPTION
For #825.

If the custom byline is set without a link, then there is nothing to link to in the footer. It is assumed that any coauthor or actual author is meant to be hidden by the use of the custom byline, so the sticky footer does not fill the array of coauthors with coauthors or authors:

	if( get_post_meta( $post->ID, 'largo_byline_text' ) ) {
		$byline_text = esc_attr( get_post_meta( $post->ID, 'largo_byline_text', true ) );
		$byline_link = esc_attr( get_post_meta( $wp_query->post->ID, 'largo_byline_link', true ) );
	} else if ( function_exists('get_coauthors') ) {
		$coauthors =  get_coauthors( $post->ID );
	} else {
		$coauthors = array( get_userdata( $post->post_author ));
	}

But because the byline link was not set, the partial attempted to render a portion of the partial that depends on `$coauthors` being filled with authors:

	<?php if ( !empty( $byline_text ) && !empty( $byline_link ) ): ?>
		<a href="<?php echo $byline_link; ?>" class="icon-link"><?php echo esc_html( $byline_text ); ?></a>
	<?php else : ?>
		<?php // $coauthor covers base case (1 dimensional) or where coauthors were defined. ?>
		<?php foreach( $coauthors as $author ) : ?>
			<div class="follow-author">
			<a href="<?php echo get_author_feed_link( $author->ID, '' ); ?>" class="icon-rss"></a>
			<?php if ( $twitter = get_the_author_meta( 'twitter', $author->ID ) ) : ?>
				<a href="https://twitter.com/<?php echo largo_twitter_url_to_username( esc_url( $twitter ) ); ?>" class="icon-twitter"></a>
			<?php endif; ?>
			<a href="<?php echo get_author_posts_url( $author->ID, $author->user_nicename ); ?>"><?php echo esc_html( $author->display_name ); ?></a>
			</div>
		<?php endforeach; ?>
	<?php endif; ?>

This PR has the sticky footer output nothing for the author if the custom byline is set and not the custom byline link.