### PR TITLE
Developer docs: Adding 'npm install' and some style fixes.

### DIFF
--- a/docs/developers/grunt-commands.rst
+++ b/docs/developers/grunt-commands.rst
@@ -1,0 +1,69 @@
+Grunt commands
+==============
+
+``less``
+    Recompiles all LESS files into their corresponding CSS files, including sourcemaps, and then runs ``cssmin``.
+    The list of files that will be compiled is defined in ``Gruntfile.js`` in the variable ``cssLessFiles``.
+
+``uglify``
+    Minifies Largo's ``.js`` JavaScript files to ``.min.js`` files.
+
+``cssmin``
+    Takes all ``.css`` files in ``css/`` and ``homepages/assets/css`` that are not ``.min.css`` files and makes minified versions with the file extension ``.min.css``.
+
+``shell``
+    Runs commands directly on the command line, instead of running Grunt modules.
+
+    ``shell:apidocs``
+        Recompiles the `Largo API Docs </api/>`_ from structured comments in Largo's PHP code using `/docs/generate_api_docs.py <https://github.com/INN/Largo/blob/master/docs/generate_api_docs.py>`_ into reStructuredText files.
+
+    ``shell:sphinx``
+        Converts all available reStructuredText files into HTML documentation, which is saved locally in ``docs/_build/html/``. If you want to preview these docs without pushing them to `largo.readthedocs.org <https://largo.readthedocs.org>`_, run ``python -m SimpleHTTPServer`` as described in `the documentation contribution instructions <setup-documentation.html#setting-up>`_.
+
+    ``shell:msmerge``
+        Runs `msgmerge <https://www.gnu.org/software/gettext/manual/html_node/msgmerge-Invocation.html>`_ to merge translation files.
+
+``watch``
+    Runs ``less`` if a ``.less`` file in ``less/`` or ``homepages/assets/less/`` is modified.
+    Runs ``docs`` if a reStructuredText ``.rst`` file changes in ``docs/``.
+
+``pot``
+    Scans the Largo code for the WordPress localization functions and generates ``.po`` files for working with localization software.
+
+``po2mo``
+    Converts the ``.po`` files to ``.mo`` files. For more information about ``.po`` and ``.mo`` files, see the `Wikipedia articles on gettext <https://en.wikipedia.org/wiki/Gettext>`_.
+
+``apidocs``
+    Runs ``shell:apidocs``, rebuilding only the API docs.
+
+``docs``
+    Runs ``shell:sphinx``, rebuilding ALL docs.
+
+``build``
+    Runs ``less``, ``cssmin``, ``uglify``, ``apidocs``, ``docs``, ``pot``, and ``shell:msmerge`` to rebuild the assets, docs, and language files.
+
+``version``
+    Increments the Largo version number based on ``package.json``. Files affected are: ``docs/conf.py``, ``style.css``, ``readme.md``.
+
+``build-release``
+    Runs ``build`` and ``version``.
+
+``publish``
+    Runs the following tasks to publish the newest version of Largo on the ``master`` branch:
+
+    ``confirm``
+        Makes sure that you want to publish a release.
+
+    ``gitcheckout``
+        Checks out the ``master`` branch of Largo.
+
+    ``gitmerge``
+        Merges the ``develop`` branch into ``master``.
+
+    ``gittag``
+        Tags the latest commit with the version number from ``package.json``.
+
+    ``gitpush``
+        Pushes the ``master`` branch back to GitHub.
+
+

--- a/docs/developers/grunt-commands.rst
+++ b/docs/developers/grunt-commands.rst
@@ -1,6 +1,10 @@
 Grunt commands
 ==============
 
+These commands are run on the command line, prefixed with ``grunt``. For example, to rebuild the CSS after editing the LESS files, you would run ``grunt less``.
+
+Some commands require you to have external applications installed. Instructions for installing dependencies `are included in the developer documentation <index.html#setting-up-a-development-environment>`_.
+
 ``less``
     Recompiles all LESS files into their corresponding CSS files, including sourcemaps, and then runs ``cssmin``.
     The list of files that will be compiled is defined in ``Gruntfile.js`` in the variable ``cssLessFiles``.
@@ -13,6 +17,8 @@ Grunt commands
 
 ``shell``
     Runs commands directly on the command line, instead of running Grunt modules.
