### PR TITLE
Move the is-image check to the end of largo_hero_class

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -637,15 +637,16 @@ if ( ! function_exists( 'largo_hero_class' ) ) {
 		$hero_class = "is-empty";
 		$featured_media = (largo_has_featured_media($post_id))? largo_get_featured_media($post_id) : array();
 		$type = (isset($featured_media['type']))? $featured_media['type'] : false;
+		var_log($type);
 
 		if (get_post_meta($post_id, 'youtube_url', true) || $type == 'video')
 			$hero_class = 'is-video';
-		else if (has_post_thumbnail($post_id) || $type == 'image')
-			$hero_class = 'is-image';
 		else if ($type == 'gallery')
 			$hero_class = 'is-gallery';
 		else if ($type == 'embed-code')
 			$hero_class = 'is-embed';
+		else if (has_post_thumbnail($post_id) || $type == 'image')
+			$hero_class = 'is-image';
 
 		if ($echo)
 			echo $hero_class;

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -637,7 +637,6 @@ if ( ! function_exists( 'largo_hero_class' ) ) {
 		$hero_class = "is-empty";
 		$featured_media = (largo_has_featured_media($post_id))? largo_get_featured_media($post_id) : array();
 		$type = (isset($featured_media['type']))? $featured_media['type'] : false;
-		var_log($type);
 
 		if (get_post_meta($post_id, 'youtube_url', true) || $type == 'video')
 			$hero_class = 'is-video';


### PR DESCRIPTION
## Changes

Because galleries, videos, and optionally embeds set a featured image, the check for a thumbnail should be last. this moves it to the last position.

We don't have any styles for `.is-embed` in Largo, and the lone style for `.is-gallery` makes the background of the hero transparent in color. This shouldn't affect any child themes negatively.

## Why

I'm filing this against master because it's presumably something we'll want to ship before 0.5.4.

For #1026 and [VO-6](http://jira.inn.org/browse/VO-6)