### PR TITLE
Fix erroneous closing div tags on category template

### DIFF
--- a/category.php
+++ b/category.php
@@ -23,35 +23,37 @@ $posts_term = of_get_option('posts_term_plural', 'Stories');
 		<?php get_template_part('partials/archive', 'category-related'); ?>
 	</header>
 
-	<?php
-
-	if ( $paged < 2 && of_get_option('hide_category_featured') == '0' ) {
+	<?php if ( $paged < 2 && of_get_option('hide_category_featured') == '0' ) {
 		$featured_posts = largo_get_featured_posts_in_category( $wp_query->query_vars['category_name'] );
 		if ( count( $featured_posts ) > 0 ) {
-			foreach ( $featured_posts as $idx => $featured_post ) {
-				$shown_ids[] = $featured_post->ID;
-				if ( $idx == 0 ) { ?>
-					<div class="primary-featured-post">
-						<?php largo_render_template(
-							'partials/archive',
-							'category-primary-feature',
-							array( 'featured_post' => $featured_post )
-						); ?>
+			list($top_featured) = array_slice($featured_posts, 0, 1);
+			$shown_ids[] = $top_featured->ID; ?>
+
+			<div class="primary-featured-post">
+				<?php largo_render_template(
+					'partials/archive',
+					'category-primary-feature',
+					array( 'featured_post' => $top_featured )
+				); ?>
+			</div>
+
+			<?php $secondary_featured = array_slice($featured_posts, 1);
+			if ( count($secondary_featured) > 0 ) { ?>
+				<div class="secondary-featured-post">
+					<div class="row-fluid clearfix"><?php
+						foreach ( $secondary_featured as $idx => $featured_post ) {
+								$shown_ids[] = $featured_post->ID;
+								largo_render_template(
+									'partials/archive',
+									'category-secondary-feature',
+									array( 'featured_post' => $featured_post )
+								);
+						} ?>
 					</div>
-					<div class="secondary-featured-post">
-						<div class="row-fluid clearfix">
-			<?php } else {
-					largo_render_template(
-						'partials/archive',
-						'category-secondary-feature',
-						array( 'featured_post' => $featured_post )
-					);
-				}
-			}
-		} ?>
-						</div>
-					</div>
-<?php } ?>
+				</div>
+		<?php }
+	}
+} ?>
 </div>
 
 <div class="row-fluid clearfix">

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -345,8 +345,8 @@ function largo_get_featured_posts_in_category($category_name, $number=5) {
 	$featured_posts = get_posts(array_merge($args, $tax_query));
 
 	// Backfill with regular posts if necessary
-	if (count( $featured_posts ) < 5) {
-		$needed = 5 - count( $featured_posts );
+	if (count( $featured_posts ) < (int) $number) {
+		$needed = (int) $number - count( $featured_posts );
 		$regular_posts = get_posts(array_merge($args, array(
 			'numberposts' => $needed,
 			'post__not_in' => array_map(function($x) { return $x->ID; }, $featured_posts)


### PR DESCRIPTION
This is for #869.

What this pull request does:

- Refactors the featured posts area at the top of the category template so that it's easy to follow what markup gets printed and under what circumstances.
- Fix the erroneous closing `</div>`'s which were printed when no featured posts were available, resulting in a broken category archive page layout.