### PR TITLE
Migrate old featured posts widgets to the Largo Featured widget, and bugfixes

### DIFF
--- a/inc/update.php
+++ b/inc/update.php
@@ -568,6 +568,8 @@ function largo_deprecated_sidebar_widget() { ?>
  *   - Add the deprecated widget class and its replacement to $upgrades
  *   - Add the replacement widget to $replacements
  *
+ * This does *not* use largo_instantiate_widget because that only appends the widget, instead of replacing it.
+ *
  * @todo: Build $replacements from $upgrades, for simplicity
  * @since 0.5.3
  */
@@ -607,7 +609,7 @@ function largo_replace_deprecated_widgets() {
 	foreach ( $replacements as $replacement ) {
 		$counting["$replacement"] = 0;
 	}
-	$all_widgets = get_option( 'sidebars_widgets ');
+	$all_widgets = get_option( 'sidebars_widgets' );
 
 	/*
 	 * count the number of existing widgets that already match one of the replacements
@@ -653,10 +655,11 @@ function largo_replace_deprecated_widgets() {
 						$counting["$temp"]++;
 						$newslug = $update['class'] . '-' . $counting["$temp"];
 
-						update_option('widget_' . $basename, $widget_options);
-						$widget_instance[$index] = $widget_option;
-						
-						
+						update_option('widget_' . $basename, $widget_option);
+						$widgets[$index] = $newslug;
+						$allwidgets[$region] = $widgets;
+						update_option( 'sidebars_widgets', $allwidgets);
+
 						/*
 						 * From here: 
 						 * Write tests
@@ -676,6 +679,9 @@ function largo_replace_deprecated_widgets() {
 
 /**
  * Checks to see if a given widget is in a given region already
+ *
+ * @since 0.5.2
+ * @return bool Whether or not the widget was found.
  */
 function largo_widget_in_region( $widget_name, $region = 'article-bottom' ) {
 

--- a/inc/update.php
+++ b/inc/update.php
@@ -37,6 +37,7 @@ function largo_perform_update() {
 
 		// Always run
 		largo_update_custom_less_variables();
+		largo_replace_deprecated_widgets();
 		largo_check_deprecated_widgets();
 
 		// Set version.

--- a/inc/update.php
+++ b/inc/update.php
@@ -657,15 +657,8 @@ function largo_replace_deprecated_widgets() {
 
 						update_option('widget_' . $basename, $widget_option);
 						$widgets[$index] = $newslug;
-						$allwidgets[$region] = $widgets;
-						update_option( 'sidebars_widgets', $allwidgets);
-
-						/*
-						 * From here: 
-						 * Write tests
-						 * Pass the tests
-						 */
-						
+						$all_widgets[$region] = $widgets;
+						update_option( 'sidebars_widgets', $all_widgets);
 					}
 				}
 			}

--- a/inc/update.php
+++ b/inc/update.php
@@ -595,7 +595,7 @@ function largo_replace_deprecated_widgets() {
 	//	'deprecated-widget-class' => array(
 	//		'class' => 'replacement-widget-class',
 	//		'defaults' => array(
-    //			// default arguments for the replacement widget
+	//			// default arguments for the replacement widget
 	//		)
 	//	)
 	);

--- a/inc/update.php
+++ b/inc/update.php
@@ -583,6 +583,7 @@ function largo_replace_deprecated_widgets() {
 	$replacements = array(
 		'largo-featured'
 	);
+	// We'll use $counting later to keep track of how many we have of widgets.
 	$counting = array();
 
 	// Populate $counting with the widgets in $replacements;
@@ -629,17 +630,18 @@ function largo_replace_deprecated_widgets() {
 							$widget_option = get_option('widget_' . $basename, false);
 							// get this specific widget
 						}
-						$widget_option[2] = array_merge($widget_option[2], $update['defaults']);
+						$widget_option[$number] = array_merge($widget_option[$number], $update['defaults']);
 
 						$temp = $update['class'];
 						$counting["$temp"]++;
 						$newslug = $update['class'] . '-' . $counting["$temp"];
+
+						update_option('widget_' . $basename, $widget_options);
+						$widget_instance[$index] = $widget_option;
+						
 						
 						/*
 						 * From here: 
-						 * Add the enw widget with $widget_instance["$newslug"] = $widget_option
-						 * Unset $widget_instance[$index]
-						 * Unhook this from admin_init and make part of the update functions
 						 * Write tests
 						 * Pass the tests
 						 */
@@ -649,9 +651,7 @@ function largo_replace_deprecated_widgets() {
 			}
 		}
 	}
-	//var_log($counting);
 }
