### PR TITLE
Fix small problems in Recent Posts widget

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -555,7 +555,7 @@ class Largo_Related {
 		$taxonomies = get_the_terms( $this->post_id, array('category', 'post_tag') );
 
 		//loop thru taxonomies, much like series, and get posts
-		if ( count($taxonomies) ) {
+		if ( is_array($taxonomies) ) {
 			//sort by popularity
 			usort( $taxonomies, array(__CLASS__, 'popularity_sort' ) );
 

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -48,8 +48,7 @@ class largo_related_posts_widget extends WP_Widget {
 				?>
 				<h4><a href="<?php the_permalink(); ?>" title="Read: <?php esc_attr( the_title('','', FALSE) ); ?>"><?php the_title(); ?></a></h4>
 				<h5 class="byline">
-					<span class="by-author"><?php largo_byline( true, true ); ?></span>
-					<time class="entry-date updated dtstamp pubdate" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php largo_time(); ?></time>
+					<span class="by-author"><?php largo_byline( true, false ); ?></span>
 				</h5>
 				<?php // post excerpt/summary
 				largo_excerpt(get_the_ID(), 2, false, '', true);


### PR DESCRIPTION
## Changes:

- Don't duplicate the date
- Do call `largo_byline` with the argument that doesn't suppress the output of the date.
- Change the conditional determinant inside the Related Posts function, because `count(false)` returns `1`. [Yep.](https://secure.php.net/manual/en/function.count.php)

## Why

For #1110 and http://jira.inn.org/browse/WE-85