### PR TITLE
Largo_Related tests and bugfixes

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -503,7 +503,7 @@ class Largo_Related {
 								$args['order'] = 'ASC';
 								break;
 							case 'custom':
-								$args['orderby'] = 'series_custom';
+								$args['orderby'] = 'series_custom, ASC';
 								break;
 							case 'featured, DESC':
 							case 'featured, ASC':

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -507,12 +507,11 @@ class Largo_Related {
 								break;
 							case 'featured, DESC':
 							case 'featured, ASC':
-								var_log(isset($opt['post_order']));
 								$args['orderby'] = $opt['post_order'];
 								break;
 						}
 					}
-				} else { echo "Nope, no posts" ;}
+				}
 
 				// build the query with the sort defined
 				$series_query = new WP_Query( $args );

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -460,6 +460,7 @@ class Largo_Related {
 	 * Fetches posts contained within the series(es) this post resides in. Feeds them into $this->post_ids array
 	 *
 	 * @access protected
+	 * @see largo_series_custom_order
 	 */
 	protected function get_series_posts() {
 
@@ -502,12 +503,13 @@ class Largo_Related {
 							case 'ASC':
 								$args['order'] = 'ASC';
 								break;
+							// 'series_custom' and 'featured' are custom ones, caught with largo_series_custom_order in inc/wp-taxonomy-landing/functions/cftl-series-order.php
 							case 'custom':
-								$args['orderby'] = 'series_custom, ASC';
+								$args['orderby'] = 'series_custom';
 								break;
 							case 'featured, DESC':
 							case 'featured, ASC':
-								$args['orderby'] = $opt['post_order'];
+								$args['orderby'] = $has_order;
 								break;
 						}
 					}

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -488,7 +488,9 @@ class Largo_Related {
 				// see if there's a post that has the sort order info for this series
 				$cftl_query = new WP_Query( array(
 					'post_type' => 'cftl-tax-landing',
-					'series' => $term->slug,
+					'tax_query' => array (
+						'series' => $term->slug,
+					),
 					'posts_per_page' => 1
 				));
 
@@ -505,11 +507,12 @@ class Largo_Related {
 								break;
 							case 'featured, DESC':
 							case 'featured, ASC':
+								var_log(isset($opt['post_order']));
 								$args['orderby'] = $opt['post_order'];
 								break;
 						}
 					}
-				}
+				} else { echo "Nope, no posts" ;}
 
 				// build the query with the sort defined
 				$series_query = new WP_Query( $args );

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -226,13 +226,13 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 
 		// Create a landing page that sets the order to ASC
-		$this->factory->post->create(array(
+		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
 				'series' => $this->series->slug,
 			),
-			'has_order' => 'ASC'
 		));
+		update_post_meta($landing, 'has_order', 'ASC');
 
 		$lr = new Largo_Related(2, $this->considered);
 		$ids = $lr->ids();
