### PR TITLE
Make the article-bottom widget area into an action

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -261,6 +261,7 @@ These actions are run on all homepage templates, including the Legacy Three Colu
  - **largo_after_post_content** - directly after the .entry-content closing <div> tag
  - **largo_after_post_footer** (deprecated in 0.4) - before the closing </article> tag, replaced in the new layouts by largo_after_post_content
  - **largo_before_post_bottom_widget_area** - after the closing </article> tag but before the post bottom widget area
+ - **largo_post_bottom_widget_area** - by default, the "Article Bottom" widget area is output here through `largo_post_bottom_widget_area`
  - **largo_after_post_bottom_widget_area** - directly after the post bottom widget area (but before the comments section)
  - **largo_before_comments** - before the comments section
  - **largo_after_comments** - after the comments section

--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -354,9 +354,30 @@ function largo_sidebar_span_class() {
 		return 'span4';
 }
 
+/**
+ * Output the "Header Widget" sidebar
+ *
+ * @action largo_header_after_largo_header
+ * @since 0.5.5
+ */
 function largo_header_widget_sidebar() {
 	if ( of_get_option('header_widget_enabled') ) {
 		dynamic_sidebar('header-widget');
 	}
 }
 add_action('largo_header_after_largo_header', 'largo_header_widget_sidebar');
+
+/**
+ * Output the "Article Bottom" sidebar
+ *
+ * @action largo_header_after_largo_header
+ * @since 0.5.5
+ */
+function largo_post_bottom_widget_area() {
+	if ( is_active_sidebar( 'article-bottom' ) ) {
+		echo '<div class="article-bottom nocontent">';
+		dynamic_sidebar( 'article-bottom' );
+		echo '</div>';
+	}
+}
+add_action('largo_post_bottom_widget_area', 'largo_post_bottom_widget_area');

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -26,17 +26,12 @@ get_header();
 			get_template_part( 'partials/content', $partial );
 
 			if ( $partial === 'single' ) {
-				if ( is_active_sidebar( 'article-bottom' ) ) {
 
-					do_action( 'largo_before_post_bottom_widget_area' );
+				do_action( 'largo_before_post_bottom_widget_area' );
 
-					echo '<div class="article-bottom nocontent">';
-					dynamic_sidebar( 'article-bottom' );
-					echo '</div>';
+				do_action( 'largo_post_bottom_widget_area' );
 
-					do_action( 'largo_after_post_bottom_widget_area' );
-
-				}
+				do_action( 'largo_after_post_bottom_widget_area' );
 
 				do_action( 'largo_before_comments' );
 

--- a/single-two-column.php
+++ b/single-two-column.php
@@ -16,10 +16,9 @@ get_header();
 ?>
 
 <div id="content" class="span8" role="main">
-
 	<?php
 		while ( have_posts() ) : the_post();
-		
+
 			$shown_ids[] = get_the_ID();
 
 			$partial = ( is_page() ) ? 'page' : 'single-classic';
@@ -27,23 +26,18 @@ get_header();
 			get_template_part( 'partials/content', $partial );
 
 			if ( $partial == 'single-classic' ) {
-				if ( is_active_sidebar( 'article-bottom' ) ) {
 
-					do_action( 'largo_before_post_bottom_widget_area' );
+				do_action( 'largo_before_post_bottom_widget_area' );
 
-					echo '<div class="article-bottom nocontent">';
-					dynamic_sidebar( 'article-bottom' );
-					echo '</div>';
+				do_action( 'largo_post_bottom_widget_area' );
 
-					do_action( 'largo_after_post_bottom_widget_area' );
+				do_action( 'largo_after_post_bottom_widget_area' );
 
-				}
-
-				do_action('largo_before_comments');
+				do_action( 'largo_before_comments' );
 
 				comments_template( '', true );
 
-				do_action('largo_after_comments');
+				do_action( 'largo_after_comments' );
 			}
 
 		endwhile;


### PR DESCRIPTION
## Changes

- Replaces the article-bottom widget area call in the single one- and two-column templates with the action `largo_post_bottom_widget_area`
- Adds new function `largo_post_bottom_widget_area` to output the article-bottom widget area, hooked on `largo_post_bottom_widget_area`. (Same name for function and action.)
- Docs in docs/developers/hooksfilters.rst

## Why

To make it easier to modify this area.