### PR TITLE
Use correct query args to get correct partial for LMP, redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - WP_VERSION=4.1.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.2.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.3.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.4 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 # Only test the unittests branch for now
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ php:
 
 # WordPress version used in first build configuration.
 env:
-    - WP_VERSION=3.9.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.0.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.1.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
     - WP_VERSION=4.2.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=4.3.1 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 # Only test the unittests branch for now
 branches:

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -138,33 +138,35 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	function largo_load_more_posts_choose_partial($post_query) {
 		global $opt;
 
+		$qv = $post_query->query_vars;
+
 		// Default is to use partials/content-home.php
 		$partial = 'home';
 
 		// This might be a category, tag, search, date, author, non-landing-page series, or other other archive
 
 		// check if this query is for a category
-		if ( isset($post_query->category_name) && $post_query->category_name != '' ) {
+		if ( isset($qv['category_name']) && $qv['category_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for an author page
-		if ( isset($post_query->author_name) && $post_query->author_name != '' ) {
+		if ( isset($qv['author_name']) && $qv['author_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a tag
-		if ( isset($post_query->tag) && $post_query->tag != '' ) {
+		if ( isset($qv['tag']) && $qv['tag'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a search
-		if ( isset($post_query->s) && $post_query->s != '' ) {
+		if ( isset($qv['s']) && $qv['s'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a date, assuming that all date queries have a year.
-		if ( isset($post_query->year) && $post_query->year != 0 ) {
+		if ( isset($qv['year']) && $qv['year'] != 0 ) {
 			$partial = 'archive';
 		}
 
@@ -175,7 +177,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		}
 
 		// Non-series-landing series archives
-		if ( isset($post_query->query_vars['series']) && $post_query->query_vars['series'] != '' ) {
+		if ( isset($qv['series']) && $qv['series'] != '' ) {
 			$partial = 'archive';
 		}
 

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -45,6 +45,155 @@ class AjaxFunctionsTestAjaxFunctions extends WP_Ajax_UnitTestCase {
 		$this->post_count = 10;
 		$this->post_ids = $this->factory->post->create_many($this->post_count);
 		of_reset_options();
+
+		/**
+		 * A sample wordpress query that can be extended for use in tests like for largo_load_more_posts_choose_partial
+		 */
+		$this->post_query = new WP_Query(array(
+			'query_vars' => array (
+				'paged' => 2,
+				'post_status' => 'publish',
+				'posts_per_page' => 10,
+				'ignore_sticky_posts' => true,
+				'post__not_in' => array (),
+				'error' => '',
+				'm' => '',
+				'p' => 0,
+				'post_parent' => '',
+				'subpost' => '',
+				'subpost_id' => '',
+				'attachment' => '',
+				'attachment_id' => 0,
+				'name' => '',
+				'static' => '',
+				'pagename' => '',
+				'page_id' => 0,
+				'second' => '',
+				'minute' => '',
+				'hour' => '',
+				'day' => 0,
+				'monthnum' => 0,
+				'year' => 0,
+				'w' => 0,
+				'category_name' => '',
+				'tag' => '',
+				'cat' => '',
+				'tag_id' => '',
+				'author' => '',
+				'author_name' => '',
+				'feed' => '',
+				'tb' => '',
+				'comments_popup' => '',
+				'meta_key' => '',
+				'meta_value' => '',
+				'preview' => '',
+				'sentence' => '',
+				'fields' => '',
+				'menu_order' => '',
+				'category__in' => array (),
+				'category__not_in' => array (),
+				'category__and' => array (),
+				'post__in' => array (),
+				'tag__in' => array (),
+				'tag__not_in' => array (),
+				'tag__and' => array (),
+				'tag_slug__in' => array (),
+				'tag_slug__and' => array (),
+				'post_parent__in' => array (),
+				'post_parent__not_in' => array (),
+				'author__in' => array (),
+				'author__not_in' => array (),
+				'suppress_filters' => false,
+				'cache_results' => true,
+				'update_post_term_cache' => true,
+				'update_post_meta_cache' => true,
+				'post_type' => 'any',
+				'nopaging' => false,
+				'comments_per_page' => '50',
+				'no_found_rows' => false,
+				'search_terms_count' => 1,
+				'search_terms' => array (),
+				'search_orderby_title' => array (),
+				'order' => 'DESC',
+			),
+			'tax_query' => array( // Should be a WP_Tax_Query
+				'queries' => array (),
+				'relation' => 'AND',
+				'table_aliases' => array (),
+				'queried_terms' => array (),
+				'primary_table' => 'wp_46_posts',
+				'primary_id_column' => 'ID',
+			),
+			'meta_query' => array( // should be a WP_Meta_Query
+				'queries' => array (),
+				'relation' => NULL,
+				'meta_table' => NULL,
+				'meta_id_column' => NULL,
+				'primary_table' => NULL,
+				'primary_id_column' => NULL,
+				'table_aliases' => array (),
+				'clauses' => array (),
+			),
+			'date_query' => false,
+			'post_count' => 10,
+			'current_post' => -1,
+			'in_the_loop' => false,
+			'comment_count' => 0,
+			'current_comment' => -1,
+			'found_posts' => '63',
+			'max_num_pages' => 7,
+			'max_num_comment_pages' => 0,
+			'is_single' => false,
+			'is_preview' => false,
+			'is_page' => false,
+			'is_archive' => false,
+			'is_date' => false,
+			'is_year' => false,
+			'is_month' => false,
+			'is_day' => false,
+			'is_time' => false,
+			'is_author' => false,
+			'is_category' => false,
+			'is_tag' => false,
+			'is_tax' => false,
+			'is_search' => true,
+			'is_feed' => false,
+			'is_comment_feed' => false,
+			'is_trackback' => false,
+			'is_home' => true,
+			'is_404' => false,
+			'is_comments_popup' => false,
+			'is_paged' => true,
+			'is_admin' => false,
+			'is_attachment' => false,
+			'is_singular' => false,
+			'is_robots' => false,
+			'is_posts_page' => false,
+			'is_post_type_archive' => false,
+			'query_vars_hash' => 'b788e6e7c1f6a66fc9c1445dd3168165',
+			'query_vars_changed' => false,
+			'thumbnails_cached' => false,
+			'stopwords' => array (), // Normally a long list of words that should be ignored in searches.
+			'compat_fields' => array (
+				0 => 'query_vars_hash',
+				1 => 'query_vars_changed',
+			),
+			'compat_methods' => array (
+				0 => 'init_query_flags',
+				1 => 'parse_tax_query',
+			),
+			'query' => array (
+				'paged' => 2,
+				'post_status' => 'publish',
+				'posts_per_page' => 10,
+				'ignore_sticky_posts' => true,
+				'post__not_in' => NULL,
+				's' => 'chicken',
+			),
+			'request' => '', // Normally a long SQL query.
+			'posts' => array ()
+		));
+		// end $this->post_query
 	}
 
 	function test_largo_load_more_posts() {
@@ -61,6 +210,85 @@ class AjaxFunctionsTestAjaxFunctions extends WP_Ajax_UnitTestCase {
 				$this->assertTrue((bool) $pos);
 			}
 		}
+	}
+
+	/*
+	 * Apologies in advance for the mess here. This will be using real queries from vagrant, and there will consequently be a mess.
+	 */
+	function test_largo_load_more_posts_choose_partial_home() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('home', $ret, "Didn't return home on an empty query.");
+	}
+	function test_largo_load_more_posts_choose_partial_category() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['category_name'] = 'foo';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return 'archive' on a category query.");
+	}
+	function test_largo_load_more_posts_choose_partial_author() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['author_name'] = 'foo';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return home on an empty query.");
+	}
+	function test_largo_load_more_posts_choose_partial_tag() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['tag'] = 'foo';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return home on an empty query.");
+	}
+	function test_largo_load_more_posts_choose_partial_search() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['s'] = 'foo';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return home on an empty query.");
+	}
+	function test_largo_load_more_posts_choose_partial_date() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['year'] = '1992';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return home on an empty query.");
+	}
+	function test_largo_load_more_posts_choose_partial_series_landing_page() {
+		$_POST['is_series_landing'] = true;
+		$_POST['opt'] = 'Boo!';
+		global $opt;
+		$backup = $opt;
+		$pq = $this->post_query;
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('series', $ret, "Didn't return 'series' on a series landing page");
+		$this->assertEquals('Boo!', $opt, 'Did not set the global $opt to $_POST[\'opt\'] on a series landing page.');
+		$opt = $backup;
+	}
+	function test_largo_load_more_posts_choose_partial_series() {
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+		$pq->query_vars['series'] = 'foo';
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('archive', $ret, "Didn't return 'archive' on a series without a landing page.");
+	}
+	// Will be removed with https://github.com/INN/Largo/issues/926
+	function test_largo_load_more_posts_choose_partial_argolinks() {
+		$this->markTestIncomplete();
+		$_POST['is_series_landing'] = false;
+		$pq = $this->post_query;
+
+		$ret = largo_load_more_posts_choose_partial($pq);
+		$this->assertEquals('argolinks', $ret, "Didn't return 'argolinks' when the returned post type was argolinks.");
 	}
 
 	/*


### PR DESCRIPTION
## Changes

- `largo_load_more_posts_choose_partial` now checks for arguments in indices on the array on the `query_vars` property of the `WP_Query` object fed to it, rather than looking for the arguments directly in the `WP_Query` object passed.
- tests, which #925 did *not* have
- removes WordPress versions 3.9 and 4.0 from .travis.yml, and with those removes Largo's support for those versions of WordPress.
- adds 4.3.1 to .travis.yml. 

## Why

Because the tag archive on http://womensenews.largoproject.org/tag/kenya/ was using `partials/content-home.php` instead of the appropriate one. And that's because none of the conditionals in `largo_load_more_posts_choose_partial` were tripping.

Tests to prevent this happening again.

The giant set of arguments in `tests/inc/test-ajax-functions.php` is so we're playing with like-live data.

The change in Travis is because of commentary on https://github.com/INN/Largo/pull/1000

For [WE-15](http://jira.inn.org/browse/WE-15) and #868.