+
+    These commands require you to have set up Largo according to the `complete dev environment <setup.html>`_ or `documentation contribution environment <setup-documentation.html>`_ instructions, because they require several Python libraries that were installed by following those instructions. Besure to have activated your python virtualenv with ``workon``, as described in those instructions.
 
     ``shell:apidocs``
         Recompiles the `Largo API Docs </api/>`_ from structured comments in Largo's PHP code using `/docs/generate_api_docs.py <https://github.com/INN/Largo/blob/master/docs/generate_api_docs.py>`_ into reStructuredText files.
@@ -30,8 +36,12 @@ Grunt commands
 ``pot``
     Scans the Largo code for the WordPress localization functions and generates ``.po`` files for working with localization software.
 
+    Running this command requires your computer to have ``xgettext`` installed. Installation instructions vary based on operating system; your best bet is Google.
+
 ``po2mo``
     Converts the ``.po`` files to ``.mo`` files. For more information about ``.po`` and ``.mo`` files, see the `Wikipedia articles on gettext <https://en.wikipedia.org/wiki/Gettext>`_.
+
+    Running this command requires your computer to have ``xgettext`` installed. Installation instructions vary based on operating system; your best bet is Google.
 
 ``apidocs``
     Runs ``shell:apidocs``, rebuilding only the API docs.
@@ -65,5 +75,3 @@ Grunt commands
 
     ``gitpush``
         Pushes the ``master`` branch back to GitHub.
-
-

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -24,6 +24,7 @@ We encourage all INN member organizations looking to add features to or otherwis
 
     setup
     setup-documentation
+    intro-command-line
 
 Child Themes
 ------------
@@ -55,6 +56,7 @@ A few brief technical notes that might be helpful as you get started:
     :maxdepth: 2
 
     technicalnotes
+    grunt-commands
 
 Function Reference
 ------------------

--- a/docs/developers/intro-command-line.rst
+++ b/docs/developers/intro-command-line.rst
@@ -1,0 +1,19 @@
+An introduction to the command line
+===================================
+
+Coursework introductions to the command line:
+
+- CodeCademy: https://www.codecademy.com/learn/learn-the-command-line
+- Learn Code The Hard Way: http://cli.learncodethehardway.org/book/
+- Thomas Wilburn's CLI Basics: https://github.com/thomaswilburn/itc240-2014/blob/master/assignment-0/command-line.md
+
+Articles
+
+- http://www.davidbaumgold.com/tutorials/command-line/
+
+Cheatsheets
+
+- Matt Waite: https://github.com/mattwaite/JOUR491-News-Applications/blob/master/Helpers/terminal_cheat_sheet.md
+- Journalist's Guide to the command line: https://github.com/chrislkeller/nicar15-command-line-basics (Contains many links to more tools and tutorials)
+- GitHub 201: https://github.com/githubteacher/nicar-2015
+- GitHub Training's cheatsheet: https://training.github.com/kit/downloads/github-git-cheat-sheet

--- a/docs/developers/setup-documentation.rst
+++ b/docs/developers/setup-documentation.rst
@@ -18,13 +18,17 @@ Setting up
 This presumes that you're familiar with the command line, and are using OSX or another UNIX-like system.
 
 1. `Fork INN/Largo <https://github.com/INN/Largo#fork-destination-box>`_ into your own GitHub account.
-2. Clone your branch: ::
+2. Clone your branch:
 
-	git clone git@github.com:you/Largo.git
+	::
 
-3. Check out the `write-the-docs` branch ::
+		git clone git@github.com:you/Largo.git
 
-	git checkout write-the-docs
+3. Check out the `write-the-docs` branch:
+
+	::
+
+		git checkout write-the-docs
 
 4. Install the required dependencies
 
@@ -54,15 +58,16 @@ This presumes that you're familiar with the command line, and are using OSX or a
 		cd doxphp/bin
 		mv doxph* /path/to/bin/
 
-6. With all dependencies installed, running the generator is as simple as: ::
+6. With all dependencies installed, running the generator is as simple as:
+
+	::
 
 		cd docs
 		make php && make html
 
+	But if you don't want to have to manually recreate the documentation every time you save a file, you can run ``grunt watch`` from the Largo directory. This command only rebuilds documentation, though, and doesn't recompile the API docs.
 
