### PR TITLE
Use minified version of LMP javascript, if LARGO_DEBUG isn't true. 

### DIFF
--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -15,11 +15,15 @@
 if ( !function_exists( 'largo_load_more_posts_enqueue_script' ) ) {
 	/**
 	 * Enqueue script for "load more posts" functionality
+	 *
+	 * @since 0.5.3
+	 * @global LARGO_DEBUG
 	 */
 	function largo_load_more_posts_enqueue_script() {
+		$suffix = (LARGO_DEBUG)? '' : '.min';
 		wp_enqueue_script(
 			'load-more-posts',
-			get_template_directory_uri() . '/js/load-more-posts.js',
+			get_template_directory_uri() . '/js/load-more-posts'. $suffix . '.js',
 			array('jquery'), null, false
 		);
 	}

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -11,6 +11,9 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_load_more_posts_enqueue_script() {
+		/**
+		 * This test does not, cannot test whether the global LARGO_DEBUG affects enqueueing.
+		 */
 		global $wp_scripts;
 		largo_load_more_posts_enqueue_script();
 		$this->assertTrue(!empty($wp_scripts->registered['load-more-posts']));


### PR DESCRIPTION
## Changes

- checks `LARGO_DEBUG` for whether to use `/js/load-more-posts.min.js` or `/js/load-more-posts.js` in the LMP enqueue.

## Debt

This change can't be tested without a way to change constants at runtime. I left a note in the test.

## Why

For #967.