### PR TITLE
add fb tracking pixel

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -93,7 +93,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 	function largo_footer_js() { ?>
 
 
-		<?php 
+		<?php
 		// Are the widgets that contain facebook social buttons loaded (or are we on single/author?)
 		if( largo_facebook_widget::is_rendered() || largo_follow_widget::is_rendered() || is_single() || is_author() ) : ?>
 
@@ -107,9 +107,42 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		  fjs.parentNode.insertBefore(js, fjs);
 		}(document, 'script', 'facebook-jssdk'));</script>
 
-		<?php endif; ?>
+		<?php endif;
 
-		<?php 
+		/**
+		 * Load Facebook Tracking Pixel if defined in Theme Options
+		 *
+		 * Function loads Facebook's JavaScript (circa September 2015) for
+		 * conversion tracking and send the default event.
+		 *
+		 * @link https://developers.facebook.com/docs/ads-for-websites/drive-conversions
+		 * @since 0.5.4
+		 */
+		 if( of_get_option( 'fb_tracking_pixel', true ) ) : ?>
+
+		 <script>(function() {
+		 var _fbq = window._fbq || (window._fbq = []);
+		 if (!_fbq.loaded) {
+		 	var fbds = document.createElement('script');
+		 	fbds.async = true;
+		 	fbds.src = '//connect.facebook.net/<?php echo get_locale() ?>/fbds.js';
+		 	var s = document.getElementsByTagName('script')[0];
+		 	s.parentNode.insertBefore(fbds, s);
+		 	_fbq.loaded = true;
+		 }
+		 _fbq.push(['addPixelId', '<?php echo of_get_option( 'fb_tracking_pixel'); ?>']);
+
+		 })();
+		 window._fbq = window._fbq || [];
+		 window._fbq.push(['track', 'PixelInitialized', {}]);
+		 </script>
+	 <!-- Fallback for environments not friendly to script -->
+		 <noscript>
+		 	<img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<?php echo of_get_option( 'fb_tracking_pixel'); ?>&amp;ev=PixelInitialized" />
+		 </noscript>
+		 <?php endif;
+		 /* END tracking pixel code */
+
 		// Are the widgets that contain twitter social buttons loaded (or are we on single/author?)
 		if( largo_twitter_widget::is_rendered() || largo_follow_widget::is_rendered() || is_single() || is_author() ) : ?>
 
@@ -162,4 +195,3 @@ if ( ! function_exists( 'largo_google_analytics' ) ) {
 	}
 }
 add_action( 'wp_head', 'largo_google_analytics' );
-

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -109,7 +109,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 
 		<?php endif;
 
-		/**
+		/*
 		 * Load Facebook Tracking Pixel if defined in Theme Options
 		 *
 		 * Function loads Facebook's JavaScript (circa September 2015) for
@@ -118,7 +118,8 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		 * @link https://developers.facebook.com/docs/ads-for-websites/drive-conversions
 		 * @since 0.5.4
 		 */
-		 if( of_get_option( 'fb_tracking_pixel', true ) ) : ?>
+		 $fb_pixel_id = of_get_option( 'fb_tracking_pixel', true );
+		 if( !empty($fb_pixel_id) ) : ?>
 
 		 <script>(function() {
 		 var _fbq = window._fbq || (window._fbq = []);
@@ -130,7 +131,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		 	s.parentNode.insertBefore(fbds, s);
 		 	_fbq.loaded = true;
 		 }
-		 _fbq.push(['addPixelId', '<?php echo of_get_option( 'fb_tracking_pixel'); ?>']);
+		 _fbq.push(['addPixelId', '<?php echo $fb_pixel_id; ?>']);
 
 		 })();
 		 window._fbq = window._fbq || [];
@@ -138,7 +139,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		 </script>
 	 <!-- Fallback for environments not friendly to script -->
 		 <noscript>
-		 	<img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<?php echo of_get_option( 'fb_tracking_pixel' ); ?>&amp;ev=PixelInitialized" />
+		 	<img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<?php echo $fb_pixel_id; ?>&amp;ev=PixelInitialized" />
 		 </noscript>
 		 <?php endif;
 		 /* END tracking pixel code */

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -138,7 +138,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		 </script>
 	 <!-- Fallback for environments not friendly to script -->
 		 <noscript>
-		 	<img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<?php echo of_get_option( 'fb_tracking_pixel'); ?>&amp;ev=PixelInitialized" />
+		 	<img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<?php echo of_get_option( 'fb_tracking_pixel' ); ?>&amp;ev=PixelInitialized" />
 		 </noscript>
 		 <?php endif;
 		 /* END tracking pixel code */

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -118,7 +118,7 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 		 * @link https://developers.facebook.com/docs/ads-for-websites/drive-conversions
 		 * @since 0.5.4
 		 */
-		 $fb_pixel_id = of_get_option( 'fb_tracking_pixel', true );
+		 $fb_pixel_id = of_get_option( 'fb_tracking_pixel' );
 		 if( !empty($fb_pixel_id) ) : ?>
 
 		 <script>(function() {

--- a/options.php
+++ b/options.php
@@ -279,7 +279,7 @@ function optionsframework_options() {
 	 * 
 	 *  1 - show social icons in sticky footer.
 	 *  0 - do not show social icons in the sticky footer.
-	 * 
+	 *
 	 * @since 0.5
 	 */
 	$options[] = array(
@@ -290,9 +290,8 @@ function optionsframework_options() {
 
 	/**
 	 * Which social icons should be shown in the sticky footer.
-	 * 
+	 *
 	 *  defaults: $footer_utility_buttons_defaults - facebook, twitter and email.
-	 * 
 	 * @since 0.5
 	 */
 	$options[] = array(
@@ -520,7 +519,7 @@ function optionsframework_options() {
 			'1col' => $imagepath . 'footer-1col.png'
 			// Want to add something to this list in a child theme? Use the largo_options filter!
 		)
-	
+
 	);
 
 	/*
@@ -655,6 +654,12 @@ function optionsframework_options() {
 		'id' 	=> 'fb_app_id',
 		'std' 	=> '',
 		'type' 	=> 'text');
+
+	$options[] = array(
+			'desc' 	=> __('<strong>Facebook Tracking Pixel ID.</strong> Unique numerical ID (one per Facebook Ads account) to enable tracking of site visitors and targeting of specific Facebook ads at your audience.', 'largo'),
+			'id' 	=> 'fb_tracking_pixel',
+			'std' 	=> '',
+			'type' 	=> 'text');
 
 	$options[] = array(
 		'desc' 	=> __('<strong>Bitly site verification.</strong> This is a string of numbers and letters used to verify your site with bitly analytics.', 'largo'),


### PR DESCRIPTION
## Adds facebook audience conversion tracking pixel:
https://developers.facebook.com/docs/ads-for-websites/website-custom-audiences/getting-started#install-the-pixel

Facebook loads this pixel to allow audience conversion and passing of information.

### Notes
* NEW OPTION in database `fb_tracking_pixel` using the options framework. 
    * *Note for Changelog*
* Adds new script enqueued in `inc/enqueue.php` in the site footer if option is set

### Future Notes
I just added the base tracking of "pixel initiated" blanket to the site (loads on every page). When a logged in facebook user loads the site, information is passed via the pixel. 

In the future, additional parameters can be passed including search queries, the category of content (i.e. Environment) and other page meta. This allows deeply targeted ads such as "Show this ad to Facebook users who have read an Environmental story." 
