### PR TITLE
Improve support for Link Roundups in archives

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -4,6 +4,7 @@
  *
  * @package Largo
  * @since 0.1
+ * @filter largo_partial_by_post_type
  */
 get_header();
 $queried_object = get_queried_object();
@@ -86,7 +87,9 @@ $queried_object = get_queried_object();
 				rewind_posts();
 
 				while ( have_posts() ) : the_post();
-					get_template_part( 'partials/content', 'archive' );
+					$post_type = get_post_type();
+					$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
+					get_template_part( 'partials/content', $partial );
 				endwhile;
 
 				largo_content_nav( 'nav-below' );

--- a/category.php
+++ b/category.php
@@ -4,6 +4,7 @@
  *
  * @package Largo
  * @since 0.4
+ * @filter largo_partial_by_post_type
  */
 get_header();
 
@@ -67,6 +68,8 @@ $queried_object = get_queried_object();
 			while ( have_posts() ) {
 				the_post();
 				//$shown_ids[] = get_the_ID();
+				$post_type = get_post_type();
+				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 				get_template_part( 'partials/content', 'archive' );
 			}
 			largo_content_nav( 'nav-below' );

--- a/partials/content-roundup.php
+++ b/partials/content-roundup.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * The template for displaying posts from the Roundup post type from INN/link-roundups
+ *
+ * @package Largo
+ * @since 0.5.4
+ * @link https://github.com/INN/link-roundups
+ * @link https://wordpress.org/plugins/link-roundups/
+ */
+$tags = of_get_option( 'tag_display' );
+$hero_class = largo_hero_class( $post->ID, FALSE );
+$values = get_post_custom( $post->ID );
+$featured = has_term( 'homepage-featured', 'prominence' );
+?>
+<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
+
+	<?php
+		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails or videos.
+		$entry_classes = 'entry-content';
+		echo '<div class="' . $entry_classes . '">';
+
+		if ( largo_has_categories_or_tags() && $tags === 'top' ) {
+		 	echo '<h5 class="top-tag">' . largo_top_term( $args = array( 'echo' => FALSE ) ) . '</h5>';
+		}
+	?>
+
+		<h2 class="entry-title">
+			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
+		</h2>
+
+		<h5 class="byline visuallyhidden"><?php largo_byline(); ?></h5>
+
+		<?php the_content(); ?>
+
+		</div><!-- .entry-content -->
+
+</article><!-- #post-<?php the_ID(); ?> -->

--- a/partials/content-rounduplink.php
+++ b/partials/content-rounduplink.php
@@ -1,4 +1,15 @@
-<?php $custom = get_post_custom($post->ID); ?>
+<?php
+/*
+ * The template for displaying posts from the Roundup Link post type from INN/link-roundups
+ *
+ * @package Largo
+ * @since 0.5.4
+ * @link https://github.com/INN/link-roundups
+ * @link https://wordpress.org/plugins/link-roundups/
+ */
+
+$custom = get_post_custom($post->ID);
+?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
 	<header>

--- a/partials/content-rounduplink.php
+++ b/partials/content-rounduplink.php
@@ -1,0 +1,25 @@
+<?php $custom = get_post_custom($post->ID); ?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
+	<header>
+		<h2 class="entry-title"><?php echo ( isset( $custom['lr_url'][0] ) ) ? '<a href="' . $custom['lr_url'][0] . '">' . get_the_title() . '</a>' : get_the_title(); ?></h2>
+	</header>
+
+	<div class="entry-content">
+	<?php
+	if ( isset( $custom['lr_desc'][0] ) ) {
+		echo '<p class="description">';
+		echo $custom['lr_desc'][0];
+		echo '</p>';
+	}
+	if ( isset($custom['lr_source'][0] ) ) {
+		echo '<p class="source">' . __('Source: ', 'argo-links') . '<span>';
+		echo ( isset( $custom['lr_url'][0] ) ) ? '<a href="' . $custom['lr_url'][0] . '">' . $custom['lr_source'][0] . '</a>' : $custom['lr_source'][0];
+		echo '</span></p>';
+	}
+	?>
+	<p class="posted-on">Posted on: <?php the_time('F j, Y') ?></p>
+	</div>
+</article> <!-- /.post-lead -->
+
+


### PR DESCRIPTION
## Changes

- Create partials for use in Largo:
    - `content-rounduplink.php`: no byline, very little in the way of content. This is essentially a rehash of the `argolinks` partial removed for #926.
    - `content-roundup.php`:
        - displays whole `the_content()` in archives, as the content will be primarily shortcodes and thus will not be rendered in `largo_excerpt`. 
        - byline is output, buy `.visuallyhidden`
- In `archive.php` and `category.php`, use `largo_get_partial_by_post_type` for the partial selector, so those can be filtered with `largo_partial_by_post_type`.

A demonstration of the `content-roundup.php` partial in the archive:

<img width="685" alt="screen shot 2016-02-05 at 5 43 38 pm" src="https://cloud.githubusercontent.com/assets/1754187/12861249/087af60c-cc30-11e5-8d91-d1a8e1abf91e.png">

Generated saved links, with one edited to have a description and link:

<img width="656" alt="screen shot 2016-02-05 at 5 44 19 pm" src="https://cloud.githubusercontent.com/assets/1754187/12861267/25dcfb82-cc30-11e5-81f3-7ea90f64e1c8.png">


## Why

While the Link Roundups plugin can use the filter `largo_partial_by_post_type`, it can't provide partials that will be loaded by [`get_template_part( 'partials/content', $partial )`](https://codex.wordpress.org/Function_Reference/get_template_part) unless we also filter the `partials/content` part of `get_template_part`.

So, a compromise: 

- Largo keeps the partials
- Link roundups does the filtering ( PR https://github.com/INN/link-roundups/pull/109 )

To get the `/rounduplink/` and `/roundup/` archives, all that needs be done is for the site user to resave permalinks after activating the plugin. Both post types are registered with `'has_archive' => true,`, so the archives will automatically be available in at those urls.
