### PR TITLE
Use rawurlencode for maximum redundancy.

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -198,8 +198,9 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 			$fb_share = '<span class="facebook"><a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u=%1$s"><i class="icon-facebook"></i><span class="hidden-phone">%2$s</span></a></span>';
 			$output .= sprintf(
 				$fb_share,
-				esc_attr( get_permalink() ),
-				esc_attr( ucfirst( of_get_option( 'fb_verb' ) ) )
+				// Yes, rawurlencode. Otherwise, the link will break.
+				rawurlencode( get_permalink() ),
+				rawurlencode( ucfirst( of_get_option( 'fb_verb' ) ) )
 			);
 		}
 
@@ -221,14 +222,14 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 					}
 				}
 				if ( count( $author_twitters ) == 1 ) {
-					$via = '&via=' . esc_attr( largo_twitter_url_to_username( $author_twitters[0] ) );
+					$via = '&via=' . rawurlencode( largo_twitter_url_to_username( $author_twitters[0] ) );
 				}
 				// in the event that there are more than one author twitter accounts, we fall back to the org account
 				// @link https://github.com/INN/Largo/issues/1088
 			} else if ( !isset( $values['largo_byline_text'] ) ) {
 				$user =  get_the_author_meta( 'twitter' );
 				if ( !empty( $user ) ) {
-					$via = '&via=' . esc_attr( largo_twitter_url_to_username( $user ) );
+					$via = '&via=' . rawurlencode( largo_twitter_url_to_username( $user ) );
 				}
 			}
 
@@ -236,16 +237,17 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 			if ( empty( $via ) ) {
 				$site = of_get_option( 'twitter_link' );
 				if ( !empty( $site ) ) {
-					$via = '&via=' . esc_attr( largo_twitter_url_to_username( $site ) ) ;
+					$via = '&via=' . rawurlencode( largo_twitter_url_to_username( $site ) ) ;
 				}
 			}
 
 			$output .= sprintf(
 				$twitter_share,
-				esc_attr( get_the_title() ),
-				esc_attr( get_permalink() ),
+				// Yes, rawurlencode. Otherwise, the link will break.
+				rawurlencode( get_the_title() ),
+				rawurlencode( get_permalink() ),
 				$via,
-				esc_attr( __( 'Tweet', 'largo' ) )
+				rawurlencode( __( 'Tweet', 'largo' ) )
 			);
 		}
 		

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -80,6 +80,8 @@ EOT;
 		$this->assertRegExp('/class="twitter"/' , $ret, "The 'twitter' class did not appear in the output");
 		// @TODO: insert a test for the get_the_author_meta test here
 		$this->assertRegExp('/' . __('Tweet', 'largo') . '/', $ret, "The translation of 'Tweet' was not in the Twitter output");
+		$this->assertRegExp('/' . preg_quote(rawurlencode(get_permalink()), '/') . '/', $ret, "The permalink was not in the Twitter output");
+		$this->assertRegExp('/' . preg_quote(rawurlencode(get_the_title()), '/') . '/', $ret, "The title was not in the Twitter output");
 		unset($ret);
 		of_reset_options();
 
@@ -89,7 +91,7 @@ EOT;
 		largo_post_social_links();
 		$ret = ob_get_clean();
 		$this->assertRegExp('/' . preg_quote(esc_attr( of_get_option( 'fb_verb' ) ), '/' ) . '/i', $ret, "The Facebook Verb was not in the Facebook output");
-		$this->assertRegExp('/' . preg_quote(get_permalink(), '/') . '/', $ret, "The permalink was not in the Facebook output");
+		$this->assertRegExp('/' . preg_quote(rawurlencode(get_permalink()), '/') . '/', $ret, "The permalink was not in the Facebook output");
 		unset($ret);
 		of_reset_options();
 


### PR DESCRIPTION
Please don't use esc_attr for post titles that are part of URLs.

## Changes

- replaces several `esc_attr` in `largo_post_social_buttons` with `rawurlencode`: https://secure.php.net/manual/en/function.rawurlencode.php

## Why

Because the changes in https://github.com/INN/Largo/pull/1077/files were undone by the redo of the post social buttons.

## To do:

Write tests for these buttons, perhaps as part of the `largo_post_social_links` redo in #219.