-But if you don't want to have to manually recreate the documentation every time you save a file, you can run ``grunt watch`` from the Largo directory. This command only rebuilds documentation, though, and doesn't recompile the API docs.
-
-7. You can view the generated docs in the `docs/_build/html` directory
+7. You can view the generated docs in the `docs/_build/html` directory:
 
 	There are two main ways of doing this. First, you can view the files with a browser as files. It won't be the best experience. 
 

--- a/docs/developers/setup-documentation.rst
+++ b/docs/developers/setup-documentation.rst
@@ -58,7 +58,7 @@ This presumes that you're familiar with the command line, and are using OSX or a
 		cd doxphp/bin
 		mv doxph* /path/to/bin/
 
-6. With all dependencies installed, running the generator is as simple as:
+6. With all dependencies installed, you can run the generator:
 
 	::
 

--- a/docs/developers/setup-documentation.rst
+++ b/docs/developers/setup-documentation.rst
@@ -13,7 +13,7 @@ Once you've completed this recipe, you'll be able to:
 Setting up
 ----------
 
-This presumes that you're familiar with the command line, and are using OSX or another UNIX-like system.
+This presumes that you're familiar with the command line, and are using OSX or another UNIX-like system. If you're not familiar with the command line, check out `our collection of command-line resources <intro-command-line.html>`_.
 
 1. `Fork INN/Largo <https://github.com/INN/Largo#fork-destination-box>`_ into your own GitHub account.
 2. Clone your branch:
@@ -63,7 +63,7 @@ This presumes that you're familiar with the command line, and are using OSX or a
 		cd docs
 		make php && make html
 
