### PR TITLE
Use content-archive partial for LMP in series without a landing page

### DIFF
--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -176,7 +176,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 
 		// Non-series-landing series archives
 		if ( isset($post_query->query_vars['series']) && $post_query->query_vars['series'] != '' ) {
-			$partial = 'series';
+			$partial = 'archive';
 		}
 
 		// argolinks post type


### PR DESCRIPTION
Fixes #954 where the non-landing page series archive's Load More Posts button was using `partials/content-series.php` instead of the archive partial, leading to incomplete posts.