### PR TITLE
Use the post ID argument on post_class() in the hierarchical archive pages

### DIFF
--- a/partials/archive-category-primary-feature.php
+++ b/partials/archive-category-primary-feature.php
@@ -1,4 +1,4 @@
-<article id="post-<?php echo $featured_post->ID ?>" <?php post_class('clearfix row-fluid'); ?>>
+<article id="post-<?php echo $featured_post->ID ?>" <?php post_class('clearfix row-fluid', $featured_post->ID); ?>>
 <?php if ( has_post_thumbnail($featured_post->ID) ) { ?>
 	<div class="span4 <?php largo_hero_class($featured_post->ID); ?>">
 		<a href="<?php echo post_permalink($featured_post->ID); ?>"><?php echo get_the_post_thumbnail($featured_post->ID, 'rect_thumb'); ?></a>

--- a/partials/archive-category-secondary-feature.php
+++ b/partials/archive-category-secondary-feature.php
@@ -1,4 +1,4 @@
-<article id="post-<?php echo $featured_post->ID; ?>" <?php post_class('span3'); ?>>
+<article id="post-<?php echo $featured_post->ID; ?>" <?php post_class('span3', $featured_post->ID); ?>>
 	<?php if ( has_post_thumbnail($featured_post->ID) ) { ?>
 		<div class="<?php largo_hero_class($featured_post->ID); ?>">
 			<a href="<?php echo post_permalink($featured_post->ID); ?>">


### PR DESCRIPTION
## Changes

Uses the second argument of `post_class()` to specify that the classes to be output are from the current post, not for the `global $post`.

## Why
For #1052.

Posts had the wrong classes, most noticeably because the post ID in the classes was not the post ID in the html element ID.