### PR TITLE
Add a bunch of actions to the homepages

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -118,6 +118,14 @@ Here is the current list of hooks available in Largo (available as of v.0.4):
  - **largo_after_nav** - after the nav, before #main opening div tag
  - **largo_main_top** - directly after the opening #main div tag
  
+**home.php**
+
+These actions are run on all homepage templates, including the Legacy Three Column layout.
+
+ - **largo_before_sticky_posts** - Runs in the main column, before the sticky post would be rendered
+ - **largo_after_sticky_posts** - Runs in the main column, after where the sticky post would be rendered, before the homepage bottom area.
+ - **largo_after_homepage_hottom** - Runs after the homepage bottom area, before the termination of the main column.
+ 
 **sidebar.php**
 
  - **largo_before_sidebar** - before the sidebar opening div tag

--- a/home.php
+++ b/home.php
@@ -36,10 +36,15 @@ else
 	largo_render_homepage_layout($home_template);
 
 	if ($home_template !== 'LegacyThreeColumn') {
+
+		do_action('largo_before_sticky_posts');
+
 		// sticky posts box if this site uses it
 		if ( of_get_option( 'show_sticky_posts' ) ) {
 			get_template_part( 'partials/sticky-posts', 'home' );
 		}
+
+		do_action('largo_after_sticky_posts');
 
 		// bottom section, we'll either use a two-column widget area or a single column list of recent posts
 		if ( of_get_option('homepage_bottom') === 'widgets' ) {
@@ -47,6 +52,8 @@ else
 		} else if (of_get_option('homepage_bottom') === 'list') {
 			get_template_part('partials/home-post-list');
 		}
+
+		do_action('largo_after_homepage_bottom');
 	}
 ?>
 </div><!-- #content-->

--- a/homepages/templates/legacy-three-column.php
+++ b/homepages/templates/legacy-three-column.php
@@ -8,16 +8,23 @@
 
 	get_template_part('homepages/templates/top-stories');
 
+	do_action('largo_before_sticky_posts');
+
 	// sticky posts box if this site uses it
 	if (of_get_option('show_sticky_posts'))
 		get_template_part('partials/sticky-posts');
+
+	do_action('largo_after_sticky_posts');
 
 	// bottom section, we'll either use a two-column widget area or a single column list of recent posts
 	if (of_get_option('homepage_bottom') === 'widgets') {
 		get_template_part('partials/home', 'bottom-widget-area');
 	} else {
 		get_template_part('partials/home-post-list');
-	} ?>
+	}
+
+	do_action('largo_after_homepage_bottom');
+	?>
 </div>
 
 <div id="left-rail" class="span4">


### PR DESCRIPTION
## Changes

Adds the following actions to the Legacy Three Column and the other homepage layouts:

- `largo_before_sticky_posts`: Runs before the sticky post would be rendered
- `largo_after_sticky_posts`: Runs after the sticky post would be rendered, before the homepage bottom area.
- `largo_after_homepage_hottom`: Runs after the homepage bottom area.

These run before the termination of the main column, so any widgets placed here will be beside the sidebar, not below it.

## Why

To avoid making duplicate partials for [HELPDESK-438](http://jira.inn.org/browse/HELPDESK-438).

To make it easier to add things to a relatively-unmodified homepage, without authoring a whole new homepage template.

PR against master because this is a hotfix.