-	But if you don't want to have to manually recreate the documentation every time you save a file, you can run ``grunt watch`` from the Largo directory. This command only rebuilds documentation, though, and doesn't recompile the API docs.
+	But if you don't want to have to manually recreate the documentation every time you save a file, you can run ``grunt watch`` from the Largo directory. This command only rebuilds documentation, though, and doesn't recompile the API docs. (For a full list of ``grunt`` commands, see `the Largo grunt docs <grunt-commands.html>`_.
 
 7. You can view the generated docs in the `docs/_build/html` directory:
 

--- a/docs/developers/setup-documentation.rst
+++ b/docs/developers/setup-documentation.rst
@@ -10,8 +10,6 @@ Once you've completed this recipe, you'll be able to:
 - rebuild the translation files.
 - push your edits to GitHub and request that we incorporate them in Largo
 
-This presumes that you're familiar with the command line, and are using OSX or another UNIX-like system.
-
 Setting up
 ----------
 

--- a/docs/developers/setup.rst
+++ b/docs/developers/setup.rst
@@ -54,6 +54,7 @@ Setting up Largo and WordPress
 
 6. You're going to have to install some things first.
 
+
 7. First, install the Python dependencies.
 
 	We use a few Python libraries for this project, including `Fabric <http://www.fabfile.org>`_ which powers the INN deploy-tools to elegantly run `many common but complex tasks <https://github.com/INN/deploy-tools/blob/master/COMMANDS.md>`_. In the `OS X setup guide <https://github.com/inn/docs/staffing/onboarding/os-x-setup.md>`_, you should have installed Python virtualenv and virtualenvwrapper.
@@ -73,7 +74,14 @@ Setting up Largo and WordPress
 		workon largo-umbrella
 		pip install -r requirements.txt
 
-8. Our API docs/function reference uses doxphp to generate documentation based on the comments embedded in Largo's source code. You'll need to install doxphp to generate API docs.
+8. Now, the NodeJS dependencies.
+
+	If this command fails, make sure you're in the ``largo-dev`` directory. ::
+
+		npm install
+
+
+9. Our API docs/function reference uses doxphp to generate documentation based on the comments embedded in Largo's source code. You'll need to install doxphp to generate API docs.
 
 	- Installation process with PEAR: ::
 
@@ -90,7 +98,7 @@ Setting up Largo and WordPress
 
 	The last step may require you to use sudo.
 
-9. Make sure that you have the necessary prerequisites for these next steps.
+10. Make sure that you have the necessary prerequisites for these next steps.
 
 	From the top level of the project, run the setup routine `as described in the deploy-tools documentation <https://github.com/INN/deploy-tools#setup>`_ ::
 
@@ -101,7 +109,7 @@ Setting up Largo and WordPress
 
 	If the above command fails to run, make sure you have run the ``workon`` and ``pip install`` commands listed above in step 7.
 
-10. Time to install WordPress.
+11. Time to install WordPress.
 
 	INN's deploy tools have a handy utility that will install any tagged release of WordPress for you.
 
@@ -132,22 +140,22 @@ Setting up Largo and WordPress
 
 	This tells your system that whenever you use the address ``http://vagrant.dev``, you really mean the IP address of the virtual machine. If you're working on a multisite instance of WordPress, you can add the subdomains such as ``another.blog.at.vagrant.dev`` at the end of the line, separated by a space from ``vagrant.dev``. 
 
-11. Now that the vagrant box is up and running, you can create a database for it to use: ::
+12. Now that the vagrant box is up and running, you can create a database for it to use:
 
-			fab vagrant.create_db
+	Without any arguments, this command will read the defaults from the ``Fabfile.py`` in the root of your project directory. ::
 
-
-Without any arguments, this command will read the defaults from the ``Fabfile.py`` in the root of your project directory.
-
-12. Now, let's take a snapshot of the virtual machine in its new, provisioned, freshly-deployed state. ::
-
-			vagrant plugin install vagrant-vbox-snapshot
-			vagrant snapshot take default snapshot_name_goes_here
+		fab vagrant.create_db
 
 
-You can name the snapshot anything you want, and I would recommend describing it in a short way that describes what that state would give you if you were to revert.
+13. Now, let's take a snapshot of the virtual machine in its new, provisioned, freshly-deployed state.
 
-13. Now you're going to set up WordPress on Vagrant. Open a browser and point it at http://vagrant.dev/. You should automatically be redirected to http://vagrant.dev/wp-admin/setup-config.php. Choose your language, then enter the details below as they are entered in your ``Fabfile.py``: ::
+	You can name the snapshot anything you want, and I would recommend describing it in a short way that describes what that state would give you if you were to revert. ::
+
+		vagrant plugin install vagrant-vbox-snapshot
+		vagrant snapshot take default snapshot_name_goes_here
+
+
+14. Now you're going to set up WordPress on Vagrant. Open a browser and point it at http://vagrant.dev/. You should automatically be redirected to http://vagrant.dev/wp-admin/setup-config.php. Choose your language, then enter the details below as they are entered in your ``Fabfile.py``: ::
 
     * Database Name: `largoproject`
     * User Name: `root`
@@ -155,7 +163,9 @@ You can name the snapshot anything you want, and I would recommend describing it
     * Database Host: `localhost`
     * Table Prefix: `wp_`
 
-14. If you are working on a multisite install, you will want to add these settings to ``wp-config.php`` at the bottom, before "Do not edit below this line." ::
+15. If you are working on a multisite install, you will want to add these settings to ``wp-config.php`` at the bottom, before "Do not edit below this line."
+
+	::
 
 
 		/* Make this a multisite install. */
@@ -166,7 +176,7 @@ You can name the snapshot anything you want, and I would recommend describing it
 		define('SITE_ID_CURRENT_SITE', 1);
 		define('BLOG_ID_CURRENT_SITE', 1);
 
-All done? Log into WordPress and start poking around. Remember to take Vagrant snapshots when you get things working how you like the. You'll probably want to take one after you add some posts and configure your menus for testing purposes. If you want to log into the vagrant box, it's as easy as ``vagrant ssh``.
+	All done? Log into WordPress and start poking around. Remember to take Vagrant snapshots when you get things working how you like the. You'll probably want to take one after you add some posts and configure your menus for testing purposes. If you want to log into the vagrant box, it's as easy as ``vagrant ssh``.
 
 You have installed:
 
@@ -204,7 +214,7 @@ Every command in `the list of commands <https://github.com/INN/deploy-tools/blob
 
 If you recieve an error when running your command, make sure that you have run ``workon largo-umbrella``, or the name of the Python virtualenv you are using. When run, ``workon`` will prefix your prompt: ::
 
-	blk@oyster:~$ workon largo
-	(largo)blk@oyster:~$
+	you@computer:~$ workon largo
+	(largo-umbrella)you@computer:~$
 
 To exit the virtualenv, you can use the command ``deactivate``.


### PR DESCRIPTION
## Changes

- Adds `npm install` to the developer umbrella setup instructions
- Some style fixes in the developer setup and the developer just-for-docs setup instructions.

## Why

For #953. People who try to run grunt commands will experience an unhappy surprise.