### PR TITLE
resubmitting PHP4 widget constructor removal against master branch

### DIFF
--- a/inc/widgets/largo-about.php
+++ b/inc/widgets/largo-about.php
@@ -4,12 +4,12 @@
  */
 class largo_about_widget extends WP_Widget {
 
-	function largo_about_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-about',
 			'description'	=> __('Show the site description from your theme options page', 'largo')
 		);
-		$this->WP_Widget( 'largo-about-widget', __('Largo About Site', 'largo'), $widget_ops);
+		parent::__construct( 'largo-about-widget', __('Largo About Site', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -4,12 +4,12 @@
  */
 class largo_author_widget extends WP_Widget {
 
-	function largo_author_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-author',
 			'description'	=> __('Show the author bio in a widget', 'largo')
 		);
-		$this->WP_Widget( 'largo-author-widget', __('Largo Author Bio', 'largo'), $widget_ops);
+		parent::__construct( 'largo-author-widget', __('Largo Author Bio', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-disclaimer-widget.php
+++ b/inc/widgets/largo-disclaimer-widget.php
@@ -4,12 +4,12 @@
  */
 class largo_disclaimer_widget extends WP_Widget {
 
-	function largo_disclaimer_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-disclaimer',
 			'description'	=> __('Show the article disclaimer', 'largo')
 		);
-		$this->WP_Widget( 'largo-disclaimer-widget', __('Largo Disclaimer', 'largo'), $widget_ops);
+		parent::__construct( 'largo-disclaimer-widget', __('Largo Disclaimer', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-donate.php
+++ b/inc/widgets/largo-donate.php
@@ -4,12 +4,12 @@
  */
 class largo_donate_widget extends WP_Widget {
 
-	function largo_donate_widget() {
+	function __construct() {
 		$widget_opts = array(
 			'classname' => 'largo-donate',
 			'description'=> __('Call-to-action for donations', 'largo')
 		);
-		$this->WP_Widget('largo-donate-widget', __('Largo Donate Widget', 'largo'),$widget_opts);
+		parent::__construct( 'largo-donate-widget', __('Largo Donate Widget', 'largo'),$widget_opts);
 	}
 	function widget( $args, $instance ) {
 		extract( $args );

--- a/inc/widgets/largo-explore-related.php
+++ b/inc/widgets/largo-explore-related.php
@@ -4,12 +4,12 @@
  */
 class largo_explore_related_widget extends WP_Widget {
 
-	function largo_explore_related_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-explore-related',
 			'description' 	=> __('A fancy tabbed interface showing posts related to the current post; formerly a theme option.', 'largo')
 		);
-		$this->WP_Widget( 'largo-explore-related-widget', __('Largo Explore Related', 'largo'), $widget_ops);
+		parent::__construct( 'largo-explore-related-widget', __('Largo Explore Related', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-facebook.php
+++ b/inc/widgets/largo-facebook.php
@@ -11,12 +11,12 @@ class largo_facebook_widget extends WP_Widget {
 	 */
 	private static $rendered = false;
 
-	function largo_facebook_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-facebook',
 			'description' 	=> __('Show a Facebook Like Box for your page', 'largo')
 		);
-		$this->WP_Widget( 'largo-facebook-widget', __('Largo Facebook Widget', 'largo'), $widget_ops);
+		parent::__construct( 'largo-facebook-widget', __('Largo Facebook Widget', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-featured.php
+++ b/inc/widgets/largo-featured.php
@@ -4,12 +4,12 @@
  */
 class largo_featured_widget extends WP_Widget {
 
-	function largo_featured_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-featured',
 			'description' 	=> 'Show recent featured posts with thumbnails and excerpts', 'largo-featured'
 		);
-		$this->WP_Widget( 'largo-featured-widget', __('Largo Featured Posts', 'largo'), $widget_ops);
+		parent::__construct( 'largo-featured-widget', __('Largo Featured Posts', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-follow.php
+++ b/inc/widgets/largo-follow.php
@@ -15,7 +15,7 @@ class largo_follow_widget extends WP_Widget {
 	 */
 	private static $rendered = false;
 
-	function largo_follow_widget() {
+	function __construct() {
 		/* Widget settings. */
 		$widget_ops = array(
 			'classname' 	=> 'largo-follow',
@@ -23,7 +23,7 @@ class largo_follow_widget extends WP_Widget {
 		);
 
 		/* Create the widget. */
-		$this->WP_Widget( 'largo-follow-widget', __('Largo Follow', 'largo'), $widget_ops );
+		parent::__construct( 'largo-follow-widget', __('Largo Follow', 'largo'), $widget_ops );
 
 		self::$rendered = true;
 	}

--- a/inc/widgets/largo-footer-featured.php
+++ b/inc/widgets/largo-footer-featured.php
@@ -4,12 +4,12 @@
  */
 class largo_footer_featured_widget extends WP_Widget {
 
-	function largo_footer_featured_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-footer-featured',
 			'description' 	=> '*DEPRECATED* Show recent featured posts with thumbnails and excerpts', 'largo-footer-featured'
 		);
-		$this->WP_Widget( 'largo-footer-featured-widget', __('Largo Footer Featured Posts', 'largo'), $widget_ops);
+		parent::__construct( 'largo-footer-featured-widget', __('Largo Footer Featured Posts', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-image-widget.php
+++ b/inc/widgets/largo-image-widget.php
@@ -22,10 +22,12 @@ class largo_image_widget extends WP_Widget {
 	 *
 	 * @author Modern Tribe, Inc.
 	 */
-	function Largo_Image_Widget() {
+	function __construct() {
 		$widget_ops = array( 'classname' => 'widget_sp_image', 'description' => __( 'Showcase a single image with a Title, URL, and a Description', 'largo' ) );
 		$control_ops = array( 'id_base' => 'widget_sp_image' );
-		$this->WP_Widget('widget_sp_image', __('Largo Image Widget', 'largo'), $widget_ops, $control_ops);
+		
+		parent::__construct( 'widget_sp_image', __('Largo Image Widget', 'largo'), $widget_ops, $control_ops);
+		
 		add_action( 'sidebar_admin_setup', array( $this, 'admin_setup' ) );
 		add_action( 'admin_head-widgets.php', array( $this, 'admin_head' ) );
 	}

--- a/inc/widgets/largo-post-series-links.php
+++ b/inc/widgets/largo-post-series-links.php
@@ -5,12 +5,12 @@
  */
 class largo_post_series_links_widget extends WP_Widget {
 
-	function largo_post_series_links_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-post-series-links',
 			'description' 	=> __('Shows the titles/descriptions of the series the post belongs to.', 'largo')
 		);
-		$this->WP_Widget( 'largo-post-series-links-widget', __('Largo Post Series Links', 'largo'), $widget_ops);
+		parent::__construct( 'largo-post-series-links-widget', __('Largo Post Series Links', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-prev-next-post-links.php
+++ b/inc/widgets/largo-prev-next-post-links.php
@@ -4,12 +4,12 @@
  */
 class largo_prev_next_post_links_widget extends WP_Widget {
 
-	function largo_prev_next_post_links_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-prev-next-post-links',
 			'description' 	=> __('Prev/next post navigation, typically at the bottom of single posts; formerly a theme option.', 'largo')
 		);
-		$this->WP_Widget( 'largo-prev-next-post-links-widget', __('Largo Prev/Next Links', 'largo'), $widget_ops);
+		parent::__construct( 'largo-prev-next-post-links-widget', __('Largo Prev/Next Links', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-recent-comments.php
+++ b/inc/widgets/largo-recent-comments.php
@@ -8,7 +8,7 @@ class largo_recent_comments_widget extends WP_Widget {
 	/**
 	 * Widget setup.
 	 */
-	function largo_recent_comments_widget() {
+	function __construct() {
 		/* Widget settings. */
 		$widget_ops = array(
 			'classname' 	=> 'largo-recent-comments',
@@ -16,7 +16,7 @@ class largo_recent_comments_widget extends WP_Widget {
 		);
 
 		/* Create the widget. */
-		$this->WP_Widget( 'largo-recent-comments-widget', __('Largo Recent Comments', 'largo'), $widget_ops );
+		parent::__construct( 'largo-recent-comments-widget', __('Largo Recent Comments', 'largo'), $widget_ops );
 		$this->alt_option_name = 'largo_recent_comments';
 
 		add_action( 'comment_post', array(&$this, 'flush_widget_cache') );

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -4,12 +4,12 @@
  */
 class largo_related_posts_widget extends WP_Widget {
 
-	function largo_related_posts_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-related-posts',
 			'description' 	=> __('Lists posts related to the current post', 'largo')
 		);
-		$this->WP_Widget( 'largo-related-posts-widget', __('Largo Related Posts', 'largo'), $widget_ops);
+		parent::__construct( 'largo-related-posts-widget', __('Largo Related Posts', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-series-posts.php
+++ b/inc/widgets/largo-series-posts.php
@@ -4,12 +4,12 @@
  */
 class largo_series_posts_widget extends WP_Widget {
 
-	function largo_series_posts_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-series-posts',
 			'description' 	=> __('Lists posts in the given series', 'largo')
 		);
-		$this->WP_Widget( 'largo-series-posts-widget', __('Largo Series Posts', 'largo'), $widget_ops);
+		parent::__construct( 'largo-series-posts-widget', __('Largo Series Posts', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-sidebar-featured.php
+++ b/inc/widgets/largo-sidebar-featured.php
@@ -4,12 +4,12 @@
  */
 class largo_sidebar_featured_widget extends WP_Widget {
 
-	function largo_sidebar_featured_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-sidebar-featured',
 			'description' 	=> __('*DEPRECATED* Show recent featured posts with thumbnails and excerpts', 'largo')
 		);
-		$this->WP_Widget( 'largo-sidebar-featured-widget', __('Largo Sidebar Featured Posts', 'largo'), $widget_ops);
+		parent::__construct( 'largo-sidebar-featured-widget', __('Largo Sidebar Featured Posts', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-tag-list.php
+++ b/inc/widgets/largo-tag-list.php
@@ -4,12 +4,12 @@
  */
 class largo_tag_list_widget extends WP_Widget {
 
-	function largo_tag_list_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-tag-list',
 			'description' 	=> __('A list of tags for the current post; formerly a theme option.', 'largo')
 		);
-		$this->WP_Widget( 'largo-tag-list-widget', __('Largo Tag List', 'largo'), $widget_ops);
+		parent::__construct( 'largo-tag-list-widget', __('Largo Tag List', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-taxonomy-list.php
+++ b/inc/widgets/largo-taxonomy-list.php
@@ -4,12 +4,12 @@
  */
 class largo_taxonomy_list_widget extends WP_Widget {
 
-	function largo_taxonomy_list_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-taxonomy-list',
 			'description' 	=> __('List all of the terms in a custom taxonomy with links', 'largo')
 		);
-		$this->WP_Widget( 'largo-taxonomy-list-widget', __('Largo Taxonomy List', 'largo'), $widget_ops);
+		parent::__construct( 'largo-taxonomy-list-widget', __('Largo Taxonomy List', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {

--- a/inc/widgets/largo-twitter.php
+++ b/inc/widgets/largo-twitter.php
@@ -11,12 +11,12 @@ class largo_twitter_widget extends WP_Widget {
 	 */
 	private static $rendered = false;
 
-	function largo_twitter_widget() {
+	function __construct() {
 		$widget_ops = array(
 			'classname' 	=> 'largo-twitter',
 			'description' 	=> __('Show a Twitter profile, list or search widget', 'largo')
 		);
-		$this->WP_Widget( 'largo-twitter-widget', __('Largo Twitter Widget', 'largo'), $widget_ops);
+		parent::__construct( 'largo-twitter-widget', __('Largo Twitter Widget', 'largo'), $widget_ops);
 	}
 
 	function widget( $args, $instance ) {


### PR DESCRIPTION
Per @aschweigert’s request, resubmitting #969 against master branch.

https://markjaquith.wordpress.com/2009/09/29/using-php5-object-constructors-in-wp-widget-api/
https://wiki.php.net/rfc/remove_php4_constructors

Resolves issue #949