### PR TITLE
Make the archive.php rounduplinks title filterable

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -54,7 +54,7 @@ $queried_object = get_queried_object();
 				 * @param string $title The title of the archive page
 				 * @since 0.5.4
 				 */
-				$title = apply_filters('largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
+				$title = apply_filters( 'largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
 				$rss_link = '/rounduplink/feed';
 			}
 		?>

--- a/archive.php
+++ b/archive.php
@@ -47,7 +47,14 @@ $queried_object = get_queried_object();
 					$title = _e( 'Blog Archives', 'largo' );
 				}
 			} elseif ( is_post_type_archive( 'rounduplink' ) ) {
-				$title = __( 'Saved Links' , 'largo' );
+				/**
+				 * Make the title of the rounduplink archive filterable
+				 *
+				 * @link https://github.com/INN/Largo/issues/1123
+				 * @param string $title The title of the archive page
+				 * @since 0.5.4
+				 */
+				$title = apply_filters('largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
 				$rss_link = '/rounduplink/feed';
 			}
 		?>

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -37,6 +37,17 @@ filter: **largo_homepage_topstories_post_count**
 Other filters and actions
 -------------------------
 
+filter: **largo_archive_rounduplink_title**
+
+    Called in `archive.php` to filter the page title for posts in the `rounduplink` post type.
+
+    **Usage:** ::
+
+    function filter_rounduplink_title($title) {
+        return "Custom title here";
+    }
+    add_action('largo_archive_rounduplink_title', 'filter_rounduplink_title');
+
 filter: **largo_registration_extra_fields**
 
     Called directly before the `[largo_registration_form]` shortcode has finished executing. You can append to this any addition form fields that you want to process.


### PR DESCRIPTION
## Changes

- creates new filter `largo_archive_rounduplink_title` and runs the title of `archive.php` through that when the archive is for the `rounduplink` post type.
- docs for same in `developers/hooksfilters.rst`, including example function.

## Why

For #1123 and http://jira.inn.org/browse/GIJN-35