### PR TITLE
Remove 'Show read more link?' in Largo Recent Posts widget

### DIFF
--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -120,11 +120,6 @@ class largo_recent_posts_widget extends WP_Widget {
 	                $output .= '<p>' . get_the_excerpt() . '</p>';
 				}
 
-				// read more link
-				if ( isset( $instance['show_read_more'] ) && $instance['show_read_more'] === 1) {
-					$output .= '<p class="more-link"><a href="' . get_permalink() . '">' . __( 'Read More','largo') . '</a></p>';
-				}
-
 				// close the item
 				$output .= '</li>';
 
@@ -161,7 +156,6 @@ class largo_recent_posts_widget extends WP_Widget {
 		$instance['num_sentences'] = intval( $new_instance['num_sentences'] );
 		$instance['show_byline'] = ! empty($new_instance['show_byline']);
 		$instance['show_top_term'] = ! empty($new_instance['show_top_term']);
-		$instance['show_read_more'] = ! empty( $new_instance['show_read_more'] ) ? 1 : 0;
 		$instance['cat'] = intval( $new_instance['cat'] );
 		$instance['tag'] = sanitize_text_field( $new_instance['tag'] );
 		$instance['taxonomy'] = sanitize_text_field( $new_instance['taxonomy'] );
@@ -183,7 +177,6 @@ class largo_recent_posts_widget extends WP_Widget {
 			'num_sentences' 	=> 2,
 			'show_byline'       => '',
 			'show_top_term'     => '',
-			'show_read_more' 	=> '',
 			'cat' 				=> 0,
 			'tag'				=> '',
 			'taxonomy'			=> '',
@@ -196,7 +189,6 @@ class largo_recent_posts_widget extends WP_Widget {
 		$duplicates = $instance['avoid_duplicates'] ? 'checked="checked"' : '';
 		$showbyline = $instance['show_byline'] ? 'checked="checked"' : '';
 		$show_top_term = $instance['show_top_term'] ? 'checked="checked"' : '';
-		$showreadmore = $instance['show_read_more'] ? 'checked="checked"' : '';
 		?>
 
 		<p>
@@ -252,10 +244,6 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		<p>
 			<input class="checkbox" type="checkbox" <?php echo $show_top_term; ?> id="<?php echo $this->get_field_id('show_top_term'); ?>" name="<?php echo $this->get_field_name('show_top_term'); ?>" /> <label for="<?php echo $this->get_field_id('show_top_term'); ?>"><?php _e('Show the top term on posts?', 'largo'); ?></label>
-		</p>
-
-		<p>
-			<input class="checkbox" type="checkbox" <?php echo $showreadmore; ?> id="<?php echo $this->get_field_id('show_read_more'); ?>" name="<?php echo $this->get_field_name('show_read_more'); ?>" /> <label for="<?php echo $this->get_field_id('show_read_more'); ?>"><?php _e('Show read more link?', 'largo'); ?></label>
 		</p>
 
 		<p><strong><?php _e('Limit by Author, Categories or Tags', 'largo'); ?></strong><br /><small><?php _e('Select an author or category from the dropdown menus or enter post tags separated by commas (\'cat,dog\')', 'largo'); ?></small></p>


### PR DESCRIPTION
## Changes

- Removes read-more link display from the widget
- Removes controls for showing the read-more link in the widget settings
- Removes the setting from the widget defaults and settings

I tested this on NPQ's front page, which has the absolute highest concentration of Largo Recent Posts widgets in existence. There were no errors.

This doesn't trigger any changes in the tests, because we have no tests for widgets.

This doesn't trigger any changes in docs, because the docs for this widget are kind of general: https://largo.readthedocs.org/users/sidebarswidgets.html#custom-widgets

> - **Largo Recent Posts** - A powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author.

## Why

Because the read-more link is deprecated and discouraged. 

For #798 