### PR TITLE
Correcting bug in largo_load_more_posts_choose_partial

### DIFF
--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -122,8 +122,8 @@ if ( !function_exists( 'largo_load_more_posts' ) ) {
 			while ( $query->have_posts() ) : $query->the_post();
 				// Use largo_get_partial_by_post_type here as well as in the search archive,
 				// to ensure that LMP posts will be using the partial set by the child theme for that post type.
-				$partial = largo_get_partial_by_post_type($partial, get_post_type(), $partial);
-				get_template_part( 'partials/content', $partial );
+				$post_type_partial = largo_get_partial_by_post_type($partial, get_post_type(), $partial);
+				get_template_part( 'partials/content', $post_type_partial );
 			endwhile;
 		}
 		wp_die();

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -75,9 +75,11 @@ if ( !function_exists( 'largo_load_more_posts_data' ) ) {
 if ( !function_exists( 'largo_load_more_posts' ) ) {
 	/**
 	 * Renders markup for a page of posts and sends it back over the wire.
+	 *
 	 * @global $opt
 	 * @global $_POST
-	 * @see largo_load_more_posts_choose_partial
+	 * @uses largo_load_more_posts_choose_partial
+	 * @uses largo_get_partial_by_post_type
 	 */
 	function largo_load_more_posts() {
 
@@ -118,6 +120,9 @@ if ( !function_exists( 'largo_load_more_posts' ) ) {
 
 			// Render all the posts
 			while ( $query->have_posts() ) : $query->the_post();
+				// Use largo_get_partial_by_post_type here as well as in the search archive,
+				// to ensure that LMP posts will be using the partial set by the child theme for that post type.
+				$partial = largo_get_partial_by_post_type($partial, get_post_type(), $partial);
 				get_template_part( 'partials/content', $partial );
 			endwhile;
 		}
@@ -138,6 +143,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 * @global $opt
 	 * @global $_POST
 	 * @see largo_load_more_posts
+	 * @since 0.5.3
 	 */
 	function largo_load_more_posts_choose_partial($post_query) {
 		global $opt;

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -133,7 +133,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 *
 	 * Includes a "largo_lmp_template_partial" filter to allow for modifying the value $partial.
 	 *
-	 * @param object $post_query The query object being used to generate LMP markup
+	 * @param Array $post_query The WP_Query->query_vars array being used to generate LMP markup
 	 * @return string $partial The slug of partial that should be loaded.
 	 * @global $opt
 	 * @global $_POST
@@ -141,6 +141,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 */
 	function largo_load_more_posts_choose_partial($post_query) {
 		global $opt;
+		var_log($post_query);
 
 		// Default is to use partials/content-home.php
 		$partial = 'home';
@@ -150,6 +151,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		// check if this query is for a category
 		if ( isset($post_query['category_name']) && $post_query['category_name'] != '' ) {
 			$partial = 'archive';
+		} else {
 		}
 
 		// check if this query is for an author page
@@ -173,7 +175,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		}
 
 		// Series landing pages
-		if ($_POST['is_series_landing'] == 'true') {
+		if ( isset($_POST['is_series_landing']) && $_POST['is_series_landing'] == 'true') {
 			$partial = 'series';
 			$opt = $_POST['opt'];
 		}

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -170,7 +170,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 
 		// check if this query is for a search
 		if ( isset($post_query['s']) && $post_query['s'] != '' ) {
-			$partial = 'archive';
+			$partial = 'search';
 		}
 
 		// check if this query is for a date, assuming that all date queries have a year.

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -150,7 +150,6 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		// check if this query is for a category
 		if ( isset($post_query['category_name']) && $post_query['category_name'] != '' ) {
 			$partial = 'archive';
-		} else {
 		}
 
 		// check if this query is for an author page

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -141,7 +141,6 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 */
 	function largo_load_more_posts_choose_partial($post_query) {
 		global $opt;
-		var_log($post_query);
 
 		// Default is to use partials/content-home.php
 		$partial = 'home';

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -190,8 +190,8 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		 * Filter to modify the Load More Posts template partial.
 		 *
 		 * @since 0.5.3
-		 * @param string $partial The string represeting the template partial to use for the current context
-		 * @param object $post_query The query object used to produce the LMP markup
+		 * @param Atring $partial The string represeting the template partial to use for the current context
+		 * @param Array $post_query The query_vars property of the WP_Query used to produce the LMP markup. It's an array.
 		 */
 		$partial = apply_filters( 'largo_lmp_template_partial', $partial, $post_query );
 

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -116,7 +116,7 @@ if ( !function_exists( 'largo_load_more_posts' ) ) {
 
 		if ( $query->have_posts() ) {
 			// Choose the correct partial to load here
-			$partial = largo_load_more_posts_choose_partial($query->query_vars);
+			$partial = largo_load_more_posts_choose_partial($query);
 
 			// Render all the posts
 			while ( $query->have_posts() ) : $query->the_post();
@@ -138,7 +138,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 *
 	 * Includes a "largo_lmp_template_partial" filter to allow for modifying the value $partial.
 	 *
-	 * @param Array $post_query The WP_Query->query_vars array being used to generate LMP markup
+	 * @param WP_Query $post_query The WP_Query being used to generate LMP markup
 	 * @return string $partial The slug of partial that should be loaded.
 	 * @global $opt
 	 * @global $_POST
@@ -147,6 +147,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 	 */
 	function largo_load_more_posts_choose_partial($post_query) {
 		global $opt;
+		$query_vars = $post_query->query_vars;
 
 		// Default is to use partials/content-home.php
 		$partial = 'home';
@@ -154,27 +155,27 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		// This might be a category, tag, search, date, author, non-landing-page series, or other other archive
 
 		// check if this query is for a category
-		if ( isset($post_query['category_name']) && $post_query['category_name'] != '' ) {
+		if ( isset($query_vars['category_name']) && $query_vars['category_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for an author page
-		if ( isset($post_query['author_name']) && $post_query['author_name'] != '' ) {
+		if ( isset($query_vars['author_name']) && $query_vars['author_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a tag
-		if ( isset($post_query['tag']) && $post_query['tag'] != '' ) {
+		if ( isset($query_vars['tag']) && $query_vars['tag'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a search
-		if ( isset($post_query['s']) && $post_query['s'] != '' ) {
+		if ( isset($query_vars['s']) && $query_vars['s'] != '' ) {
 			$partial = 'search';
 		}
 
 		// check if this query is for a date, assuming that all date queries have a year.
-		if ( isset($post_query['year']) && $post_query['year'] != 0 ) {
+		if ( isset($query_vars['year']) && $query_vars['year'] != 0 ) {
 			$partial = 'archive';
 		}
 
@@ -185,7 +186,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		}
 
 		// Non-series-landing series archives
-		if ( isset($post_query['series']) && $post_query['series'] != '' ) {
+		if ( isset($query_vars['series']) && $query_vars['series'] != '' ) {
 			$partial = 'archive';
 		}
 
@@ -195,9 +196,20 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		/**
 		 * Filter to modify the Load More Posts template partial.
 		 *
+		 * When building your own filter, you must set the fourth parameter of add_filter to 2:
+		 *
+		 *     function your_filter_name($partial, $post_type, $context) {
+		 *         // things
+		 *         return $partials;
+		 *     }
+		 *     add_filter( 'largo_lmp_template_partial', 'your_filter_name', 10, 2);
+		 *                                                                       ^
+		 * Without setting '2', your filter will not be passed the $post_type or $context arguments.
+		 * In order to set '2', you must set the third parameter of add_filter, which defaults to 10. it is safe to leave that at 10.
+		 *
 		 * @since 0.5.3
-		 * @param Atring $partial The string represeting the template partial to use for the current context
-		 * @param Array $post_query The query_vars property of the WP_Query used to produce the LMP markup. It's an array.
+		 * @param String $partial The string represeting the template partial to use for the current context
+		 * @param WP_Query $post_query The WP_Query object used to produce the LMP markup.
 		 */
 		$partial = apply_filters( 'largo_lmp_template_partial', $partial, $post_query );
 

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -114,7 +114,7 @@ if ( !function_exists( 'largo_load_more_posts' ) ) {
 
 		if ( $query->have_posts() ) {
 			// Choose the correct partial to load here
-			$partial = largo_load_more_posts_choose_partial($query);
+			$partial = largo_load_more_posts_choose_partial($query->query_vars);
 
 			// Render all the posts
 			while ( $query->have_posts() ) : $query->the_post();
@@ -148,27 +148,27 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		// This might be a category, tag, search, date, author, non-landing-page series, or other other archive
 
 		// check if this query is for a category
-		if ( isset($post_query->category_name) && $post_query->category_name != '' ) {
+		if ( isset($post_query['category_name']) && $post_query['category_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for an author page
-		if ( isset($post_query->author_name) && $post_query->author_name != '' ) {
+		if ( isset($post_query['author_name']) && $post_query['author_name'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a tag
-		if ( isset($post_query->tag) && $post_query->tag != '' ) {
+		if ( isset($post_query['tag']) && $post_query['tag'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a search
-		if ( isset($post_query->s) && $post_query->s != '' ) {
+		if ( isset($post_query['s']) && $post_query['s'] != '' ) {
 			$partial = 'archive';
 		}
 
 		// check if this query is for a date, assuming that all date queries have a year.
-		if ( isset($post_query->year) && $post_query->year != 0 ) {
+		if ( isset($post_query['year']) && $post_query['year'] != 0 ) {
 			$partial = 'archive';
 		}
 
@@ -179,7 +179,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		}
 
 		// Non-series-landing series archives
-		if ( isset($post_query->query_vars['series']) && $post_query->query_vars['series'] != '' ) {
+		if ( isset($post_query['series']) && $post_query['series'] != '' ) {
 			$partial = 'archive';
 		}
 

--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -216,3 +216,47 @@ function largo_url_to_attachmentid($url) {
     	return false;
 
 }
+
+/**
+ * Given a post type and an optional context, return the partial that should be loaded for that sort of post.
+ *
+ * The default context is search, and the context isn't actually used by this function,
+ * but it is passed to the filter this function runs, largo_partial_by_post_type.
+ *
+ * @link https://github.com/INN/Largo/issues/1023
+ * @param string $partial Required, the default partial in this context.
+ * @param string $post_type Required, the given post's post type
+ * @param string $context Required, the context of this partial.
+ * @return string The partial that should be loaded. This defaults to 'search'.
+ * @filter largo_partial_by_post_type
+ * @since 0.5.4
+ */
+function largo_get_partial_by_post_type($partial, $post_type, $context) {
+	// Remove this conditional in #926.
+	if ($post_type == 'argolinks') {
+		$partial = 'argolinks';
+	}
+
+	/**
+	 * Filter the output of largo_get_partial_by_post_type
+	 *
+	 * When building your own filter, you must set the fourth parameter of add_filter to 3:
+	 *
+	 *     function your_filter_name($partial, $post_type, $context) {
+	 *         // things
+	 *         return $partial;
+	 *     }
+	 *     add_filter('largo_partial_by_post_type', 'your_filter_name', 10, 3);
+	 *                                                                      ^
+	 * Without setting '3', your filter will not be passed the $post_type or $context arguments.
+	 * In order to set '3', you must set the third parameter of add_filter, which defaults to 10. it is safe to leave that at 10.
+	 *
+	 * @since 0.5.4
+	 * @param string $partial The string representing the template partial to use for the current post
+	 * @param string $post_type The current post's post_type
+	 * @param string $context The context in which this filter is being called, defaulting to search.
+	 */
+	$partial = apply_filters('largo_partial_by_post_type', $partial, $post_type, $context);
+
+	return $partial;
+}

--- a/partials/content-search.php
+++ b/partials/content-search.php
@@ -1,48 +1,24 @@
 <?php
 /*
- * The default template for displaying content
+ * The template for displaying the search partial.
  *
  * @package Largo
  */
 $tags = of_get_option( 'tag_display' );
 $hero_class = largo_hero_class( $post->ID, FALSE );
 $values = get_post_custom( $post->ID );
-$featured = has_term( 'homepage-featured', 'prominence' );
-
+?>
 <article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
 
 	<?php
-		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails or videos.
-		if ( $featured && ( has_post_thumbnail() || $values['youtube_url'] ) ) {
-	?>
-		<header>
-			<div class="hero span12 <?php echo $hero_class; ?>">
-			<?php
-				if ( $youtube_url = $values['youtube_url'][0] ) {
-					echo '<div class="embed-container">';
-					largo_youtube_iframe_from_url( $youtube_url );
-					echo '</div>';
-				} elseif( has_post_thumbnail() ){
-					echo('<a href="' . get_permalink() . '" title="' . the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ', 'echo' => false )) . '" rel="bookmark">');
-					the_post_thumbnail( 'full' );
-					echo('</a>');
-				}
-			?>
-			</div>
-		</header>
-	<?php
-		} // end Homepage Featured thumbnail block
 		$entry_classes = 'entry-content';
-		if ( $featured ) $entry_classes .= ' span10 with-hero';
 		echo '<div class="' . $entry_classes . '">';
 
 		if ( largo_has_categories_or_tags() && $tags === 'top' ) {
 		 	echo '<h5 class="top-tag">' . largo_top_term( $args = array( 'echo' => FALSE ) ) . '</h5>';
 		}
 
-		if ( !$featured ) {
-			echo '<div class="has-thumbnail '.$hero_class.'"><a href="' . get_permalink() . '">' . get_the_post_thumbnail() . '</a></div>';
-		}
+		echo '<div class="has-thumbnail '.$hero_class.'"><a href="' . get_permalink() . '">' . get_the_post_thumbnail() . '</a></div>';
 	?>
 
 	 	<h2 class="entry-title">

--- a/partials/content.php
+++ b/partials/content.php
@@ -8,13 +8,24 @@ $tags = of_get_option( 'tag_display' );
 $hero_class = largo_hero_class( $post->ID, FALSE );
 $values = get_post_custom( $post->ID );
 $featured = has_term( 'homepage-featured', 'prominence' );
+
+// Is this a search page?
+if (
+	is_search() ||
+	isset($wp_query->query_vars['s']) ||
+	property_exists(json_decode(stripslashes($_POST['query'])), 's') // the LMP query is JSON.
+) {
+	$search = true;
+} else {
+	$search = false;
+}
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
 
 	<?php
-		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term
-		if ( $featured && ( has_post_thumbnail() || $values['youtube_url'] ) ) {
+		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails or videos, but not on the search page.
+		if ( $featured && !$search && ( has_post_thumbnail() || $values['youtube_url'] ) ) {
 	?>
 		<header>
 			<div class="hero span12 <?php echo $hero_class; ?>">

--- a/search.php
+++ b/search.php
@@ -72,11 +72,8 @@ get_header();
 
 			<?php
 				while ( have_posts() ) : the_post();
-					if ( get_post_type( $post ) == 'argolinks' ) {
-						get_template_part( 'partials/content', 'argolinks' );
-					} else {
-						get_template_part( 'partials/content', 'search' );
-					}
+					$partial = largo_get_partial_by_post_type('search', get_post_type( $post ), 'search');
+					get_template_part( 'partials/content', $partial );
 				endwhile;
 				largo_content_nav( 'nav-below' );
 			} else {

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -45,7 +45,6 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_load_more_posts_choose_partial() {
-		global $opt;
 		$qv = array();
 
 		// Note: These options are arrayed in the order that they are tested for in largo_load_more_posts_choose_partial($qv)
@@ -70,46 +69,49 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		$qv['category_name'] = 'foo';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing category');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Author archive page
 		$qv['author_name'] = 'admin';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing author archive');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// tag
 		$qv['tag'] = 'tag';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing tag');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Search
 		$qv['s'] = 'search';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing search');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Date archive
 		$qv['year'] = '2015';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing date query with "year" => "2015"');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// series landing pages
 		$_POST['is_series_landing'] = 'true';
+		$_POST['opt'] = 'foo';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('series', $ret, '');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		global $opt;
+		$this->assertEquals($opt, $_POST['opt'], 'global $opt was not set to the value supplied in $_POST["opt"]');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// non-series-landing series archives
 		$qv['series'] = 'series';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, '');
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// @todo find way to test get_post_type() returning argolinks.
-		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Test the filter.
 	}

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -86,7 +86,7 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		// Search
 		$qv['s'] = 'search';
 		$ret = largo_load_more_posts_choose_partial($qv);
-		$this->assertEquals('archive', $ret, 'Testing search');
+		$this->assertEquals('search', $ret, 'Testing search');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Date archive

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -45,7 +45,9 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 	}
 
 	function test_largo_load_more_posts_choose_partial() {
-		$qv = array();
+		$qv = (object) array(
+			'query_vars' => array()
+		);
 
 		// Note: These options are arrayed in the order that they are tested for in largo_load_more_posts_choose_partial($qv)
 		// That is to say, later options *should* override earlier options. This is why $qv is not being unset($qv).
@@ -54,43 +56,43 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		$this->assertEquals('home', $ret, 'empty query vars did not result in a determination that the partial type is home');
 
 		// Test it with everything that shouldn't affect the determination that this is home.
-		$qv['category_name'] = '';
-		$qv['author_name'] = '';
-		$qv['tag'] = '';
-		$qv['s'] = '';
-		$qv['year'] = '';
+		$qv->query_vars['category_name'] = '';
+		$qv->query_vars['author_name'] = '';
+		$qv->query_vars['tag'] = '';
+		$qv->query_vars['s'] = '';
+		$qv->query_vars['year'] = '';
 		$_POST['is_series_landing'] = false;
-		$qv['series'] = '';
+		$qv->query_vars['series'] = '';
 		// @todo find way to test get_post_type() returning argolinks.
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('home', $ret, 'empty query vars did not result in a determination that the partial type is home');
 
 		// category
-		$qv['category_name'] = 'foo';
+		$qv->query_vars['category_name'] = 'foo';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing category');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Author archive page
-		$qv['author_name'] = 'admin';
+		$qv->query_vars['author_name'] = 'admin';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing author archive');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// tag
-		$qv['tag'] = 'tag';
+		$qv->query_vars['tag'] = 'tag';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing tag');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Search
-		$qv['s'] = 'search';
+		$qv->query_vars['s'] = 'search';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('search', $ret, 'Testing search');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// Date archive
-		$qv['year'] = '2015';
+		$qv->query_vars['year'] = '2015';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, 'Testing date query with "year" => "2015"');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
@@ -105,7 +107,7 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');
 
 		// non-series-landing series archives
-		$qv['series'] = 'series';
+		$qv->query_vars['series'] = 'series';
 		$ret = largo_load_more_posts_choose_partial($qv);
 		$this->assertEquals('archive', $ret, '');
 		$this->assertFalse(('home' == $ret), 'set query query vars did result in a determination that the partial type is home');

--- a/tests/inc/test-ajax-functions.php
+++ b/tests/inc/test-ajax-functions.php
@@ -37,6 +37,83 @@ class AjaxFunctionsTestFunctions extends WP_UnitTestCase {
 		largo_load_more_posts_data('test_nav', $wp_query);
 	}
 
+	// @todo: Test this! Can we actually test something that calls wp_die() ?
+	function test_largo_load_more_posts() {
+		$this->markTestIncomplete(
+		' This test calls wp_die(), which we may not be able to tests. Try it and see, sometime later.'
+		);
+	}
+
+	function test_largo_load_more_posts_choose_partial() {
+		global $opt;
+		$qv = array();
+
+		// Note: These options are arrayed in the order that they are tested for in largo_load_more_posts_choose_partial($qv)
+		// That is to say, later options *should* override earlier options. This is why $qv is not being unset($qv).
+
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('home', $ret, 'empty query vars did not result in a determination that the partial type is home');
+
+		// Test it with everything that shouldn't affect the determination that this is home.
+		$qv['category_name'] = '';
+		$qv['author_name'] = '';
+		$qv['tag'] = '';
+		$qv['s'] = '';
+		$qv['year'] = '';
+		$_POST['is_series_landing'] = false;
+		$qv['series'] = '';
+		// @todo find way to test get_post_type() returning argolinks.
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('home', $ret, 'empty query vars did not result in a determination that the partial type is home');
+
+		// category
+		$qv['category_name'] = 'foo';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, 'Testing category');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// Author archive page
+		$qv['author_name'] = 'admin';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, 'Testing author archive');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// tag
+		$qv['tag'] = 'tag';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, 'Testing tag');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// Search
+		$qv['s'] = 'search';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, 'Testing search');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// Date archive
+		$qv['year'] = '2015';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, 'Testing date query with "year" => "2015"');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// series landing pages
+		$_POST['is_series_landing'] = 'true';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('series', $ret, '');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// non-series-landing series archives
+		$qv['series'] = 'series';
+		$ret = largo_load_more_posts_choose_partial($qv);
+		$this->assertEquals('archive', $ret, '');
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// @todo find way to test get_post_type() returning argolinks.
+		$this->assertFalse('home', $ret, 'set query query vars did result in a determination that the partial type is home');
+
+		// Test the filter.
+	}
+
 }
 
 class AjaxFunctionsTestAjaxFunctions extends WP_Ajax_UnitTestCase {

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -78,5 +78,10 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 
 	}
 
+	function test_largo_get_partial_by_post_type() {
+		$ret = largo_get_partial_by_post_type('foo', 'bar', 'baz');
+		$this->assertEquals($ret, 'foo'); // dummy test so that this test will run. Mostly we're just asserting that the function doesn't cause errors.
+		$this->markTestIncomplete();
+	}
 
 }


### PR DESCRIPTION
## Changes

Functionality: 
- `largo_load_more_posts_choose_partial()`: 
    - Adds tests for `largo_load_more_posts_choose_partial()`
    - `largo_load_more_posts_choose_partial()` doesn't require `$_POST['is_series_landing']` to be set in order to run.
    - `largo_load_more_posts_choose_partial()` now checks inside the `query_vars` property of the `WP_Query` object, not various properties of the `WP_Query`. This should fix the problem where it was returning 'home' for categories and author archives.
    - `largo_load_more_posts_choose_partial()` now returns 'search' on search pages, meaning that the `partials/content-search` partial will be loaded on search. Since Largo does not ship that partial, this will fall back to `partials/content.php`.
    - `largo_load_more_posts_choose_partial()` and `search.php` now use `largo_get_partial_by_post_type()` to determine the correct partial for a post type. (#1023)

- `partials/content.php` was the fallback partial on the search page, because Largo didn't ship a `partials/content-search.php`. Largo now ships that partial.

- Adds new function `largo_get_partial_by_post_type()` that returns `argolinks` if the post type is `argolinks`, and runs a new filter `largo_partial_by_post_type` on the partial. This allows LMP to use plugin-defined and theme-defined partials as appropriate. (#1023)
- `search.php`
     - `largo_load_more_posts_choose_partial()` and `search.php` now use `largo_get_partial_by_post_type()` to determine the correct partial for a post type. (#1023)

Tests: 


- Adds tests for `largo_load_more_posts_choose_partial()`
- stubbed test for `largo_load_more_posts()` and `largo_get_partial_by_post_type()`
- Because of time constraints, this does not test for the `argolinks` post type.

## Questions:

- ~~see https://github.com/INN/Largo/pull/1021#issuecomment-164895213~~

## Why

For #1018 and [we-47](http://jira.inn.org/browse/WE-47).

For #1023 and [AJ-3](http://jira.inn.org/browse/AJ-3)