### PR TITLE
Fix missing > in homepages/templates/top-stories.php

### DIFF
--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -64,7 +64,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				$count = 1;
 				while ( $substories->have_posts() ) : $substories->the_post(); $shown_ids[] = get_the_ID();
 					if ( $count <= 3 ) : ?>
-						<div <?php post_class( 'story' ); ?>
+						<div <?php post_class( 'story' ); ?> >
 							<?php if ( largo_has_categories_or_tags() && $tags === 'top' ) : ?>
 								<h5 class="top-tag"><?php largo_top_term(); ?></h5>
 							<?php endif; ?>


### PR DESCRIPTION
## Changes

Re-inserts a closing `>` on a `<div>` in the homepage Top Stories template [lost in 0.5.2](https://github.com/INN/Largo/commit/090c5f73d162dcbb9ad9a32cf2e5a65806845b45).


## Why

Without the `>` on the `<div`, the `<h5>` created to contain `largo_top_term()` becomes part of the `<div` tag:

![david's screenshot](https://s3.amazonaws.com/uploads.hipchat.com/93536/2129515/iAOpjuGLEOgqy6Y/Screen%20Shot%202015-08-31%20at%209.31.49%20AM.png)

This breaks the styles on the top tag.

For [HELPDESK-339](http://jira.inn.org/browse/HELPDESK-339)