### PR TITLE
support only one image in query for largo recent posts

### DIFF
--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -76,16 +76,27 @@ class largo_recent_posts_widget extends WP_Widget {
         if ( $my_query->have_posts() ) {
 
         	$output = '';
-
-			while ( $my_query->have_posts() ) : $my_query->the_post(); $shown_ids[] = get_the_ID();
-
+        	
+        	// setup a counter only if needed
+        	if($thumb == 'first-large') { 
+        	  $count = 0;
+        	}
+        	
+			while ( $my_query->have_posts() ) : $my_query->the_post(); $shown_ids[] = get_the_ID(); 
+			    
+			    // setup a counter only if needed
+			    if($thumb == 'first-large') {
+			      $count++;
+			    }
+			    
         		// wrap the items in li's.
 				$output .= '<li>';
 
 				$context = array(
 					'instance' => $instance,
 					'thumb' => $thumb,
-					'excerpt' => $excerpt
+					'excerpt' => $excerpt,
+					'count'   => $count
 				);
 
 				ob_start();
@@ -183,6 +194,7 @@ class largo_recent_posts_widget extends WP_Widget {
 			    <option <?php selected( $instance['thumbnail_display'], 'small'); ?> value="small"><?php _e('Small (60x60)', 'largo'); ?></option>
 			    <option <?php selected( $instance['thumbnail_display'], 'medium'); ?> value="medium"><?php _e('Medium (140x140)', 'largo'); ?></option>
 			    <option <?php selected( $instance['thumbnail_display'], 'large'); ?> value="large"><?php _e('Large (Full width of the widget)', 'largo'); ?></option>
+			    <option <?php selected( $instance['thumbnail_display'], 'first-large'); ?> value="first-large"><?php _e('First Large (First has large, subsequent imageless)', 'largo'); ?></option>
 			    <option <?php selected( $instance['thumbnail_display'], 'none'); ?> value="none"><?php _e('None', 'largo'); ?></option>
 			</select>
 		</p>

--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -21,10 +21,16 @@ if ($thumb == 'small') {
 	$img_attr = array();
 	$img_attr['class'] .= " attachment-large"; ?>
 	<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'large', $img_attr); ?></a>
+<?php } elseif ($thumb == 'first-large') {
+    if( $count == 1 ) {
+      $img_attr = array();
+	  $img_attr['class'] .= " attachment-large"; ?>
+      <a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'large', $img_attr); ?></a>
 <?php }
+}
+?>
 
-// the headline
-?><h5><a href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h5>
+<h5><a href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h5>
 
 <?php // byline on posts
 if ( isset( $instance['show_byline'] ) && $instance['show_byline'] == true) { ?>


### PR DESCRIPTION
Per discussion with @aschweigert about Cornell Sun homepage, modified Largo Recent Posts widget to have counter and only show a featured image for the first story in query. Counter is conditional to not add unnecessary expense to other queries.