### PR TITLE
Stop enqueueing homepage assets in places that aren't the homepage

### DIFF
--- a/homepages/homepage-class.php
+++ b/homepages/homepage-class.php
@@ -83,11 +83,13 @@ class Homepage {
 	}
 
 	public function enqueueAssets() {
-		foreach ($this->assets as $asset) {
-			if (preg_match('/\.js$/', $asset[1]))
-				call_user_func_array('wp_enqueue_script', $asset);
-			if (preg_match('/\.css$/', $asset[1]))
-				call_user_func_array('wp_enqueue_style', $asset);
+		if ( is_home() ) {
+			foreach ($this->assets as $asset) {
+				if (preg_match('/\.js$/', $asset[1]))
+					call_user_func_array('wp_enqueue_script', $asset);
+				if (preg_match('/\.css$/', $asset[1]))
+					call_user_func_array('wp_enqueue_style', $asset);
+			}
 		}
 	}
 

--- a/tests/homepages/test-homepage-class.php
+++ b/tests/homepages/test-homepage-class.php
@@ -85,13 +85,31 @@ class HomepageClassTest extends WP_UnitTestCase {
 		// appropriate global -- $wp_styles or $wp_scripts.
 		global $wp_styles, $wp_scripts;
 
+		$this->go_to('/'); // Run this on the homepage
 		$this->layout->enqueueAssets();
 
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
-		$this->assertTrue(!empty($wp_styles->registered[$expected_css_handle]));
+		$this->assertTrue(!empty($wp_styles->registered[$expected_css_handle]), "Homepage styles were not enqueued on the homepage");
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
-		$this->assertTrue(!empty($wp_scripts->registered[$expected_js_handle]));
+		$this->assertTrue(!empty($wp_scripts->registered[$expected_js_handle]), "Homepage scripts were not enqueued on the homepage");
+
+		/*
+		 * Regression test for #791
+		 *
+		 * @since 0.5.2
+		 */
+		$wp_styles->reset();
+		$wp_scripts->reset();
+		$this->go_to('/?p=1'); // a page that is not the homepage
+
+		$this->layout->enqueueAssets();
+		$expected_css_handle = $this->layoutOptions['assets'][0][0];
+		$this->assertTrue(!empty($wp_styles->registered[$expected_css_handle]), "Homepage styles were not enqueued on the homepage");
+
+		$expected_js_handle = $this->layoutOptions['assets'][1][0];
+		$this->assertTrue(!empty($wp_scripts->registered[$expected_js_handle]), "Homepage scripts were not enqueued on the homepage");
+		var_log($wp_styles);
 	}
 
 	function testRegisterSidebars() {

--- a/tests/homepages/test-homepage-class.php
+++ b/tests/homepages/test-homepage-class.php
@@ -93,14 +93,19 @@ class HomepageClassTest extends WP_UnitTestCase {
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
 		$this->assertNotEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were not enqueued on the homepage");
+	}
 
+	function testEnqueueAssets_791() {
 		/*
-		 * Regression test for #791
+		 * Regression test for #791, where homepage assets were being enqueued on pages not the homepage.
 		 *
 		 * @since 0.5.2
 		 */
-		$wp_styles->reset();
-		$wp_scripts->reset();
+
+		// Homepage::enqueueAssets should add js and css asset definitions to the
+		// appropriate global -- $wp_styles or $wp_scripts.
+		global $wp_styles, $wp_scripts;
+
 		// create a post
 		$post_id = $this->factory->post->create();
 		$this->go_to("/?p=$post_id"); // a page that is not the homepage
@@ -108,7 +113,6 @@ class HomepageClassTest extends WP_UnitTestCase {
 		$this->layout->enqueueAssets();
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
 		$this->assertEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were enqueued on not the homepage");
-		var_log($wp_styles);
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
 		$this->assertEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were enqueued on not the homepage");

--- a/tests/homepages/test-homepage-class.php
+++ b/tests/homepages/test-homepage-class.php
@@ -89,10 +89,10 @@ class HomepageClassTest extends WP_UnitTestCase {
 		$this->layout->enqueueAssets();
 
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
-		$this->assertTrue(!empty($wp_styles->registered[$expected_css_handle]), "Homepage styles were not enqueued on the homepage");
+		$this->assertNotEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were not enqueued on the homepage");
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
-		$this->assertTrue(!empty($wp_scripts->registered[$expected_js_handle]), "Homepage scripts were not enqueued on the homepage");
+		$this->assertNotEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were not enqueued on the homepage");
 
 		/*
 		 * Regression test for #791
@@ -101,15 +101,17 @@ class HomepageClassTest extends WP_UnitTestCase {
 		 */
 		$wp_styles->reset();
 		$wp_scripts->reset();
-		$this->go_to('/?p=1'); // a page that is not the homepage
+		// create a post
+		$post_id = $this->factory->post->create();
+		$this->go_to("/?p=$post_id"); // a page that is not the homepage
 
 		$this->layout->enqueueAssets();
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
-		$this->assertTrue(!empty($wp_styles->registered[$expected_css_handle]), "Homepage styles were not enqueued on the homepage");
+		$this->assertEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were enqueued on not the homepage");
+		var_log($wp_styles);
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
-		$this->assertTrue(!empty($wp_scripts->registered[$expected_js_handle]), "Homepage scripts were not enqueued on the homepage");
-		var_log($wp_styles);
+		$this->assertEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were enqueued on not the homepage");
 	}
 
 	function testRegisterSidebars() {

--- a/tests/homepages/test-homepage-class.php
+++ b/tests/homepages/test-homepage-class.php
@@ -29,6 +29,19 @@ class HomepageClassTest extends WP_UnitTestCase {
 			'zoneMarker' => 'Hello World!'
 		);
 		$this->layout = new TestHomepageLayout($this->layoutOptions);
+
+		global $wp_styles, $wp_scripts;
+		$this->wp_styles_backup = $wp_styles;
+		$this->wp_scripts_backup = $wp_scripts;
+		$wp_styles = new WP_Styles;
+		$wp_scripts = new WP_Scripts;
+	}
+
+	function tearDown() {
+		global $wp_styles, $wp_scripts;
+		$wp_styles = $this->wp_styles_backup;
+		$wp_scripts = $this->wp_scripts_backup;
+
 	}
 
 	function testLoad() {
@@ -89,10 +102,10 @@ class HomepageClassTest extends WP_UnitTestCase {
 		$this->layout->enqueueAssets();
 
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
-		$this->assertNotEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were not enqueued on the homepage");
+		$this->assertTrue(wp_style_is( $expected_css_handle, 'enqueued'), "Homepage styles were not enqueued on the homepage");
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
-		$this->assertNotEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were not enqueued on the homepage");
+		$this->assertTrue(wp_script_is( $expected_js_handle, 'enqueued'), "Homepage scripts were not enqueued on the homepage");
 	}
 
 	function testEnqueueAssets_791() {
@@ -111,11 +124,14 @@ class HomepageClassTest extends WP_UnitTestCase {
 		$this->go_to("/?p=$post_id"); // a page that is not the homepage
 
 		$this->layout->enqueueAssets();
+		
 		$expected_css_handle = $this->layoutOptions['assets'][0][0];
-		$this->assertEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were enqueued on not the homepage");
+		$this->assertFalse(wp_style_is( $expected_css_handle, 'enqueued'), "Homepage styles were enqueued on not the homepage");
+		//$this->assertEmpty($wp_styles->registered[$expected_css_handle], "Homepage styles were enqueued on not the homepage");
 
 		$expected_js_handle = $this->layoutOptions['assets'][1][0];
-		$this->assertEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were enqueued on not the homepage");
+		$this->assertFalse(wp_script_is( $expected_js_handle, 'enqueued'), "Homepage scripts were enqueued on not the homepage");
+		//$this->assertEmpty($wp_scripts->registered[$expected_js_handle], "Homepage scripts were enqueued on not the homepage");
 	}
 
 	function testRegisterSidebars() {


### PR DESCRIPTION
## Changes:

- the Homepage class checks `is_home()` before enqueueing CSS and Javascripts
- tests

For #791 