### PR TITLE
Add job title to fields accepted by coauthors

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -102,17 +102,22 @@ if ( ! function_exists( 'largo_byline' ) ) {
 
 		$values = get_post_custom( $post_id );
 
+		// If Co-Authors Plus is enabled
 		if ( function_exists( 'get_coauthors' ) && !isset( $values['largo_byline_text'] ) ) {
 			$coauthors = get_coauthors( $post_id );
 			foreach( $coauthors as $author ) {
 				$byline_text = $author->display_name;
 				$show_job_titles = of_get_option('show_job_titles');
-				if ( $job = $author->job_title && $show_job_titles )
-					$byline_text .= ', ' . $job;
 				if ( $org = $author->organization )
 					$byline_text .= ' (' . $org . ')';
 
-				$out[] = '<a class="url fn n" href="' . get_author_posts_url( $author->ID, $author->user_nicename ) . '" title="' . esc_attr( sprintf( __( 'Read All Posts By %s', 'largo' ), $author->display_name ) ) . '" rel="author">' . esc_html( $byline_text ) . '</a>';
+				$byline_temp = '<a class="url fn n" href="' . get_author_posts_url( $author->ID, $author->user_nicename ) . '" title="' . esc_attr( sprintf( __( 'Read All Posts By %s', 'largo' ), $author->display_name ) ) . '" rel="author">' . esc_html( $byline_text ) . '</a>';
+				if ( $show_job_titles && $job = $author->job_title ) {
+					// Use parentheses in case of multiple guest authorss. Comma separators would be nonsensical: Firstname lastname, Job Title, Secondname Thirdname, and Fourthname Middle Fifthname
+					$byline_temp .= ' (' . $job . ')';
+				}
+
+				$out[] = $byline_temp;
 
 			}
 
@@ -126,6 +131,7 @@ if ( ! function_exists( 'largo_byline' ) ) {
 				$authors = $out[0];
 			}
 
+		// If Co-Authors Plus is not enabled
 		} else {
 			$authors = largo_author_link( false, $post_id );
 			$author_id = get_post_meta( $post_id, 'post_author', true );
@@ -133,7 +139,6 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			if ( $show_job_titles && $job = get_the_author_meta( 'job_title' , $author_id ) ) {
 				$authors  .= ', ' . $job;
 			}
-
 		}
 
 		$output = '<span class="by-author"><span class="by">' . __( 'By', 'largo' ) . '</span> <span class="author vcard" itemprop="author">' . $authors . '</span></span>';

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -66,6 +66,10 @@ if ( ! function_exists( 'largo_author_link' ) ) {
 
 		$byline_text = isset( $values['largo_byline_text'] ) ? $values['largo_byline_text'][0] : get_the_author_meta('display_name', $author_id);
 
+		if ( $job = get_the_author_meta( 'job_title' )) {
+			$byline_text .= ', ' . $job;
+		}
+
 		// if it's a custom byline but there's no link, just output the byline text
 		if ( isset( $values['largo_byline_text'] ) && !isset( $values['largo_byline_link'] ) ) {
 			$output = esc_html( $byline_text );

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -106,7 +106,8 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			$coauthors = get_coauthors( $post_id );
 			foreach( $coauthors as $author ) {
 				$byline_text = $author->display_name;
-				if ( $job = $author->job_title )
+				$show_job_titles = of_get_option('show_job_titles');
+				if ( $job = $author->job_title && $show_job_titles )
 					$byline_text .= ', ' . $job;
 				if ( $org = $author->organization )
 					$byline_text .= ' (' . $org . ')';
@@ -128,7 +129,8 @@ if ( ! function_exists( 'largo_byline' ) ) {
 		} else {
 			$authors = largo_author_link( false, $post_id );
 			$author_id = get_post_meta( $post_id, 'post_author', true );
-			if ( $job = get_the_author_meta( 'job_title' , $author_id )) {
+			$show_job_titles = of_get_option('show_job_titles');
+			if ( $show_job_titles && $job = get_the_author_meta( 'job_title' , $author_id ) ) {
 				$authors  .= ', ' . $job;
 			}
 

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -66,10 +66,6 @@ if ( ! function_exists( 'largo_author_link' ) ) {
 
 		$byline_text = isset( $values['largo_byline_text'] ) ? $values['largo_byline_text'][0] : get_the_author_meta('display_name', $author_id);
 
-		if ( $job = get_the_author_meta( 'job_title' )) {
-			$byline_text .= ', ' . $job;
-		}
-
 		// if it's a custom byline but there's no link, just output the byline text
 		if ( isset( $values['largo_byline_text'] ) && !isset( $values['largo_byline_link'] ) ) {
 			$output = esc_html( $byline_text );
@@ -131,6 +127,11 @@ if ( ! function_exists( 'largo_byline' ) ) {
 
 		} else {
 			$authors = largo_author_link( false, $post_id );
+			$author_id = get_post_meta( $post_id, 'post_author', true );
+			if ( $job = get_the_author_meta( 'job_title' , $author_id )) {
+				$authors  .= ', ' . $job;
+			}
+
 		}
 
 		$output = '<span class="by-author"><span class="by">' . __( 'By', 'largo' ) . '</span> <span class="author vcard" itemprop="author">' . $authors . '</span></span>';

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -106,7 +106,7 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			$coauthors = get_coauthors( $post_id );
 			foreach( $coauthors as $author ) {
 				$byline_text = $author->display_name;
-				if ( $author->show_job_title && $job = $author->job_title )
+				if ( $job = $author->job_title )
 					$byline_text .= ', ' . $job;
 				if ( $org = $author->organization )
 					$byline_text .= ' (' . $org . ')';
@@ -128,8 +128,7 @@ if ( ! function_exists( 'largo_byline' ) ) {
 		} else {
 			$authors = largo_author_link( false, $post_id );
 			$author_id = get_post_meta( $post_id, 'post_author', true );
-			$show_job_title = get_the_author_meta( 'show_job_title', $author_id);
-			if ( $show_job_title === 'on' && $job = get_the_author_meta( 'job_title' , $author_id )) {
+			if ( $job = get_the_author_meta( 'job_title' , $author_id )) {
 				$authors  .= ', ' . $job;
 			}
 

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -106,7 +106,7 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			$coauthors = get_coauthors( $post_id );
 			foreach( $coauthors as $author ) {
 				$byline_text = $author->display_name;
-				if ( $job = $author->job_title )
+				if ( $author->show_job_title && $job = $author->job_title )
 					$byline_text .= ', ' . $job;
 				if ( $org = $author->organization )
 					$byline_text .= ' (' . $org . ')';
@@ -128,7 +128,8 @@ if ( ! function_exists( 'largo_byline' ) ) {
 		} else {
 			$authors = largo_author_link( false, $post_id );
 			$author_id = get_post_meta( $post_id, 'post_author', true );
-			if ( $job = get_the_author_meta( 'job_title' , $author_id )) {
+			$show_job_title = get_the_author_meta( 'show_job_title', $author_id);
+			if ( $show_job_title === 'on' && $job = get_the_author_meta( 'job_title' , $author_id )) {
 				$authors  .= ', ' . $job;
 			}
 

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -106,6 +106,8 @@ if ( ! function_exists( 'largo_byline' ) ) {
 			$coauthors = get_coauthors( $post_id );
 			foreach( $coauthors as $author ) {
 				$byline_text = $author->display_name;
+				if ( $job = $author->job_title )
+					$byline_text .= ', ' . $job;
 				if ( $org = $author->organization )
 					$byline_text .= ' (' . $org . ')';
 

--- a/inc/users.php
+++ b/inc/users.php
@@ -85,13 +85,6 @@ function largo_filter_guest_author_fields( $fields_to_return, $groups ) {
 			'group'    => 'name',
 		);
 		$fields_to_return[] = array(
-			'key'      => 'show_job_title',
-			'label'    => 'Show Job Title',
-			'group'    => 'contact-info',
-			'input'    => 'checkbox',
-			'type'     => 'checkbox',
-		);
-		$fields_to_return[] = array(
 			'key'      => 'organization',
 			'label'    => 'Organization',
 			'group'    => 'name',
@@ -272,7 +265,6 @@ add_shortcode('roster', 'largo_render_staff_list_shortcode');
  */
 function more_profile_info($user) {
 	$show_email = get_user_meta( $user->ID, "show_email", true );
-	$show_job_title = get_user_meta( $user->ID, "show_job_title", true );
 	$hide = get_user_meta( $user->ID, "hide", true );
 	?>
 	<h3><?php _e( 'More profile information', 'largo' ); ?></h3>
@@ -282,15 +274,6 @@ function more_profile_info($user) {
 			<td>
 				<input type="text" name="job_title" id="job_title" value="<?php echo esc_attr( get_the_author_meta( 'job_title', $user->ID ) ); ?>" class="regular-text" /><br />
 				<span class="description"><?php _e( 'Please enter your job title.', 'largo' ); ?></span>
-			</td>
-		</tr>
-
-		<tr>
-			<th><label for="show_job_title"><?php _e( 'Show Job Title', 'largo' ); ?></label></th>
-			<td>
-				<input type="checkbox" name="show_job_title" id="show_job_title"
-					<?php if ( esc_attr($show_job_title) === "on" ) { ?>checked<?php } ?> />
-				<label for="show_job_title"><?php _e( 'Show job title publicly?', 'largo' ); ?></label><br />
 			</td>
 		</tr>
 
@@ -329,10 +312,6 @@ function save_more_profile_info($user_id) {
 	if (!current_user_can('edit_user', $user_id ))
 		return false;
 	
-	if ( ! isset($_POST['show_job_title']) ) {
-		$_POST['show_job_title'] = 'off';
-	}
-
 	if ( ! isset($_POST['show_email']) ) {
 		$_POST['show_email'] = 'off';
 	}
@@ -346,7 +325,6 @@ function save_more_profile_info($user_id) {
 
 	update_user_meta($user_id, 'job_title', $job_title);
 	update_user_meta($user_id, 'show_email', $show_email);
-	update_user_meta($user_id, 'show_job_title', $show_job_title);
 	update_user_meta($user_id, 'hide', $hide);
 }
 add_action('personal_options_update', 'save_more_profile_info');

--- a/inc/users.php
+++ b/inc/users.php
@@ -70,6 +70,13 @@ function largo_filter_guest_author_fields( $fields_to_return, $groups ) {
 			'label'    => 'Google+<br><em>https://plus.google.com/userID/</em>',
 			'group'    => 'contact-info',
 		);
+		$fields_to_return[] = array(
+			'key'      => 'show_email',
+			'label'    => 'Show Email Address',
+			'group'    => 'contact-info',
+			'input'    => 'checkbox',
+			'type'     => 'checkbox',
+		);
 	}
 	if ( in_array( 'all', $groups ) || in_array( 'name', $groups ) ) {
 		$fields_to_return[] = array(

--- a/inc/users.php
+++ b/inc/users.php
@@ -73,6 +73,11 @@ function largo_filter_guest_author_fields( $fields_to_return, $groups ) {
 	}
 	if ( in_array( 'all', $groups ) || in_array( 'name', $groups ) ) {
 		$fields_to_return[] = array(
+			'key'      => 'job_title',
+			'label'    => 'Job Title',
+			'group'    => 'name',
+		);
+		$fields_to_return[] = array(
 			'key'      => 'organization',
 			'label'    => 'Organization',
 			'group'    => 'name',

--- a/inc/users.php
+++ b/inc/users.php
@@ -85,6 +85,13 @@ function largo_filter_guest_author_fields( $fields_to_return, $groups ) {
 			'group'    => 'name',
 		);
 		$fields_to_return[] = array(
+			'key'      => 'show_job_title',
+			'label'    => 'Show Job Title',
+			'group'    => 'contact-info',
+			'input'    => 'checkbox',
+			'type'     => 'checkbox',
+		);
+		$fields_to_return[] = array(
 			'key'      => 'organization',
 			'label'    => 'Organization',
 			'group'    => 'name',
@@ -265,6 +272,7 @@ add_shortcode('roster', 'largo_render_staff_list_shortcode');
  */
 function more_profile_info($user) {
 	$show_email = get_user_meta( $user->ID, "show_email", true );
+	$show_job_title = get_user_meta( $user->ID, "show_job_title", true );
 	$hide = get_user_meta( $user->ID, "hide", true );
 	?>
 	<h3><?php _e( 'More profile information', 'largo' ); ?></h3>
@@ -274,6 +282,15 @@ function more_profile_info($user) {
 			<td>
 				<input type="text" name="job_title" id="job_title" value="<?php echo esc_attr( get_the_author_meta( 'job_title', $user->ID ) ); ?>" class="regular-text" /><br />
 				<span class="description"><?php _e( 'Please enter your job title.', 'largo' ); ?></span>
+			</td>
+		</tr>
+
+		<tr>
+			<th><label for="show_job_title"><?php _e( 'Show Job Title', 'largo' ); ?></label></th>
+			<td>
+				<input type="checkbox" name="show_job_title" id="show_job_title"
+					<?php if ( esc_attr($show_job_title) === "on" ) { ?>checked<?php } ?> />
+				<label for="show_job_title"><?php _e( 'Show job title publicly?', 'largo' ); ?></label><br />
 			</td>
 		</tr>
 
@@ -312,6 +329,10 @@ function save_more_profile_info($user_id) {
 	if (!current_user_can('edit_user', $user_id ))
 		return false;
 	
+	if ( ! isset($_POST['show_job_title']) ) {
+		$_POST['show_job_title'] = 'off';
+	}
+
 	if ( ! isset($_POST['show_email']) ) {
 		$_POST['show_email'] = 'off';
 	}
@@ -325,6 +346,7 @@ function save_more_profile_info($user_id) {
 
 	update_user_meta($user_id, 'job_title', $job_title);
 	update_user_meta($user_id, 'show_email', $show_email);
+	update_user_meta($user_id, 'show_job_title', $show_job_title);
 	update_user_meta($user_id, 'hide', $hide);
 }
 add_action('personal_options_update', 'save_more_profile_info');

--- a/options.php
+++ b/options.php
@@ -681,6 +681,17 @@ function optionsframework_options() {
 		'std' 	=> '0',
 		'type' 	=> 'checkbox');
 
+	$options[] = array(
+		'name' 	=> __('Byline Options', 'largo'),
+		'type'	=> 'info');
+
+	$options[] = array(
+		'desc' => __('Enable display of job titles in bylines and author biographies?', 'largo'),
+		'id'   => 'show_job_titles',
+		'std'  => '0',
+		'type' => 'checkbox');
+
+
 /*
  * Removing inn_member_since in 0.5.2
 	if ( INN_MEMBER ) { // only relevant in this case, options affecting the logo display

--- a/partials/author-bio-description.php
+++ b/partials/author-bio-description.php
@@ -20,6 +20,12 @@ if ( largo_has_avatar( $author_obj->user_email ) ) {
 }
 
 // Description
+var_log($author_obj);
+if ( $author_obj->job_title && $author_obj->show_job_title ) {
+	if ( $author_obj->show_job_title === 'on' || $author_obj->show_job_title == '1' ) {
+		echo '<p class="job-title">' . esc_attr( $author_obj->job_title ) . '</p>';
+	}
+}
 if ( $author_obj->description ) {
 	echo '<p>' . esc_attr( $author_obj->description ) . '</p>';
 }

--- a/partials/author-bio-description.php
+++ b/partials/author-bio-description.php
@@ -19,6 +19,11 @@ if ( largo_has_avatar( $author_obj->user_email ) ) {
 	echo '<div class="photo">' . $photo . '</div>';
 }
 
+// Job!
+$show_job_titles = of_get_option('show_job_titles');
+if ( $job = $author_obj->job_title && $show_job_titles ) {
+	echo '<p>' . esc_attr( $author_obj->job_title ) . '</p>';
+}
 // Description
 if ( $author_obj->description ) {
 	echo '<p>' . esc_attr( $author_obj->description ) . '</p>';

--- a/partials/author-bio-description.php
+++ b/partials/author-bio-description.php
@@ -20,12 +20,6 @@ if ( largo_has_avatar( $author_obj->user_email ) ) {
 }
 
 // Description
-var_log($author_obj);
-if ( $author_obj->job_title && $author_obj->show_job_title ) {
-	if ( $author_obj->show_job_title === 'on' || $author_obj->show_job_title == '1' ) {
-		echo '<p class="job-title">' . esc_attr( $author_obj->job_title ) . '</p>';
-	}
-}
 if ( $author_obj->description ) {
 	echo '<p>' . esc_attr( $author_obj->description ) . '</p>';
 }

--- a/partials/author-bio-description.php
+++ b/partials/author-bio-description.php
@@ -22,7 +22,7 @@ if ( largo_has_avatar( $author_obj->user_email ) ) {
 // Job!
 $show_job_titles = of_get_option('show_job_titles');
 if ( $job = $author_obj->job_title && $show_job_titles ) {
-	echo '<p>' . esc_attr( $author_obj->job_title ) . '</p>';
+	echo '<p class="job-title">' . esc_attr( $author_obj->job_title ) . '</p>';
 }
 // Description
 if ( $author_obj->description ) {

--- a/partials/author-bio-social-links.php
+++ b/partials/author-bio-social-links.php
@@ -11,7 +11,14 @@ $email = $author_obj->user_email;
  * Figure out whether to hide the author's email address
  */
 $user_meta = get_user_meta($author_obj->ID);
-$show_email = $user_meta['show_email'][0];
+
+$show_email = 'off';
+if (isset($user_meta['show_email'][0])) {
+	$show_email = $user_meta['show_email'][0];
+} else if ( !empty($author_obj->show_email) ) {
+	$show_email = $author_obj->show_email;
+}
+
 ?>
 <ul class="social-links">
 	<?php if ( $fb = $author_obj->fb ) { ?>


### PR DESCRIPTION
## Changes

- Adds "Job Title" to the fields supported by Co-Authors Plus
- Adds the job title to the output of `largo_byline` if Co-Authors Plus is enabled
- Adds the job title to the output of `largo_byline` if Co-Authors Plus is not enabled
- Does not link the job title to the author's byline page
- Does not affect `largo_author_link`
- Adds the option to show a coauthor's email address. There doesn't appear to be a way to set a default, with [how the metabox is constructed](https://github.com/Automattic/Co-Authors-Plus/blob/f4da16bb59ef692d02db315771b238af7f75d8a4/php/class-coauthors-guest-authors.php#L669), so this will default to hiding the user's email address.
- Makes `partials/author-bio-social-links.php` respect the coauthors option. This will only affect coauthors users. This does not affect normal users; their email addresses will still display.

## Why

For #1097 and [WE-72](http://jira.inn.org/browse/WE-72).