### PR TITLE
Support a "None" option for the top term

### DIFF
--- a/inc/metabox-api.php
+++ b/inc/metabox-api.php
@@ -176,6 +176,5 @@ function _largo_meta_box_save( $post_id ) {
 			delete_post_meta( $post->ID, $key ); //and delete if blank
 		}
 	}
-
 }
 add_action( 'save_post', '_largo_meta_box_save' );

--- a/inc/post-metaboxes.php
+++ b/inc/post-metaboxes.php
@@ -273,7 +273,7 @@ largo_register_meta_input( 'disclaimer', 'wp_filter_post_kses' );
  * Includes the option for "None", which is not the default option, but is an option.
  *
  * @global $post
- * @since 0.5.4
+ * @since 0.5.5
  * @link https://github.com/INN/Largo/issues/1082
  */
 function largo_top_tag_display() {

--- a/inc/post-metaboxes.php
+++ b/inc/post-metaboxes.php
@@ -268,9 +268,13 @@ function largo_custom_disclaimer_meta_box_display() {
 largo_register_meta_input( 'disclaimer', 'wp_filter_post_kses' );
 
 /**
- * Metabox option to choose the top tag for the post
+ * Metabox option to choose the top tag for the posto
+ *
+ * Includes the option for "None", which is not the default option, but is an option.
  *
  * @global $post
+ * @since 0.5.4
+ * @link https://github.com/INN/Largo/issues/1082
  */
 function largo_top_tag_display() {
 	global $post;
@@ -287,10 +291,11 @@ function largo_top_tag_display() {
 	foreach ($terms as $term)
 		echo '<option value="' . (int) $term->term_id . '"' . selected( $term->term_id, $top_term, FALSE ) . ">" . $term->name . '</option>';
 
+	echo '<option value="null"' . selected( 'null' , $top_term, FALSE ) . ">None</option>";
 	echo '</select>';
 }
 largo_add_meta_content('largo_top_tag_display', 'largo_additional_options');
-largo_register_meta_input( 'top_term', 'intval' );
+largo_register_meta_input( 'top_term', 'sanitize_key' );
 
 /**
  * Load JS for our top-terms select

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -317,16 +317,19 @@ function largo_top_term( $options = array() ) {
 	$args = wp_parse_args( $options, $defaults );
 
 	$term_id = get_post_meta( $args['post'], 'top_term', TRUE );
-	//get the taxonomy slug
-	$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 
-	if ( empty( $term_id ) || empty($taxonomy) ) {	// if no top_term specified, fall back to the first category
+	if ( ! $term_id == 'null' ) { // if term id is '' or '0' or 0 for the "None" option, don't bother doing this.
+		//get the taxonomy slug
+		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
+	}
+
+	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id != 'null' ) ) {	// if no top_term specified, fall back to the first category
 		$term_id = get_the_category( $args['post'] );
 		if ( !is_array( $term_id ) || !count($term_id) ) return;	//no categories OR top term? Do nothing
 		$term_id = $term_id[0]->term_id;
 	}
 
-	if ( $term_id ) {
+	if ( $term_id && $term_id != 'null' ) {
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
 		$link = ( $args['link'] ) ? array('<a href="%2$s" title="Read %3$s in the %4$s category">','</a>') : array('', '') ;
 		// get the term object
@@ -344,6 +347,15 @@ function largo_top_term( $options = array() ) {
 		$output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude']);
 		$output = ( is_array($output) ) ? $output[0] : '';
 	}
+
+	/*
+	 * for https://github.com/INN/Largo/issues/1082, support not outputting anything
+	 * @since 0.5.5
+	 */
+	if ( $term_id == 'null' ) {
+		$output = '';
+	}
+
 	if ( $args['echo'] ) echo $output;
 	return $output;
 }

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -318,7 +318,7 @@ function largo_top_term( $options = array() ) {
 
 	$term_id = get_post_meta( $args['post'], 'top_term', TRUE );
 
-	if ( ! $term_id == 'null' ) { // if term id is '' or '0' or 0 for the "None" option, don't bother doing this.
+	if ( ! $term_id == 'null' ) { // if term id is 'null' for the "None" option, don't bother doing this.
 		//get the taxonomy slug
 		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 	}


### PR DESCRIPTION
## Changes

- adds 'none' option to largo_top_tag_display metabox function
- changes the validation function for the top term from `intval` to `sanitize_key` because "None" cannot have an id of `'0'` because `'0'` and `0` and `''` are falsy and therefore _largo_meta_box_post_save will remove the option instead of saving it
- change largo_top_term so that it outputs `''` if the top term option is `'null'`

## Why

For #1082 and [RNS-127](http://jira.inn.org/browse/RNS-127).