### PR TITLE
Filter the output of largo_byline

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -113,6 +113,12 @@ filter: **largo_partial_by_post_type**
     Without setting '3', your filter will not be passed the $post_type or $context arguments.
     In order to set '3', you must set the third parameter of add_filter, which defaults to 10. It is safe to leave that at 10.
 
+
+filter: **largo_byline**
+    *args: $output*
+    
+    Called in ``largo_byline()`` before the admin-user edit link is added. This can be used to append or prepend HTML, or to change the output of the byline function entirely. The passed string is HTML.
+
 filter: **largo_post_social_links**
 
     *args: $output*

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -132,6 +132,16 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			$output .= '<span class="sep"> | </span><time class="entry-date updated dtstamp pubdate" datetime="' . esc_attr( get_the_date( 'c', $post_id ) ) . '">' . largo_time(false, $post_id) . '</time>';
 		}
 
+		/**
+		 * Filter the largo_byline output text to allow adding items at the beginning or the end of the text.
+		 *
+		 * @since 0.5.4
+		 * @param string $partial The HTML of the output of largo_byline(), before the edit link is added.
+		 * @link https://github.com/INN/Largo/issues/1070
+		 */
+		$output = apply_filters( 'largo_byline', $output );
+
+
 		if ( current_user_can( 'edit_post', $post_id ) ) {
 			$output .= '<span class="sep"> | </span><span class="edit-link"><a href="' . get_edit_post_link( $post_id ) . '">' . __( 'Edit This Post', 'largo' ) . '</a></span>';
 		}


### PR DESCRIPTION
## changes

- Filter the output of `largo_byline()` before the edit link is appended to it
- Docs

## Why

To allow child themes to prepend or append content to the output of the byline function.

For #1070 and [RNS-107](http://jira.inn.org/browse/RNS-107).