### PR TITLE
Fix lack of caption shortcode when non-caption image credit attributes are set

### DIFF
--- a/inc/images.php
+++ b/inc/images.php
@@ -98,9 +98,14 @@ function largo_media_sideload_image($file, $post_id, $desc=null) {
 /**
  * Set the default image link to 'none'
  *
+ * This is so that we can eventually do away with largo_attachment_image_link_remove_filter
+ *
  * @since 0.5.4
+ * @see largo_attachment_image_link_remove_filter
  */
-function largo_image_default_link_type() {
-	update_option('image_default_link_type','none');
+if ( ! function_exists( 'largo_image_default_link_type' ) ) {
+	function largo_image_default_link_type() {
+		update_option('image_default_link_type','none');
+	}
 }
 add_action('admin_init', 'largo_image_default_link_type');

--- a/inc/images.php
+++ b/inc/images.php
@@ -10,14 +10,14 @@
 function largo_attachment_image_link_remove_filter( $content ) {
 	$content =
     preg_replace(
-      array('{<a(.*?)(wp-att|wp-content\/uploads)[^>]*><img}',
+      array('{<a(.*?)(wp-att|wp-content\/uploads|files)[^>]*><img}',
         '{ wp-image-[0-9]*" /></a>}'),
       array('<img','" />'),
       $content
     );
 	return $content;
 }
-add_filter( 'the_content', 'largo_attachment_image_link_remove_filter' );
+#add_filter( 'the_content', 'largo_attachment_image_link_remove_filter' );
 
 /**
  * Load the picturefill.wp plugin
@@ -94,3 +94,13 @@ function largo_media_sideload_image($file, $post_id, $desc=null) {
 		return $id;
 	}
 }
+
+/**
+ * Set the default image link to 'none'
+ *
+ * @since 0.5.4
+ */
+function largo_image_default_link_type() {
+	update_option('image_default_link_type','none');
+}
+add_action('admin_init', 'largo_image_default_link_type');

--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -257,7 +257,9 @@ class Media_Credit {
             return esc_attr( $this->credit );
         } elseif ( $this->org ) {
             return esc_attr( $this->org );
-        }
+        } else {
+			return false;
+		}
     }
 
     function update( $field, $value ) {

--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -142,18 +142,14 @@ class Navis_Media_Credit {
     function add_caption_shortcode( $html, $id, $caption, $title, $align, $url, $size, $alt = '' ) {
         $creditor = navis_get_media_credit( $id );
 
-        if ( empty( $caption ) && !$creditor->to_string()) {
-            return $html;
-        };
-
         $id = ( 0 < (int) $id ) ? 'attachment_' . $id : '';
         if ( ! preg_match( '/width="([0-9]+)/', $html, $matches ) )
             return $html;
 
         $width = $matches[1];
 
-        // XXX: not sure what this does
-        $html = preg_replace( '/(class=["\'][^\'"]*)align(none|left|right|center)\s?/', '$1', $html );
+        // Tries to remove the class "align*" in the passed $html
+        $html = preg_replace( '/(class=["\'][^\'"]*)align(none|left|right|center)/', '$1', $html );
         if ( empty($align) )
             $align = 'none';
 
@@ -193,7 +189,13 @@ class Navis_Media_Credit {
         }
 
         // XXX: maybe remove module and image classes at some point
-        $out = sprintf( '<div %s class="wp-caption module image %s" style="max-width: %spx;">%s', $id, $align, $width, do_shortcode( $content ) );
+        $out = sprintf(
+			'<div %s class="wp-caption module image %s" style="max-width: %spx;">%s',
+			$id,
+			$align,
+			$width,
+			do_shortcode( $content )
+		);
         if ( $credit ) {
             $out .= sprintf( '<p class="wp-media-credit">%s</p>', $credit );
         }

--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -135,10 +135,21 @@ class Navis_Media_Credit {
     }
 
 
-    /**
-     * navis_add_caption_shortcode(): replaces the built-in caption shortcode
-     * with one that supports a credit field.
-     */
+	/**
+	 * Navis' add_caption_shortcode(): replaces the built-in caption shortcode
+	 * with one that supports a credit field.
+	 *
+	 * @param string $html
+	 * @param string $id
+	 * @param string $caption Image caption
+	 * @param string $title Image title attribute
+	 * @param string $align Image css alignment property
+	 * @param string $url Image src URL
+	 * @param string $size Image size (thumbnail, medium, large, full, or one added with add_image_size() )
+	 * @param string $alt Alt text for the image
+	 *
+	 * @see the original WordPress function: https://developer.wordpress.org/reference/functions/image_add_caption/
+	 */
     function add_caption_shortcode( $html, $id, $caption, $title, $align, $url, $size, $alt = '' ) {
         $creditor = navis_get_media_credit( $id );
 


### PR DESCRIPTION
## Changes

- Fix to regex in `largo_attachment_image_link_remove_filter` for multisite upload URL support.
- The `image_default_link_type` option is coerced to `none` on every `admin_init` with a new pluggable function `largo_image_default_link_type`.
- Better documentation for `Navis_Media_Credit::add_caption_shortcode`
- `Navis_Media_Credit::to_string` returns `False` if it isn't able to make a string.
- Caption shortcodes will be added to images if any of the the following are set: caption, credit, organization.

## Why

For #933 and [HELPDESK-428](http://jira.inn.org/browse/HELPDESK-428).