### PR TITLE
Allow get_post_template to not use get_post_meta if global $post isn't an object

### DIFF
--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -62,7 +62,9 @@ if( !function_exists( 'post_templates_dropdown' ) ) {
 if( !function_exists( 'get_post_template' ) ) {
 	function get_post_template( $template ) {
 		global $post;
-		$custom_field = get_post_meta( $post->ID, '_wp_post_template', true );
+		if ( is_object($post) ) {
+			$custom_field = get_post_meta( $post->ID, '_wp_post_template', true );
+		}
 		if ( !empty( $custom_field ) ) {
 			if ( file_exists( get_stylesheet_directory() . "/{$custom_field}") ) {
 				$template = get_stylesheet_directory() . "/{$custom_field}";


### PR DESCRIPTION
## Changes

We already have the logic for what to do if $custom_field is empty, so we can make use of that and just not set $custom_field in the even that $post is not an object.

## Why

For #1078 and because it was cluttering up my logs when I was looking for something else.