### PR TITLE
Use 'this author' instead of any other reference in the author bio read-more link

### DIFF
--- a/partials/author-bio-social-links.php
+++ b/partials/author-bio-social-links.php
@@ -53,8 +53,9 @@ if (isset($user_meta['show_email'][0])) {
 
 	<?php
 		if ( !is_author() ) {
-			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by this author">More by this author</a></li>', 'largo' ),
-				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename )
+			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by %2$s">More by %2$s</a></li>', 'largo' ),
+				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename ),
+				!empty($author_obj->first_name) ? esc_attr( $author_obj->first_name ) : __("this author", 'largo')
 			);
 		}
 	?>

--- a/partials/author-bio-social-links.php
+++ b/partials/author-bio-social-links.php
@@ -53,9 +53,8 @@ if (isset($user_meta['show_email'][0])) {
 
 	<?php
 		if ( !is_author() ) {
-			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by %2$s">More by %2$s</a></li>', 'largo' ),
-				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename ),
-				esc_attr( $author_obj->first_name )
+			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by this author">More by this author</a></li>', 'largo' ),
+				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename )
 			);
 		}
 	?>


### PR DESCRIPTION
## Changes

- Uses 'this author' if the author's first name is not available.

<img width="737" alt="screen shot 2016-01-28 at 7 16 16 pm" src="https://cloud.githubusercontent.com/assets/1754187/12663173/a7602a64-c5f3-11e5-9b75-1123470d443a.png">


## Why

This button wasn't always displaying a username, because not all users set their "first name" field in the WordPress user settings. 

For http://jira.inn.org/browse/WE-86