@@ -252,32 +252,33 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 		// Post published before the current post in its series
 		$before_id = $this->factory->post->create(array(
-			'post_date' => '2015-01-01 00:00:00',
+			'post_date' => '2013-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
 		// Post published after the current post in its series
 		$after_id = $this->factory->post->create(array(
-			'post_date' => '2013-01-01 00:00:00',
+			'post_date' => '2015-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
 
 		// Create a landing page that sets the order to DESC
-		$this->factory->post->create(array(
+		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
 				'series' => $this->series->slug,
 			),
-			'has_order' => 'DESC'
 		));
+		update_post_meta($landing, 'has_order', 'DESC');
 
 		$lr = new Largo_Related(2, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(2, count($ids), "Largo_Related returned other than 2 posts");
-		$this->assertGreaterThan($ids[0], $ids[1], "The second post should be lower in post ID than the first");
+		$this->assertEquals($before_id, $ids[1], "The first post should be the younger post");
+		$this->assertEquals($after_id, $ids[0], "The first post should be the older post");
 	}
 
 	function test_series_series_custom() {
@@ -292,14 +293,14 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 		// Post published before the current post in its series
 		$before_id = $this->factory->post->create(array(
-			'post_date' => '2015-01-01 00:00:00',
+			'post_date' => '2013-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
 		// Post published after the current post in its series
 		$after_id = $this->factory->post->create(array(
-			'post_date' => '2013-01-01 00:00:00',
+			'post_date' => '2015-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
@@ -312,14 +313,14 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			)
 		));
 
-		// Create a landing page that sets the order to 'series_custom'
-		$this->factory->post->create(array(
+		// Create a landing page that sets the order to 'custom', setting the sort order to 'series_custom'
+		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
 				'series' => $this->series->slug,
 			),
-			'has_order' => 'custom',
 		));
+		update_post_meta($landing, 'has_order', 'custom');
 
 		/*
 		 * The order of posts within a series, if set customly, is done with each post's series_order post meta.
@@ -336,30 +337,30 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->assertFalse(array($after_id, $before_id, $past_id) == $ids, "The posts were returned in decreasing order of newness");
 		$this->assertFalse(array($before_id, $after_id, $past_id) == $ids, "The posts were returned in increasing order of post ID");
 		$this->assertFalse(array($past_id, $after_id, $before_id) == $ids, "The posts were returned in decreasing order of post ID");
-		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the custom order.");
-		$this->assertTrue(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the opposite of the custom order.");
+		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the opposite of the custom order.");
+		$this->assertTrue(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the custom order.");
 	}
 
 	function test_series_featured_desc() {
 		of_set_option('series_enabled', 1);
-		// Create a landing page that sets the order to 'series_custom'
-		$this->factory->post->create(array(
+		// Create a landing page that sets the order to 'featured, DESC'
+		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
 				'series' => $this->series->slug,
 			),
-			'has_order' => 'featured, DESC'
 		));
+		update_post_meta($landing, 'has_order', 'featured, DESC');
 		// Post published before the current post in its series
 		$before_id = $this->factory->post->create(array(
-			'post_date' => '2015-01-01 00:00:00',
+			'post_date' => '2013-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
 		// Post published after the current post in its series
 		$after_id = $this->factory->post->create(array(
-			'post_date' => '2013-01-01 00:00:00',
+			'post_date' => '2015-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
@@ -374,30 +375,32 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
+		var_log($feat);
+		var_log($ids);
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_asc() {
 		of_set_option('series_enabled', 1);
-		// Create a landing page that sets the order to 'series_custom'
+		// Create a landing page that sets the order to 'featured, ASC'
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
 				'series' => $this->series->slug,
 			),
-			'has_order' => 'featured, ASC'
 		));
+		update_post_meta($landing, 'has_order', 'featured, ASC');
 		// Post published before the current post in its series
 		$before_id = $this->factory->post->create(array(
-			'post_date' => '2015-01-01 00:00:00',
+			'post_date' => '2013-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
 		// Post published after the current post in its series
 		$after_id = $this->factory->post->create(array(
-			'post_date' => '2013-01-01 00:00:00',
+			'post_date' => '2015-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
@@ -411,6 +414,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
+		var_log($feat);
+		var_log($ids);
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
 		$this->markTestIncomplete('This test has not been implemented yet.');

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -72,13 +72,14 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 
 	function test_popularity_sort() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
-
 	}
 
 	/**
 	 * Test the function with a lot of different conditions
 	 *
 	 * - Series without organization
+	 *		- one post published after the current post
+	 *		- one post published before the current post
 	 * - Series with CFTL post with organization information
 	 *		- ASC
 	 *		- series_custom
@@ -86,6 +87,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 	 *		- featured, DESC
 	 *		- featured, ASC
 	 * - No series, but category
+	 *		- one post published after the current post
+	 *		- one post published before the current post
 	 * - No series, but tag
 	 * - Tags and Categories
 	 * - No series or category or tag

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -441,14 +441,12 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			'post_date' => '2015-01-01 00:00:00',
 		));
 		$cp = $this->factory->post->create(array(
-			'post_category' => $this->cat_id,
+			'post_category' => array($this->cat_id),
 		));
-		var_log($this->cat_id);
 		$lr = new Largo_Related(1, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(1, count($ids), "Largo_Related returned other than 1 posts");
 		$this->assertEquals($cp, $ids[0], "Largo_Related did not return the post in the category");
-		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_tags() {

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -319,11 +319,17 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
+		$this->assertFalse(array($past_id, $before_id, $after_id) == $ids, "The posts were returned in increasing order of newness");
+		$this->assertFalse(array($after_id, $before_id, $past_id) == $ids, "The posts were returned in decreasing order of newness");
+		$this->assertFalse(array($before_id, $after_id, $past_id) == $ids, "The posts were returned in increasing order of post ID");
+		$this->assertFalse(array($past_id, $after_id, $before_id) == $ids, "The posts were returned in decreasing order of post ID");
+		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the opposite of the custom order.");
 		$this->assertEquals(array($after_id, $past_id, $before_id), $ids, "The posts were not returned in the custom order");
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_desc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'series_custom'
 		$this->factory->post->create(array(
@@ -354,10 +360,10 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
-		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_asc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'series_custom'
 		$this->factory->post->create(array(
@@ -388,7 +394,6 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
-		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_category() {

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -104,7 +104,16 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_popularity_sort() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		// create some objects that look kinda like term objects if you look at them from the right angle
+		$a_term = (object) array('count' => 4);
+		$b_term = (object) array('count' => 4);
+		$c_term = (object) array('count' => 3);
+
+		$lr = new Largo_Related;
+
+		$this->assertEquals(0, $lr->popularity_sort($a_term, $b_term), 'Comparing two terms with equal numbers of posts did not return 0, which would indicate they were of the same length');
+		$this->assertEquals(-1, $lr->popularity_sort($c_term, $b_term), 'Comparing a term with 3 posts to a term with 4 posts did not return -1, which would indicate that 3 had fewer posts than 4 did. If the difference were greater than 1 post, -1 would still be returned.');
+		$this->assertEquals(1, $lr->popularity_sort($a_term, $c_term), 'Comparing a term with 4 posts to a term with 3 posts did not return 1, which would indicate that 4 had more posts than 3 did. If the difference were greater than 1 post, 1 would still be returned.');
 	}
 
 	/**
@@ -129,7 +138,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 
 	function test_unorganized_series() {
 		of_set_option('series_enabled', 1);
-		$this->factory->posts->create_many(array(
+		$this->factory->post->create_many(10,array(
 			'tax_input' => array(
 				'series' => $this->series_id
 			)

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -119,7 +119,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$b_term = (object) array('count' => 4);
 		$c_term = (object) array('count' => 3);
 
-		$lr = new Largo_Related;
+		$lr = new Largo_Related(1, $this->considered);
 
 		$this->assertEquals(0, $lr->popularity_sort($a_term, $b_term), 'Comparing two terms with equal numbers of posts did not return 0, which would indicate they were of the same length');
 		$this->assertEquals(-1, $lr->popularity_sort($c_term, $b_term), 'Comparing a term with 3 posts to a term with 4 posts did not return -1, which would indicate that 3 had fewer posts than 4 did. If the difference were greater than 1 post, -1 would still be returned.');

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -94,11 +94,6 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->go_to("/?p=$this->considered");
 		// check that Largo_Related->number equals 1 if number is not set
 		$lr = new Largo_Related();
-		/*
-		 *
-		 * State of this on Friday evening: I can't create a new Largo_Related in a way that actually triggers it as an object and not as an associative array. 
-		 *
-		 */
 		$this->assertInstanceOf('Largo_Related', $lr, 'The constructor failed to make $lr an instance of Largo_Related');
 		$this->assertEquals(1, $lr->number, "The number of posts to be returned, when not explicitly set, did not match the programmed number of 1 posts");
 
@@ -210,14 +205,14 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->factory->post->create(array(
 			'post_date' => '2015-01-01 00:00:00',
 		));
-		// Post published before the current post in its series
+		// Post published after the current post in its series
 		$before_id = $this->factory->post->create(array(
 			'post_date' => '2015-01-01 00:00:00',
 			'tax_input' => array(
 				'series' => $this->series_id
 			)
 		));
-		// Post published after the current post in its series
+		// Post published before the current post in its series
 		$after_id = $this->factory->post->create(array(
 			'post_date' => '2013-01-01 00:00:00',
 			'tax_input' => array(

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -431,6 +431,9 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
 	}
 
+	/**
+	 * @todo This test checks for a post before and a post after the considered post
+	 */
 	function test_category() {
 		of_set_option('series_enabled', false);
 		// Some randos before and after
@@ -453,10 +456,16 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
+	/**
+	 * @todo This test should ask for 2 posts, and return one post each from a category and a tag
+	 */
 	function test_category_and_tag() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
+	/**
+	 * @todo This test should check that recent posts are returned when there are no posts in the considered post's series, category, or tags
+	 */
 	function test_recent_posts() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -338,10 +338,11 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->assertFalse(array($before_id, $after_id, $past_id) == $ids, "The posts were returned in increasing order of post ID");
 		$this->assertFalse(array($past_id, $after_id, $before_id) == $ids, "The posts were returned in decreasing order of post ID");
 		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the opposite of the custom order.");
-		$this->assertTrue(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the custom order.");
+		$this->assertTrue(array($after_id, $past_id, $before_id) == $ids, "The posts were not returned in the custom order.");
 	}
 
 	function test_series_featured_desc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'featured, DESC'
 		$landing = $this->factory->post->create(array(
@@ -377,11 +378,12 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		var_log($feat);
 		var_log($ids);
+		$this->assertFalse($feat == $ids[2], "The featured post is the last post in the return.");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
-		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_asc() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'featured, ASC'
 		$landing = $this->factory->post->create(array(
@@ -406,6 +408,14 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			)
 		));
 		// create a post that is featured in this taxonomy. It shall be the first.
+		$tf = $this->factory->term->create(array(
+			'taxonomy' => 'prominence',
+		));
+		wp_update_term($tf, 'prominence',
+			array(
+				'slug' => 'taxonomy-featured'
+			)
+		);
 		$feat = $this->factory->post->create(array(
 			'series' => $this->series->slug,
 			'tax_input' => array(
@@ -416,13 +426,28 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$ids = $lr->ids();
 		var_log($feat);
 		var_log($ids);
-		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
+		$this->assertEquals(3, count($ids), "Largo_Related returned other than 3 posts");
+		$this->assertFalse($feat == $ids[2], "The featured post is the last post in the return.");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
-		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_category() {
 		of_set_option('series_enabled', false);
+		// Some randos before and after
+		$this->factory->post->create(array(
+			'post_date' => '2013-01-01 00:00:00',
+		));
+		$this->factory->post->create(array(
+			'post_date' => '2015-01-01 00:00:00',
+		));
+		$cp = $this->factory->post->create(array(
+			'post_category' => $this->cat_id,
+		));
+		var_log($this->cat_id);
+		$lr = new Largo_Related(1, $this->considered);
+		$ids = $lr->ids();
+		$this->assertEquals(1, count($ids), "Largo_Related returned other than 1 posts");
+		$this->assertEquals($cp, $ids[0], "Largo_Related did not return the post in the category");
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -313,23 +313,33 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			'post_type' => 'cftl-tax-landing',
 			'series' => $this->series->slug,
 			'has_order' => 'custom',
-			'series_'.$this->series_id.'_order' => array($after_id, $this->considered, $past_id, $before_id),
 		));
+
+		/*
+		 * The order of posts within a series, if set customly, is done with each post's series_order post meta.
+		 * It's not set on the series landing page.
+		 */
+		add_post_meta($after_id, 'series_order', 1);
+		add_post_meta($past_id, 'series_order', 2);
+		add_post_meta($before_id, 'series_order', 3);
 
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
-		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
+		$this->assertEquals(3, count($ids), "Largo_Related returned other than 3 posts");
 		$this->assertFalse(array($past_id, $before_id, $after_id) == $ids, "The posts were returned in increasing order of newness");
 		$this->assertFalse(array($after_id, $before_id, $past_id) == $ids, "The posts were returned in decreasing order of newness");
 		$this->assertFalse(array($before_id, $after_id, $past_id) == $ids, "The posts were returned in increasing order of post ID");
 		$this->assertFalse(array($past_id, $after_id, $before_id) == $ids, "The posts were returned in decreasing order of post ID");
-		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the opposite of the custom order.");
-		$this->assertEquals(array($after_id, $past_id, $before_id), $ids, "The posts were not returned in the custom order");
+		// Sigh
+		// These next two assertions are actually inverted.
+		// The posts are returned by this function in the order opposite how they're described, but it displays correctly, and so I'm at a loss for words at what is going on here.
+		// 2015-08-14 Ben Keith
+		$this->assertTrue(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the custom order.");
+		$this->assertFalse(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the opposite of the custom order.");
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_desc() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'series_custom'
 		$this->factory->post->create(array(
@@ -354,21 +364,25 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// create a post that is featured in this taxonomy. It shall be the first.
 		$feat = $this->factory->post->create(array(
 			'series' => $this->series->slug,
-			'featured' => true
+			'tax_input' => array(
+				'prominence' => 'taxonomy-featured'
+			)
 		));
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_asc() {
-		$this->markTestIncomplete('This test has not been implemented yet.');
 		of_set_option('series_enabled', 1);
 		// Create a landing page that sets the order to 'series_custom'
-		$this->factory->post->create(array(
+		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
-			'series' => $this->series->slug,
+			'tax_input' => array(
+				'series' => $this->series->slug,
+			),
 			'has_order' => 'featured, ASC'
 		));
 		// Post published before the current post in its series
@@ -388,12 +402,15 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// create a post that is featured in this taxonomy. It shall be the first.
 		$feat = $this->factory->post->create(array(
 			'series' => $this->series->slug,
-			'featured' => true
+			'tax_input' => array(
+				'prominence' => 'taxonomy-featured'
+			)
 		));
 		$lr = new Largo_Related(3, $this->considered);
 		$ids = $lr->ids();
 		$this->assertEquals(3, count($ids), "Largo_Related returned other than 2 posts");
 		$this->assertEquals($feat, $ids[0], "The featured post is not the first post in the return.");
+		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_category() {

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -60,41 +60,47 @@ class RelatedContentTestFunctions extends wp_UnitTestCase{
 }
 
 class LargoRelatedTestFunctions extends WP_UnitTestCase {
+
+	public $cat_id;
+	public $series_id;
+	public $considered;
+
 	function setUp() {
 		parent::setUp();
 
-		$cat_id = $this->factory->category->create();
-		$series_id = $this->factory->term->create(array(
+		$this->cat_id = $this->factory->category->create();
+		$this->series_id = $this->factory->term->create(array(
 			'taxonomy' => 'series'
 		));
-		global $considered;
-		$considered = $this->factory->post->create(array(
-			'post_category' => array($cat_id),
+		$this->considered = $this->factory->post->create(array(
+			'post_category' => array($this->cat_id),
 			'tax_input' => array(
-				'series' => $series_id
+				'series' => $this->series_id
 			)
 		));
 	}
 
 	function test___construct() {
+		$this->go_to("/?p=$this->considered");
 		// check that Largo_Related->number equals 1 if number is not set
 		$lr = new Largo_Related();
 		/*
 		 *
 		 * State of this on Friday evening: I can't create a new Largo_Related in a way that actually triggers it as an object and not as an associative array. 
 		 *
-		 *
-		$this->assertEquals(1, $lr->number);
+		 */
+		$this->assertInstanceOf('Largo_Related', $lr, 'The constructor failed to make $lr an instance of Largo_Related');
+		$this->assertEquals(1, $lr->number, "The number of posts to be returned, when not explicitly set, did not match the programmed number of 1 posts");
 
 		$lr = new Largo_Related(4);
-		$this->assertEquals(4, $lr->number);
+		$this->assertEquals(4, $lr->number, "The number of posts to be returned, when set to 4, was not 4");
 		// check that Largo_Related->post_id is the value of the set post, or the value of the global post
 		global $post;
-		$this->assertEquals($post->id, $lr->post_id);
+		$this->assertEquals($post->ID, $lr->post_id, "The global post's ID does not match the ID of the post considered by the Largo_Related class");
 
-		$lr = new Largo_Related(4, $considered);
-		$this->assertEquals($considered, $lr->post_id);
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->go_to('/'); // So there is no global $post
+		$lr = new Largo_Related(4, $this->considered);
+		$this->assertEquals($this->considered, $lr->post_id, "The post this test is considering does not match the post in the Largo_Related class, when that post ID is explicitly set.");
 	}
 
 	function test_popularity_sort() {
@@ -123,6 +129,11 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 
 	function test_unorganized_series() {
 		of_set_option('series_enabled', 1);
+		$this->factory->posts->create_many(array(
+			'tax_input' => array(
+				'series' => $this->series_id
+			)
+		));
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -228,7 +228,9 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// Create a landing page that sets the order to ASC
 		$this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
-			'series' => $this->series->slug,
+			'tax_input' => array(
+				'series' => $this->series->slug,
+			),
 			'has_order' => 'ASC'
 		));
 
@@ -266,7 +268,9 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// Create a landing page that sets the order to DESC
 		$this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
-			'series' => $this->series->slug,
+			'tax_input' => array(
+				'series' => $this->series->slug,
+			),
 			'has_order' => 'DESC'
 		));
 
@@ -311,7 +315,9 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// Create a landing page that sets the order to 'series_custom'
 		$this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
-			'series' => $this->series->slug,
+			'tax_input' => array(
+				'series' => $this->series->slug,
+			),
 			'has_order' => 'custom',
 		));
 
@@ -330,13 +336,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$this->assertFalse(array($after_id, $before_id, $past_id) == $ids, "The posts were returned in decreasing order of newness");
 		$this->assertFalse(array($before_id, $after_id, $past_id) == $ids, "The posts were returned in increasing order of post ID");
 		$this->assertFalse(array($past_id, $after_id, $before_id) == $ids, "The posts were returned in decreasing order of post ID");
-		// Sigh
-		// These next two assertions are actually inverted.
-		// The posts are returned by this function in the order opposite how they're described, but it displays correctly, and so I'm at a loss for words at what is going on here.
-		// 2015-08-14 Ben Keith
-		$this->assertTrue(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the custom order.");
-		$this->assertFalse(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the opposite of the custom order.");
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertFalse(array($before_id, $past_id, $after_id) == $ids, "The posts were returned in the custom order.");
+		$this->assertTrue(array($after_id, $past_id, $before_id) == $ids, "The posts were returned in the opposite of the custom order.");
 	}
 
 	function test_series_featured_desc() {
@@ -344,7 +345,9 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		// Create a landing page that sets the order to 'series_custom'
 		$this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
-			'series' => $this->series->slug,
+			'tax_input' => array(
+				'series' => $this->series->slug,
+			),
 			'has_order' => 'featured, DESC'
 		));
 		// Post published before the current post in its series

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -62,11 +62,38 @@ class RelatedContentTestFunctions extends wp_UnitTestCase{
 class LargoRelatedTestFunctions extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
+
+		$cat_id = $this->factory->category->create();
+		$series_id = $this->factory->term->create(array(
+			'taxonomy' => 'series'
+		));
+		global $considered;
+		$considered = $this->factory->post->create(array(
+			'post_category' => array($cat_id),
+			'tax_input' => array(
+				'series' => $series_id
+			)
+		));
 	}
 
 	function test___construct() {
 		// check that Largo_Related->number equals 1 if number is not set
+		$lr = new Largo_Related();
+		/*
+		 *
+		 * State of this on Friday evening: I can't create a new Largo_Related in a way that actually triggers it as an object and not as an associative array. 
+		 *
+		 *
+		$this->assertEquals(1, $lr->number);
+
+		$lr = new Largo_Related(4);
+		$this->assertEquals(4, $lr->number);
 		// check that Largo_Related->post_id is the value of the set post, or the value of the global post
+		global $post;
+		$this->assertEquals($post->id, $lr->post_id);
+
+		$lr = new Largo_Related(4, $considered);
+		$this->assertEquals($considered, $lr->post_id);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
@@ -95,30 +122,37 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 	 */
 
 	function test_unorganized_series() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_asc() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_series_custom() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_desc() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_desc() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_series_featured_asc() {
+		of_set_option('series_enabled', 1);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
 	function test_category() {
+		of_set_option('series_enabled', false);
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 


### PR DESCRIPTION
## Changes

Largo_Related now uses the correct query to catch series landing pages.

Tests for Largo_Related's:

- [x] `::__construct()`
- [x] `::popularity_sort()`
- [x] `::ids()` in the following conditions:
    - [x] unorganized series with a post published before the current post
    - [x] unorganized series with a post published after the current post
    - [x] a series with a landing page forcing the ascending sort order
    - [x] a series with a landing page forcing the descending sort order
    - [x] a series with a landing page forcing the custom sort order
    - [ ] a series with a landing page forcing descending sort order, with featured posts
    - [ ] a series with a landing page forcing ascending sort order, with featured posts
    - [x] a category with posts
    - [ ] a tag
    - [ ] the current post matches posts in both categories and tags, with results drawn from both
    - [ ] no posts in the same series, categories, or tags, so only recent posts should be returned.
- [ ] `::cleanup_ids()`

## Why

Largo_Related bugfixes for #841, Test coverage for #782.