### PR TITLE
a different approach to tracking posts that have been shown (i.e., wi…

### DIFF
--- a/category.php
+++ b/category.php
@@ -7,7 +7,7 @@
  */
 get_header();
 
-global $tags, $paged, $post, $shown_ids;
+global $tags, $paged, $post;
 
 $title = single_cat_title('', false);
 $description = category_description();
@@ -29,9 +29,8 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 	if ( $paged < 2 ) {
 		if ( count( $featured_posts ) > 0) {
 			foreach ( $featured_posts as $idx => $featured_post ) {
-				if ( $idx == 0 ) { 
-					$shown_ids[] = get_the_ID();
-				?>
+				largo_mark_post_shown($featured_post->ID);
+				if ( $idx == 0 ) { ?>
 					<div class="primary-featured-post">
 						<?php largo_render_template( 'partials/archive', 'category-primary-feature', array( 'featured_post' => $featured_post ) ); ?>
 					</div>
@@ -51,7 +50,7 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 
 			foreach ( range( 1, $needed ) as $number ) {
 				the_post();
-				$shown_ids[] = get_the_ID();
+				largo_mark_post_shown(get_the_ID());
 				if ( count( $featured_posts ) == 0 && $number == 1 ) { ?>
 					<div class="primary-featured-post">
 						<?php largo_render_template( 'partials/archive', 'category-primary-feature', array( 'featured_post' => $post) ); ?>
@@ -74,7 +73,6 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 		<?php if ( have_posts() ) {
 			while ( have_posts() ) {
 				the_post();
-				$shown_ids[] = get_the_ID();
 				get_template_part( 'partials/content', 'archive' );
 			}
 			largo_content_nav( 'nav-below' );

--- a/home.php
+++ b/home.php
@@ -19,7 +19,6 @@ get_header();
  * Collect post IDs in each loop so we can avoid duplicating posts
  * and get the theme option to determine if this is a two column or three column layout
  */
-$shown_ids = array();
 $home_template = largo_get_active_homepage_layout();
 $layout_class = of_get_option('home_template');
 $tags = of_get_option ('tag_display');

--- a/homepages/templates/full-width-image.php
+++ b/homepages/templates/full-width-image.php
@@ -1,9 +1,7 @@
 <?php
 
-global $shown_ids;
-
 $bigStoryPost = largo_home_single_top();
-$shown_ids[] = $bigStoryPost->ID; //don't repeat the current post
+largo_mark_post_shown($bigStoryPost->ID); //don't repeat the current post
 
 ?>
 <div id="homepage-featured" class="row-fluid clearfix">

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -5,7 +5,7 @@
  * Sidebars: Homepage Left Rail (An optional widget area that, when enabled, appears to the left of the main content area on the homepage)
  */
 
-global $largo, $shown_ids, $tags;
+global $largo, $tags;
 $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') ? 'top-story span12' : 'top-story span8';
 ?>
 <div id="homepage-featured" class="row-fluid clearfix">
@@ -24,7 +24,8 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 			'showposts' => 1
 		) );
 		if ( $topstory->have_posts() ) :
-			while ( $topstory->have_posts() ) : $topstory->the_post(); $shown_ids[] = get_the_ID();
+			while ( $topstory->have_posts() ) : $topstory->the_post();
+				largo_mark_post_shown(get_the_ID());
 		?>
 				<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'large' ); ?></a>
 				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
@@ -58,11 +59,12 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 					)
 				),
 				'showposts'		=> $showposts,
-				'post__not_in' 	=> $shown_ids
+				'post__not_in' 	=> largo_shown_posts()
 			) );
 			if ( $substories->have_posts() ) :
 				$count = 1;
-				while ( $substories->have_posts() ) : $substories->the_post(); $shown_ids[] = get_the_ID();
+				while ( $substories->have_posts() ) : $substories->the_post();
+					largo_mark_post_shown(get_the_ID());
 					if ( $count <= 3 ) : ?>
 						<div <?php post_class( 'story' ); ?>
 							<?php if ( largo_has_categories_or_tags() && $tags === 'top' ) : ?>

--- a/homepages/zones/zones.php
+++ b/homepages/zones/zones.php
@@ -49,8 +49,6 @@ function homepage_big_story_headline($moreLink=false) {
  * Returns a short list (3 posts) of stories in the same series as the main feature
  **/
 function homepage_series_stories_list() {
-	global $shown_ids;
-
 	$feature = largo_get_the_main_feature(largo_home_single_top());
 
 	$min = 2;
@@ -97,7 +95,7 @@ function homepage_series_stories_list() {
 	<h5 class="top-tag"><a class="post-category-link" href="<?php echo get_term_link($feature); ?>">
 		<?php echo __("More in", "largo") . " " . esc_html($feature->name) ?></a></h5>
 			<?php foreach ($series_posts as $series_post) {
-				$shown_ids[] = $series_post->ID; ?>
+				largo_mark_post_shown($series_post->ID); ?>
 				<h4 class="related-story"><a href="<?php echo esc_url(get_permalink($series_post->ID)); ?>">
 					<?php echo get_the_title($series_post->ID); ?></a></h4>
 			<?php } ?>
@@ -112,8 +110,6 @@ function homepage_series_stories_list() {
 }
 
 function homepage_feature_stories_list() {
-	global $shown_ids;
-
 	$max = 3;
 
 	/**
@@ -135,7 +131,7 @@ function homepage_feature_stories_list() {
 	ob_start();
 	$featured_stories = largo_home_featured_stories($max);
 	foreach ($featured_stories as $featured) {
-		$shown_ids[] = $featured->ID;
+		largo_mark_post_shown($featured->ID);
 ?>
 		<article class="featured-story">
 			<h5 class="top-tag"><?php largo_top_term('post=' . $featured->ID); ?></h5>

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -30,13 +30,13 @@ if (!function_exists('largo_load_more_posts_enqueue_script')) {
  */
 if (!function_exists('largo_load_more_posts_data')) {
 	function largo_load_more_posts_data($nav_id, $the_query) {
-		global $shown_ids, $post, $opt;
+		global $post, $opt;
 
 		$query = $the_query->query;
 
 		// No sticky posts or featured posts
 		$query = array_merge(array(
-			'post__not_in' => $shown_ids,
+			'post__not_in' => largo_shown_posts(),
 		), $query );
 
 		$config = array(

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -658,8 +658,8 @@ if ( ! function_exists( 'largo_hero_class' ) ) {
 }
 
 /**
- * Depricated 0.5.1.
- * 
+ * Deprecated 0.5.1.
+ *
  * Returns the featured image for a post
  * to be used as the hero image with caption and credit (if available)
  *
@@ -667,9 +667,7 @@ if ( ! function_exists( 'largo_hero_class' ) ) {
  */
 if ( ! function_exists( 'largo_hero_with_caption' ) ) {
 	function largo_hero_with_caption( $post_id ) {
-		
 		largo_featured_image_hero($post_id);
-
 	}
 }
 
@@ -695,4 +693,64 @@ if ( ! function_exists( 'largo_post_metadata' ) ) {
 			return $out;
 		}
 	}
+}
+
+/**
+ * A class for tracking shown posts and dealing with post duplication across widgets, etc.
+ *
+ * @since 0.5.2
+ */
+class LargoShownPosts {
+
+	protected static $shown_ids = array();
+
+	public static function is_post_shown($post) {
+		$post = get_post($post);
+		return in_array($post->ID, self::$shown_ids);
+	}
+
+	public static function shown_posts() {
+		return self::$shown_ids;
+	}
+
+	public static function mark_post_shown($post) {
+		$post = get_post($post);
+		if (!empty($post) && !in_array($post, self::$shown_ids)) {
+			self::$shown_ids[] = $post->ID;
+			return true;
+		}
+		return false;
+	}
+}
+
+/**
+ * Mark a post as "shown" so that we can avoid duplicates on page render
+ *
+ * @param $post mixed the post ID or post object we want to mark as shown.
+ * @return boolean true if successfully marked post as shown, false if it's already been marked.
+ * @since 0.5.2
+ */
+function largo_mark_post_shown($post) {
+	return LargoShownPosts::mark_post_shown($post);
+}
+
+/**
+ * See if a post has been marked "shown"
+ *
+ * @param $post mxied the post ID or post object we want to determine is marked or not
+ * @return boolean
+ * @since 0.5.2
+ */
+function largo_is_post_shown($post) {
+	return LargoShownPosts::is_post_shown($post);
+}
+
+/**
+ * Get ID's of all "shown" posts
+ *
+ * @return array all post ID's marked as "shown"
+ * @since 0.5.2
+ */
+function largo_shown_posts() {
+	return LargoShownPosts::shown_posts();
 }

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -30,7 +30,7 @@ class largo_recent_posts_widget extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 
-		global $post, $shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
+		global $post; // an array of post IDs already on a page so we can avoid duplicating posts;
 		
 		// Preserve global $post
 		$preserve = $post;
@@ -55,7 +55,7 @@ class largo_recent_posts_widget extends WP_Widget {
 			'post_status'	=> 'publish'
 		);
 
-		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) $query_args['post__not_in'] = $shown_ids;
+		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) $query_args['post__not_in'] = largo_shown_posts();
 		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
 		if ( $instance['tag'] != '') $query_args['tag'] = $instance['tag'];
 		if ( $instance['author'] != '') $query_args['author'] = $instance['author'];
@@ -77,7 +77,8 @@ class largo_recent_posts_widget extends WP_Widget {
 
         	$output = '';
 
-			while ( $my_query->have_posts() ) : $my_query->the_post(); $shown_ids[] = get_the_ID();
+			while ( $my_query->have_posts() ) : $my_query->the_post();
+				largo_mark_post_shown(get_the_ID());
 
         		// wrap the items in li's.
         		$output .= '<li>';

--- a/partials/home-post-list.php
+++ b/partials/home-post-list.php
@@ -1,13 +1,11 @@
 <?php
 /* Homepage blog river/list */
 
-global $shown_ids;
-
 $args = array(
 	'paged' => $paged,
 	'post_status' => 'publish',
 	'posts_per_page' => 10,
-	'post__not_in' => $shown_ids,
+	'post__not_in' => largo_shown_posts(),
 	'ignore_sticky_posts' => true
 );
 
@@ -20,10 +18,10 @@ $query = new WP_Query($args);
 if ($query->have_posts()) {
 	while ($query->have_posts()) : $query->the_post();
 		//if the post is in the array of post IDs already on this page, skip it. Just a double-check
-		if (in_array(get_the_ID(), $shown_ids))
+		if (largo_is_post_shown(get_the_ID()))
 			continue;
 		else {
-			$shown_ids[] = get_the_ID();
+			largo_mark_post_shown(get_the_ID());
 			do_action('largo_before_home_list_post', $post, $query);
 			get_template_part('partials/content', 'home');
 			do_action('largo_after_home_list_post', $post, $query);

--- a/partials/sticky-posts.php
+++ b/partials/sticky-posts.php
@@ -1,5 +1,4 @@
 <?php
-global $shown_ids;
 
 $sticky = get_option( 'sticky_posts' );
 if (empty($sticky))
@@ -15,7 +14,7 @@ $query = new WP_Query( $args );
 if ( $query->have_posts() ) {
 	while ( $query->have_posts() ) {
 	   	$query->the_post();
-	   	$shown_ids[] = get_the_ID();
+	   	largo_mark_post_shown(get_the_ID());
 
 		if ( $sticky && $sticky[0] && ! is_paged() ) { ?>
 
@@ -55,7 +54,7 @@ if ( $query->have_posts() ) {
 						<div class="entry-content">
 						<?php
 							largo_excerpt( $post, 2, false );
-							$shown_ids[] = get_the_ID();
+							largo_mark_post_shown(get_the_ID());
 
 						if ( $feature_posts ) { //if the sticky post is in a series, show up to 3 other posts in that series ?>
 							<div class="sticky-features-list">

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -5,8 +5,6 @@
  * Description: Shows the post but does not load any sidebars.
  */
 
-global $shown_ids;
-
 add_filter( 'body_class', function( $classes ) {
 	$classes[] = 'normal';
 	return $classes;
@@ -18,11 +16,11 @@ get_header();
 <div id="content" role="main">
 	<?php
 		while ( have_posts() ) : the_post();
-			
-			$shown_ids[] = get_the_ID();
-			
+
+			largo_mark_post_shown(get_the_ID());
+
 			$partial = ( is_page() ) ? 'page' : 'single';
-			
+
 			get_template_part( 'partials/content', $partial );
 
 			if ( $partial === 'single' ) {

--- a/single-two-column.php
+++ b/single-two-column.php
@@ -5,8 +5,6 @@
  * Description: Shows the post and sidebar if specified.
  */
 
-global $shown_ids;
-
 add_filter('body_class', function($classes) {
 	$classes[] = 'classic';
 	return $classes;
@@ -19,8 +17,8 @@ get_header();
 
 	<?php
 		while ( have_posts() ) : the_post();
-		
-			$shown_ids[] = get_the_ID();
+
+			largo_mark_post_shown(get_the_ID());
 
 			$partial = ( is_page() ) ? 'page' : 'single-classic';
 

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -17,8 +17,7 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_load_more_posts_data() {
-		// create $shown_ids
-		global $wp_scripts, $wp_query, $shown_ids;
+		global $wp_scripts, $wp_query;
 		$args = array(
 			'post_type' => 'post',
 		);
@@ -26,7 +25,7 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		if ($wp_query->have_posts()) {
 			while ($wp_query->have_posts()) {
 				$wp_query->the_post();
-				$shown_ids[] = get_the_ID();
+				largo_mark_post_shown(get_the_ID());
 			}
 		}
 


### PR DESCRIPTION
Opening this pull request to start the convo about how we're dealing with "shown" posts in Largo.

Since we've been using `$shown_ids` in a variety of contexts and in inconsistent ways, I thought it would be a good idea to provide some simple helper functions for dealing with this problem.
### This patch adds:
- A `LargoShownPosts` which is simply to track `$shown_ids` without clouding the global namespace any more than it already is
- Utility functions: `largo_mark_post_shown`, `largo_is_post_shown` and `largo_shown_posts`
### Using this code:

You must do two things to effectively prevent posts from showing in multiple places during a single request:
1. You must call `largo_mark_post_shown`, passing the post object or post ID of the post to mark as shown.
2. On subsequent queries for posts during the same request, you must use the return value of `largo_shown_posts` as the `post__not_in` argument passed to whatever function or class constructor you're using to get posts.
### Other notes:

We'll probably need to review our existing sites to determine whether or not they'll need updating to account for this change if we decide to merge it.
