### PR TITLE
1090 fix

### DIFF
--- a/inc/post-metaboxes.php
+++ b/inc/post-metaboxes.php
@@ -291,7 +291,7 @@ function largo_top_tag_display() {
 	foreach ($terms as $term)
 		echo '<option value="' . (int) $term->term_id . '"' . selected( $term->term_id, $top_term, FALSE ) . ">" . $term->name . '</option>';
 
-	echo '<option value="null"' . selected( 'null' , $top_term, FALSE ) . ">None</option>";
+	echo '<option value="none"' . selected( 'none' , $top_term, FALSE ) . ">None</option>";
 	echo '</select>';
 }
 largo_add_meta_content('largo_top_tag_display', 'largo_additional_options');

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -353,7 +353,9 @@ function largo_top_term( $options = array() ) {
 			$term->name,
 			$icon
 		);
-	} else {
+	}
+
+	if ( empty($output) ) {
 		$output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude']);
 		$output = ( is_array($output) ) ? $output[0] : '';
 	}

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -367,6 +367,7 @@ function largo_top_term( $options = array() ) {
 	$output .= $cheese;
 
 	if ( $args['echo'] ) echo $output;
+	echo $output;
 	return $output;
 }
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -316,19 +316,26 @@ function largo_top_term( $options = array() ) {
 
 	$args = wp_parse_args( $options, $defaults );
 
+	/*
+	 * Try to get a term ID
+	 * Or continue using 'none' if that is the case
+	 */
 	$term_id = get_post_meta( $args['post'], 'top_term', TRUE );
 
-	if ( $term_id !== 'none' ) { // if term id is 'none' for the "None" option, don't bother doing this.
+	// Try to get the taxonomy for the term ID, but if it's 'none' for the "None" option, don't bother doing this.
+	if ( !empty($term_id) && $term_id !== 'none' ) {
 		//get the taxonomy slug
 		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 	}
 
-	// if no top_term specified, fall back to the first category
+	// if no top_term specified, or if the top term is not in a taxonomy and the top term is not 'none',
 	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id !== 'none' ) ) {
+		// Get the categories the post is in and try to use the first one as a term id
 		$term_id = get_the_category( $args['post'] );
 		if ( is_array( $term_id ) &&  count($term_id) ) {
 			$term_id = $term_id[0]->term_id;
 		}
+
 		// The post isn't in a category? Try post-types if that's enabled.
 		if ( empty($term_id) && taxonomy_exists('post-type') ) {
 			$term_id = get_the_terms( $args['post'], 'post-type' );
@@ -338,8 +345,10 @@ function largo_top_term( $options = array() ) {
 		}
 	}
 
-
-	if ( $term_id && $term_id !== 'none' ) {
+	/*
+	 * Using the term ID, get the term and then generate some text
+	 */
+	if ( $term_id && $term_id !== 'none' && !empty($taxonomy) ) {
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
 		$link = ( $args['link'] ) ? array('<a href="%2$s" title="Read %3$s in the %4$s category">','</a>') : array('', '') ;
 		// get the term object
@@ -355,6 +364,10 @@ function largo_top_term( $options = array() ) {
 		);
 	}
 
+	/*
+	 * No output?
+	 * generate a link to the post's category or tags
+	 */
 	if ( empty($output) ) {
 		$output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude']);
 		$output = ( is_array($output) ) ? $output[0] : '';

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -318,18 +318,18 @@ function largo_top_term( $options = array() ) {
 
 	$term_id = get_post_meta( $args['post'], 'top_term', TRUE );
 
-	if ( ! $term_id == 'null' ) { // if term id is 'null' for the "None" option, don't bother doing this.
+	if ( ! $term_id == 'none' ) { // if term id is 'none' for the "None" option, don't bother doing this.
 		//get the taxonomy slug
 		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 	}
 
-	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id != 'null' ) ) {	// if no top_term specified, fall back to the first category
+	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id != 'none' ) ) {	// if no top_term specified, fall back to the first category
 		$term_id = get_the_category( $args['post'] );
 		if ( !is_array( $term_id ) || !count($term_id) ) return;	//no categories OR top term? Do nothing
 		$term_id = $term_id[0]->term_id;
 	}
 
-	if ( $term_id && $term_id != 'null' ) {
+	if ( $term_id && $term_id != 'none' ) {
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
 		$link = ( $args['link'] ) ? array('<a href="%2$s" title="Read %3$s in the %4$s category">','</a>') : array('', '') ;
 		// get the term object
@@ -352,7 +352,7 @@ function largo_top_term( $options = array() ) {
 	 * for https://github.com/INN/Largo/issues/1082, support not outputting anything
 	 * @since 0.5.5
 	 */
-	if ( $term_id == 'null' ) {
+	if ( $term_id == 'none' ) {
 		$output = '';
 	}
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -320,13 +320,13 @@ function largo_top_term( $options = array() ) {
 
 	$cheese = '';
 
-	if ( ! $term_id == 'none' ) { // if term id is 'none' for the "None" option, don't bother doing this.
+	if ( $term_id !== 'none' ) { // if term id is 'none' for the "None" option, don't bother doing this.
 		$cheese .= "one, ";
 		//get the taxonomy slug
 		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 	}
 
-	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id != 'none' ) ) {	// if no top_term specified, fall back to the first category
+	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id !== 'none' ) ) {	// if no top_term specified, fall back to the first category
 		$cheese .= "two, ";
 		$term_id = get_the_category( $args['post'] );
 		if ( !is_array( $term_id ) || !count($term_id) ) return;	//no categories OR top term? Do nothing
@@ -367,7 +367,7 @@ function largo_top_term( $options = array() ) {
 	$output .= $cheese;
 
 	if ( $args['echo'] ) echo $output;
-	echo $output;
+	echo "Cheese: " . $cheese;
 	return $output;
 }
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -352,9 +352,9 @@ function largo_top_term( $options = array() ) {
 	 * for https://github.com/INN/Largo/issues/1082, support not outputting anything
 	 * @since 0.5.5
 	 */
-	if ( $term_id == 'none' ) {
-		$output = '';
-	}
+//	if ( $term_id == 'none' ) {
+//		$output = '';
+//	}
 
 	if ( $args['echo'] ) echo $output;
 	return $output;

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -318,18 +318,23 @@ function largo_top_term( $options = array() ) {
 
 	$term_id = get_post_meta( $args['post'], 'top_term', TRUE );
 
+	$cheese = '';
+
 	if ( ! $term_id == 'none' ) { // if term id is 'none' for the "None" option, don't bother doing this.
+		$cheese .= "one, ";
 		//get the taxonomy slug
 		$taxonomy = $wpdb->get_var( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $term_id) );
 	}
 
 	if ( empty( $term_id ) || ( empty($taxonomy) && $term_id != 'none' ) ) {	// if no top_term specified, fall back to the first category
+		$cheese .= "two, ";
 		$term_id = get_the_category( $args['post'] );
 		if ( !is_array( $term_id ) || !count($term_id) ) return;	//no categories OR top term? Do nothing
 		$term_id = $term_id[0]->term_id;
 	}
 
 	if ( $term_id && $term_id != 'none' ) {
+		$cheese .= "three, ";
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
 		$link = ( $args['link'] ) ? array('<a href="%2$s" title="Read %3$s in the %4$s category">','</a>') : array('', '') ;
 		// get the term object
@@ -344,17 +349,22 @@ function largo_top_term( $options = array() ) {
 			$icon
 		);
 	} else {
+		$cheese .= "four, ";
 		$output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude']);
 		$output = ( is_array($output) ) ? $output[0] : '';
 	}
+		$cheese .= "five, ";
 
 	/*
 	 * for https://github.com/INN/Largo/issues/1082, support not outputting anything
 	 * @since 0.5.5
 	 */
-//	if ( $term_id == 'none' ) {
-//		$output = '';
-//	}
+	if ( $term_id == 'none' ) {
+		$output = '';
+		$cheese .= "six, ";
+	}
+
+	$output .= $cheese;
 
 	if ( $args['echo'] ) echo $output;
 	return $output;


### PR DESCRIPTION
## Changes

- allows the top term to be a term in the post-type taxonomy
- change the `id` for the "None" top term option from string `'null'` to string `'none'`, because it might've been undocumented type conversion.
- internal documentation of the function `largo_top_term`
- rework of the logic of `largo_top_term`, closing an edge case where a post with the following characteristics would not have a top term link output:
    - category set
    - no top term explicitly set
    - created in the database instead of through the post editor, because that's the only way that such a combo would exist, likely

## Why

Because the @!@#$%^&* top term wasn't showing up.

For [RNS-104](http://jira.inn.org/browse/RNS-104).