### PR TITLE
Use lowercase inn_logo for function_exists check

### DIFF
--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'largo_copyright_message' ) ) {
  *
  * @since 0.5.2
  */
-if ( ! function_exists( 'INN_logo' ) ) {
+if ( ! function_exists( 'inn_logo' ) ) {
 	function inn_logo() {
 		?>
 			<a href="//inn.org/" id="inn-logo-container">


### PR DESCRIPTION
## Why

If the check for `INN_logo` is case-sensitive, then Largo will attempt to redefine an existing function if the child theme has defined their own `inn_logo` function.