### PR TITLE
Add empty form() to Largo Author Bio widget so it has a save button.

### DIFF
--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -73,10 +73,6 @@ class largo_author_widget extends WP_Widget {
 	}
 
 	function form( $instance ) {
-		
-		$defaults = array( 'title' => sprintf( __( 'About %s', 'largo' ), get_bloginfo('name') ) );
-		$instance = wp_parse_args( (array) $instance, $defaults );
-		?>
-		<?php
+		return true;
 	}
 }

--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -71,4 +71,12 @@ class largo_author_widget extends WP_Widget {
 		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		return $instance;
 	}
+
+	function form( $instance ) {
+		
+		$defaults = array( 'title' => sprintf( __( 'About %s', 'largo' ), get_bloginfo('name') ) );
+		$instance = wp_parse_args( (array) $instance, $defaults );
+		?>
+		<?php
+	}
 }


### PR DESCRIPTION
## Changes

- defines an empty method `form()` on the Largo Author Bio widget.

## Why

For #641.

In [`wp-admin/includes/widgets.php`](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/widgets.php#L249-L252):

```php
		<div class="alignright<?php if ( 'noform' === $has_form ) echo ' widget-control-noform'; ?>">
			<?php submit_button( __( 'Save' ), 'button-primary widget-control-save right', 'savewidget', false, array( 'id' => 'widget-' . esc_attr( $id_format ) . '-savewidget' ) ); ?>
			<span class="spinner"></span>
		</div>
```

`$has_form` is defined [earlier in the same file](

```php
	$has_form = 'noform';

...

	if ( isset($control['callback']) )
		$has_form = call_user_func_array( $control['callback'], $control['params'] );
	else
		echo "\t\t<p>" . __('There are no options for this widget.') . "</p>\n"; ?>
```

Now, there obviously aren't no options for the Largo Author Box widget, because Largo hooks `largo_widget_custom_fields_form` on `in_widget_form` to get the responsive display fields, but that's not an actual callback for the purposes of generating the form.

tl;dr: All widgets extending `WP_Widget` need `form()`.