### PR TITLE
Add theme option to disable the featured posts area on category pages

### DIFF
--- a/category.php
+++ b/category.php
@@ -26,7 +26,7 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 	<?php
 
 	$featured_posts = largo_get_featured_posts_in_category( $wp_query->query_vars['category_name'] );
-	if ( $paged < 2 ) {
+	if ( $paged < 2 && of_get_option('hide_category_featured') == '0' ) {
 		if ( count( $featured_posts ) > 0 ) {
 			foreach ( $featured_posts as $idx => $featured_post ) {
 				$shown_ids[] = $featured_post->ID;

--- a/category.php
+++ b/category.php
@@ -25,8 +25,8 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 
 	<?php
 
-	$featured_posts = largo_get_featured_posts_in_category( $wp_query->query_vars['category_name'] );
 	if ( $paged < 2 && of_get_option('hide_category_featured') == '0' ) {
+		$featured_posts = largo_get_featured_posts_in_category( $wp_query->query_vars['category_name'] );
 		if ( count( $featured_posts ) > 0 ) {
 			foreach ( $featured_posts as $idx => $featured_post ) {
 				$shown_ids[] = $featured_post->ID;

--- a/docs/users/themeoptions.rst
+++ b/docs/users/themeoptions.rst
@@ -99,6 +99,8 @@ Layout Options
 
 **Single Article Template** - Starting with version 0.3, Largo introduced a new single-post template that more prominently highlights article content, which is the default. For backward compatibility, the pre-0.3 version is also available, which by default includes a sidebar. The new template optionally includes a sidebar of your choice.
 
+**Category Options** - Starting with version 0.5.3, Largo allows you to disable the standard featured posts area on top of category archive pages. The five posts that are normally displayed on top of the page become part of the main column of posts.
+
 **Sidebar Options** - These affect the presentation of the sidebar to the reader.
 
 - Add a third sidebar used only on archive pages (category, tag, author and series pages), configurable in Appearance > Widgets

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -302,6 +302,9 @@ function largo_category_archive_posts( $query ) {
 	//don't muck with admin, non-categories, etc
 	if ( !$query->is_category() || !$query->is_main_query() || is_admin() ) return;
 
+	// If this has been disabled by an option, do nothing
+	if ( of_get_option('hide_category_featured') == true ) return;
+
 	// get the featured posts
 	$featured_posts = largo_get_featured_posts_in_category($query->get('category_name'));
 

--- a/options.php
+++ b/options.php
@@ -468,6 +468,16 @@ function optionsframework_options() {
 			)
 		);
 
+	$options[] = array(
+		'name' => __('Category Options', 'largo'),
+		'type' => 'info');
+
+	$options[] = array(
+		'desc' => __('Hide the featured posts area on category pages?'),
+		'id' => 'hide_category_featured',
+		'std' => '0',
+		'type' => 'checkbox');
+
 	$widget_options[] = $options[] = array(
 		'name' 	=> __('Sidebar Options', 'largo'),
 		'type' 	=> 'info');


### PR DESCRIPTION
## Changes:

- New option "Hide the featured posts area on category pages?" `hide_category_featured` in Theme Options > Layout Options
- `hide_category_featured` if true hides the presence of the featured posts area on category pages
- `hide_category_featured` if true causes `largo_category_archive_posts` to not modify `posts__not_in` in `$wp_query`
- the featured posts query in the category moves inside the `hide_category_featured` conditional on category pages
- User-facing docs

## Why

For #860 and Catalyst Chicago's [HELPDESK-337](http://jira.inn.org/browse/HELPDESK-337)

Because not everyone wants to use featured posts in the category.