-add_action('admin_init', 'largo_replace_deprecated_widgets');
 
 /**
  * Utility function to get the basename of a widget from the widget's slug

--- a/inc/update.php
+++ b/inc/update.php
@@ -618,6 +618,16 @@ function largo_replace_deprecated_widgets() {
 						$widget_option = array_merge($widget_option[1], $update['defaults']);
 						var_log($widget_option);
 						
+						/*
+						 * From here: 
+						 * Get the array_merge up there to work
+						 * Create $newslug based on $update['class'] . '-' . $counting["$update['class']"]
+						 * Add the enw widget with $widget_instance["$newslug"] = $widget_option
+						 * Unset $widget_instance[$index]
+						 * Unhook this from admin_init and make part of the update functions
+						 * Write tests
+						 * Pass the tests
+						 */
 						
 					}
 				}

--- a/inc/update.php
+++ b/inc/update.php
@@ -567,16 +567,15 @@ function largo_deprecated_sidebar_widget() { ?>
  *
  * To add widgets to this list of widgets to be upgraded:
  *   - Add the deprecated widget class and its replacement to $upgrades
- *   - Add the replacement widget to $replacements
  *
- * @todo: Build $replacements from $upgrades, for simplicity
  * @uses largo_get_widget_basename
  * @uses largo_get_widget_number
  * @since 0.5.3
  */
 function largo_replace_deprecated_widgets() {
 
-	// This defines the classes of widget that will be updated, the class that they will be replaced with, and the default args on the replacement widget that must be set.
+	// This defines the classes of widget that will be updated, the class that they will be
+	// replaced with, and the default args on the replacement widget that must be set.
 	$upgrades = array(
 		'largo-footer-featured' => array(
 			'class' => 'largo-featured',
@@ -592,12 +591,6 @@ function largo_replace_deprecated_widgets() {
 				'title' => __('We Recommend', 'largo')
 			)
 		)
-	//	'deprecated-widget-class' => array(
-	//		'class' => 'replacement-widget-class',
-	//		'defaults' => array(
-	//			// default arguments for the replacement widget
-	//		)
-	//	)
 	);
 	$all_widgets = get_option( 'sidebars_widgets' );
 
@@ -608,17 +601,18 @@ function largo_replace_deprecated_widgets() {
 	 * Place the new widgets into the widgets list and into the sidebars list
 	 */
 	foreach ( $all_widgets as $region => $current_sidebar ) {
-		if ( $region != 'array_version' && is_array($current_sidebar) ) { // unlike largo_check_deprecated_widgets, this does not care if the widget is inactive. This replaces *all* widgets.
+		// Unlike largo_check_deprecated_widgets, this does not care if the
+		// widget is inactive. This replaces *all* widgets.
+		if ( $region != 'array_version' && is_array($current_sidebar) ) {
 			foreach ( $current_sidebar as $current_widget_slug ) {
 				foreach ( $upgrades as $old_widget_name => $upgrade ) {
-					// Check if the current widget matches a widget in $updates that needs to be replaced.
+					// Check if the current widget matches a widget in
+					// $updates that needs to be replaced.
 					if (strpos($current_widget_slug, $old_widget_name) === 0) {
-						// find the index of the widget in $current_sidebar
-
-						// Update all this here and now, in case the indexes are off because this has been meddled with in a previous loop
+						// Update all this here and now, in case the indexes are off because this
+						// has been meddled with in a previous loop.
 						$local_all_widgets = get_option( 'sidebars_widgets' );
 						$local_current_sidebar = $local_all_widgets[$region];
-
 						$index = array_search($current_widget_slug, $local_current_sidebar);
 
 						/*
@@ -660,8 +654,12 @@ function largo_replace_deprecated_widgets() {
 							$local_current_sidebar = $local_all_widgets[$region];
 
 							// Shuffle the new widget around
-							$local_current_sidebar[$index] = $liw_return['id']; // replace the old widget slug with the new widget slug
-							unset($local_current_sidebar[$liw_return['place']]); // remove the now-duplicate instance of the old widget added by largo_instantiate_widget
+							// replace the old widget slug with the new widget slug
+							$local_current_sidebar[$index] = $liw_return['id'];
+
+							// remove the now-duplicate instance of the old widget
+							// added by largo_instantiate_widget
+							unset($local_current_sidebar[$liw_return['place']]);
 							$local_all_widgets[$region] = $local_current_sidebar;
 							update_option('sidebars_widgets', $local_all_widgets);
 						}

--- a/inc/update.php
+++ b/inc/update.php
@@ -545,6 +545,23 @@ function largo_check_deprecated_widgets() {
 }
 
 /**
+ * Admin notices of older widgets
+ */
+function largo_deprecated_footer_widget() { ?>
+	<div class="update-nag"><p>
+	<?php printf( __('You are using the <strong>Largo Footer Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
+	</p></div>
+	<?php
+}
+
+function largo_deprecated_sidebar_widget() { ?>
+	<div class="update-nag"><p>
+	<?php printf( __( 'You are using the <strong>Largo Sidebar Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
+	</p></div>
+	<?php
+}
+
+/**
  * Replace deprecated widgets with new widgets
  *
  * To add widgets to this list of widgets to be upgraded:
@@ -653,41 +670,6 @@ function largo_replace_deprecated_widgets() {
 	}
 }
 
-/**
- * Utility function to get the basename of a widget from the widget's slug
- */
-function largo_get_widget_basename($slug) {
-	if (preg_match('/^(.*)\-\d+$/', $slug, $matches)) {
-		return $matches[1];
-	}
-	return false;
-}
-/**
- * Utility function to get the number of a widget from the widget's slug
- */
-function largo_get_widget_number($slug) {
-	if (preg_match('/^.*\-(\d+)$/', $slug, $matches)) {
-		return $matches[1];
-	}
-	return false;
-}
-/**
- * Admin notices of older widgets
- */
-function largo_deprecated_footer_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __('You are using the <strong>Largo Footer Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
-
-function largo_deprecated_sidebar_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __( 'You are using the <strong>Largo Sidebar Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
-
 /* --------------------------------------------------------
  * Update helper functions
  * ------------------------------------------------------ */
@@ -707,7 +689,6 @@ function largo_widget_in_region( $widget_name, $region = 'article-bottom' ) {
 		if ( stripos( $widget, $widget_name ) === 0 ) return true;	//we found a copy of this widget! Note this may return a false positive if the widget we're checking is the same name (but shorter) as another kind of widget
 	}
 	return false;	// the widget wasn't there
-
 }
 
 /**
@@ -765,6 +746,29 @@ function largo_instantiate_widget( $kind, $instance_settings, $region ) {
 	$region_widgets[ $region ][] = $kind . '-widget-' . $instance_id;
 	update_option( 'sidebars_widgets', $region_widgets );
 
+}
+
+/**
+ * Utility function to get the basename of a widget from the widget's slug
+ *
+ * @since 0.5.3
+ */
+function largo_get_widget_basename($slug) {
+	if (preg_match('/^(.*)\-\d+$/', $slug, $matches)) {
+		return $matches[1];
+	}
+	return false;
+}
+/**
+ * Utility function to get the number of a widget from the widget's slug
+ *
+ * @since 0.5.3
+ */
+function largo_get_widget_number($slug) {
+	if (preg_match('/^.*\-(\d+)$/', $slug, $matches)) {
+		return $matches[1];
+	}
+	return false;
 }
 
 /* --------------------------------------------------------

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -218,6 +218,11 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		$this->assertEquals('largo-about-widget-2', $ret['id'], "Second widget: largo_instantiate_widget did not return an array whose index 'id' matched the created widget");
 		$this->assertEquals(1, $ret['place'], "Second widget: largo_instantiate_widget did not return an array whose index 'place' matched the created widget's position in its sidebar.");
 
+		// Regression test: If you create a bunch of widgets, they should not all have the same number
+		$ret3 = largo_instantiate_widget( 'largo-about', array( 'title' => '' ), 'article-bottom');
+		$ret4 = largo_instantiate_widget( 'largo-about', array( 'title' => '' ), 'article-bottom');
+		$this->assertFalse(($ret3['place'] == $ret4['place']), "Third and Fourth widgets: largo_instantiate_widget is not detecting the presence of existing widgets, and is assigning the same widget id to all new widgets.");
+
 		delete_option('sidebars_widgets');
 		update_option('sidebars_widgets', $widgets_backup);
 		unset($widgets_backup);

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -428,11 +428,11 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 			)
 		);
 		// You will want to check this later;
-		$this->assertFalse(largo_widget_in_region('widget_largo-sidebar-featured', 'sidebar-single'), "The Largo Sidebar Featured widget was left in the Sidebar Single widget area.");
-		$this->assertFalse(largo_widget_in_region('widget_largo-footer-featured', 'footer-1'), "The Largo Footer Featured widget was left in the Footer 1 widget area.");
-		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'sidebar-single'), "The new Largo Featured widget was not found in the Sidebar Single widget area.");
-		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'footer-1'), "The new Largo Featured widget was not found in the Footer 1 widget area.");
-		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'sidebar-main'), "The old Largo Featured widget was not found in the Sidebar Main widget area.");
+		$this->assertFalse(largo_widget_in_region('largo-sidebar-featured', 'sidebar-single'), "The Largo Sidebar Featured widget was left in the Sidebar Single widget area.");
+		$this->assertFalse(largo_widget_in_region('largo-footer-featured', 'footer-1'), "The Largo Footer Featured widget was left in the Footer 1 widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-featured', 'sidebar-single'), "The new Largo Featured widget was not found in the Sidebar Single widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-featured', 'footer-1'), "The new Largo Featured widget was not found in the Footer 1 widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-featured', 'sidebar-main'), "The old Largo Featured widget was not found in the Sidebar Main widget area.");
 	}
 }
 

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -200,11 +200,23 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		) );
 
 		// instantiate the widget
-		largo_instantiate_widget( 'largo-follow', array( 'title' => '' ), 'article-bottom');
+		$ret = largo_instantiate_widget( 'largo-follow', array( 'title' => '' ), 'article-bottom');
 
 		// Check
 		$widgets = get_option('sidebars_widgets');
-		$this->assertEquals('largo-follow-widget-2', $widgets['article-bottom'][0]);
+		$this->assertEquals('largo-follow-widget-2', $widgets['article-bottom'][0], "First widget: largo_instantiate_widget did not create the expected Largo Follow widget in the first position of the Article Bottom sidebar.");
+		$this->assertInternalType('array', $ret, "First widget: largo_instantiate_widget did not return an array");
+		$this->assertEquals('largo-follow-widget-2', $ret['id'], "First widget: largo_instantiate_widget did not return an array whose index 'id' matched the created widget");
+		$this->assertEquals(0, $ret['place'], "First widget: largo_instantiate_widget did not return an array whose index 'place' matched the created widget's position in its sidebar.");
+
+		// Add another widget
+		$ret = largo_instantiate_widget( 'largo-about', array( 'title' => '' ), 'article-bottom');
+
+		$widgets = get_option('sidebars_widgets');
+		$this->assertEquals('largo-about-widget-2', $widgets['article-bottom'][1], "Second widget: largo_instantiate_widget did not create the expected Largo About widget in the second position of the Article Bottom sidebar.");
+		$this->assertInternalType('array', $ret, "Second widget: largo_instantiate_widget did not return an array");
+		$this->assertEquals('largo-about-widget-2', $ret['id'], "Second widget: largo_instantiate_widget did not return an array whose index 'id' matched the created widget");
+		$this->assertEquals(1, $ret['place'], "Second widget: largo_instantiate_widget did not return an array whose index 'place' matched the created widget's position in its sidebar.");
 
 		delete_option('sidebars_widgets');
 		update_option('sidebars_widgets', $widgets_backup);

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -412,10 +412,17 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		largo_instantiate_widget('largo-sidebar-featured', array('title'=>'Foo'), 'sidebar-single');
 		largo_instantiate_widget('largo-footer-featured', array('title'=>'Bar'), 'footer-1');
 		largo_instantiate_widget('largo-featured', array('title'=>'Baz'), 'sidebar-main');
+		largo_instantiate_widget('largo-follow', array('title'=>'Baz'), 'homepage-alert');
+
+		// chek that things were set up correctly
+		$this->assertTrue(largo_widget_in_region('largo-sidebar-featured', 'sidebar-single'), "The Largo Sidebar Featured widget was left in the Sidebar Single widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-footer-featured', 'footer-1'), "The Largo Footer Featured widget was left in the Footer 1 widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-featured', 'sidebar-main'), "Setup: The old Largo Featured widget was not created in the Sidebar Main widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-follow', 'homepage-alert'), "Setup: The Largo Follow widget was not created in the Homepage Alert widget area.");
 
 		largo_replace_deprecated_widgets();
-		global $wp_registered_sidebars;
-		var_log($wp_registered_sidebars);
+		//global $wp_registered_sidebars;
+		//var_log($wp_registered_sidebars);
 
 		// Currently unused.
 		$updates = array(
@@ -434,6 +441,7 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		$this->assertTrue(largo_widget_in_region('largo-featured', 'sidebar-single'), "The new Largo Featured widget was not found in the Sidebar Single widget area.");
 		$this->assertTrue(largo_widget_in_region('largo-featured', 'footer-1'), "The new Largo Featured widget was not found in the Footer 1 widget area.");
 		$this->assertTrue(largo_widget_in_region('largo-featured', 'sidebar-main'), "The old Largo Featured widget was not found in the Sidebar Main widget area.");
+		$this->assertTrue(largo_widget_in_region('largo-follow', 'homepage-alert'), "The Largo Follow widget was not found in the Homepage Alert widget area.");
 	}
 }
 

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -417,6 +417,7 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		global $wp_registered_sidebars;
 		var_log($wp_registered_sidebars);
 
+		// Currently unused.
 		$updates = array(
 			'largo-sidebar-featured' => array(
 				'name' => 'largo-featured',

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -406,6 +406,28 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		largo_enable_series_if_landing_page();
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
+
+	function test_largo_replace_deprecated_widgets() {
+		// First, create some deprecated widgets
+		largo_instantiate_widget('largo-sidebar-featured', array('title'=>'Foo'), 'sidebar-single');
+		largo_instantiate_widget('largo-footer-featured', array('title'=>'Bar'), 'footer-1');
+		largo_instantiate_widget('largo-featured', array('title'=>'Baz'), 'header-ads');
+
+		largo_replace_deprecated_widgets();
+
+		$updates = array(
+			'largo-sidebar-featured' => array(
+				'name' => 'largo-featured',
+				'count' => 0,
+			),
+			'largo-sidebar-featured' => array(
+				'name' => 'largo-featured',
+				'count' => 0,
+			)
+		);
+		$all_widgets = get_option( 'sidebars_widgets ');
+		// You will want to check this later;
+	}
 }
 
 class LargoUpdateTestAjaxFunctions extends WP_Ajax_UnitTestCase {

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -411,9 +411,11 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		// First, create some deprecated widgets
 		largo_instantiate_widget('largo-sidebar-featured', array('title'=>'Foo'), 'sidebar-single');
 		largo_instantiate_widget('largo-footer-featured', array('title'=>'Bar'), 'footer-1');
-		largo_instantiate_widget('largo-featured', array('title'=>'Baz'), 'header-ads');
+		largo_instantiate_widget('largo-featured', array('title'=>'Baz'), 'sidebar-main');
 
 		largo_replace_deprecated_widgets();
+		global $wp_registered_sidebars;
+		var_log($wp_registered_sidebars);
 
 		$updates = array(
 			'largo-sidebar-featured' => array(
@@ -425,8 +427,12 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 				'count' => 0,
 			)
 		);
-		$all_widgets = get_option( 'sidebars_widgets ');
 		// You will want to check this later;
+		$this->assertFalse(largo_widget_in_region('widget_largo-sidebar-featured', 'sidebar-single'), "The Largo Sidebar Featured widget was left in the Sidebar Single widget area.");
+		$this->assertFalse(largo_widget_in_region('widget_largo-footer-featured', 'footer-1'), "The Largo Footer Featured widget was left in the Footer 1 widget area.");
+		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'sidebar-single'), "The new Largo Featured widget was not found in the Sidebar Single widget area.");
+		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'footer-1'), "The new Largo Featured widget was not found in the Footer 1 widget area.");
+		$this->assertTrue(largo_widget_in_region('widget_largo-featured', 'sidebar-main'), "The old Largo Featured widget was not found in the Sidebar Main widget area.");
 	}
 }
 


### PR DESCRIPTION
## Changes

- On every time updates run, `largo_replace_deprecated_widgets` will run.
- New function `largo_replace_deprecated_widgets` that replaces a list of widgets with new widgets. Configuration is via the `$upgrades` array in `largo_replace_depracated_widgets`, and is currently set to update `largo-footer-featured` and `largo-sidebar-featured` with `largo-featured`, which was introduced in v0.4.
- Tests in general for `largo_replace_deprecated_widgets`
- `largo_instantiate_widget` now returns an array with the slug and number (2-indexed :cry: ) for the successfully-created widget and its new place in the sidebar (0-indexed):

    array(
        'id' => 'largo-featured-5',
        'place' => '4'
    )

- Bugfix in `largo_instantiate_widget` for #728 where it was not checking `widget_widget-slug` in the options table, but just `widget-slug`, which means that it never saw widgets that already existed, and was wiping widget options with every update where `largo_instantiate_widget` was called.
- Regression test for the above fix
- New utility functions `largo_get_widget_number` and `largo_get_widget_basename` stolen from INN/wp-scripts to handle extracting the widget's slug and the widget's instance number from a sidebar entry. They're just regexes. Used in `largo_replace_deprecated_widgets`.

## Why

For #881:

- The Largo Sidebar Featured and Largo Footer Featured widgets have been deprecated for a long time. We decided it was time to remove them.
- `largo_instantiate_widget`'s complex return format provides necessary information that would not be easily discovered otherwise. As a bonus, it allows `largo_replace_deprecated_widgets` to shuffle widgets within sidebars so that the new widgets, appended to the end of the sidebar by `largo_instantiate_widget`, will replace their deprecated predecessors.

For #728:

- This bugfix was required for `largo_replace_deprecated_widgets` to function correctly.

## Questions:

- What more do we need to do to test this?
    - [ ] staging
    - [ ] backup prod
    - [ ] run on prod