### PR TITLE
Deprecate the constant SHOW_STICKY_NAV

### DIFF
--- a/docs/developers/constants.rst
+++ b/docs/developers/constants.rst
@@ -73,7 +73,7 @@ The other constants
 
 .. php:const:: SHOW_STICKY_NAV
 
-	**DEPRECATED** in Largo version 0.5.4. Conditional logic based on this constant should remove the conditional logic, and make sure that the HTML stucture is similar to that of `partials/nav_sticky.php <https://github.com/INN/Largo/blob/master/partials/nav-sticky.php>`_. The element ``#sticky-nav-holder`` will be shown or hidden by `navigation.js <https://github.com/INN/Largo/blob/master/js/navigation.js>`_.
+	**DEPRECATED** in Largo version 0.5.5. Conditional logic based on this constant should remove the conditional logic, and make sure that the HTML stucture is similar to that of `partials/nav_sticky.php <https://github.com/INN/Largo/blob/master/partials/nav-sticky.php>`_. The element ``#sticky-nav-holder`` will be shown or hidden by `navigation.js <https://github.com/INN/Largo/blob/master/js/navigation.js>`_.
 
 	The sticky nav used to appear on the homepage and all internal pages, and on mobile devices, governed by ``SHOW_STICKY_NAV``. ``SHOW_STICKY_NAV`` may be defined to be true or false.
 

--- a/docs/developers/constants.rst
+++ b/docs/developers/constants.rst
@@ -73,7 +73,9 @@ The other constants
 
 .. php:const:: SHOW_STICKY_NAV
 
-	The sticky nav appears on the homepage and all internal pages, and on mobile devices, governed by ``SHOW_STICKY_NAV``. ``SHOW_STICKY_NAV`` my be defined to be true or false, but the easiest way to set it is to check "Show the Sticky Nav" in the Theme Options section of Largo.
+	**DEPRECATED** in Largo version 0.5.4. Conditional logic based on this constant should remove the conditional logic, and make sure that the HTML stucture is similar to that of `partials/nav_sticky.php <https://github.com/INN/Largo/blob/master/partials/nav-sticky.php>`_. The element ``#sticky-nav-holder`` will be shown or hidden by `navigation.js <https://github.com/INN/Largo/blob/master/js/navigation.js>`_.
+
+	The sticky nav used to appear on the homepage and all internal pages, and on mobile devices, governed by ``SHOW_STICKY_NAV``. ``SHOW_STICKY_NAV`` may be defined to be true or false.
 
 .. php:const:: SHOW_MAIN_NAV
 

--- a/functions.php
+++ b/functions.php
@@ -301,11 +301,7 @@ class Largo {
 		 * @link https://github.com/INN/Largo/issues/1135
 		 */
 		if ( ! defined( 'SHOW_STICKY_NAV' ) ) {
-			if ( of_get_option( 'sticky_nav_display_article' ) ) {
-				define( 'SHOW_STICKY_NAV', TRUE );
-			} else {
-				define( 'SHOW_STICKY_NAV', FALSE );
-			}
+			define( 'SHOW_STICKY_NAV', FALSE );
 		}
 		if ( ! defined( 'SHOW_MAIN_NAV' ) ) {
 			define( 'SHOW_MAIN_NAV', TRUE );

--- a/functions.php
+++ b/functions.php
@@ -299,7 +299,6 @@ class Largo {
 		/*
 		 * SHOW_STICKY_NAV is deprecated.
 		 * @link https://github.com/INN/Largo/issues/1135
-		 * @since 0.5.5
 		 */
 		if ( ! defined( 'SHOW_STICKY_NAV' ) ) {
 			define( 'SHOW_STICKY_NAV', FALSE );

--- a/functions.php
+++ b/functions.php
@@ -296,8 +296,12 @@ class Largo {
 		if ( ! defined( 'SHOW_GLOBAL_NAV' ) ) {
 			define( 'SHOW_GLOBAL_NAV', TRUE );
 		}
+		/*
+		 * SHOW_STICKY_NAV is deprecated.
+		 * @link https://github.com/INN/Largo/issues/1135
+		 */
 		if ( ! defined( 'SHOW_STICKY_NAV' ) ) {
-			if ( of_get_option( 'show_sticky_nav' ) ) {
+			if ( of_get_option( 'sticky_nav_display_article' ) ) {
 				define( 'SHOW_STICKY_NAV', TRUE );
 			} else {
 				define( 'SHOW_STICKY_NAV', FALSE );

--- a/functions.php
+++ b/functions.php
@@ -299,6 +299,7 @@ class Largo {
 		/*
 		 * SHOW_STICKY_NAV is deprecated.
 		 * @link https://github.com/INN/Largo/issues/1135
+		 * @since 0.5.5
 		 */
 		if ( ! defined( 'SHOW_STICKY_NAV' ) ) {
 			define( 'SHOW_STICKY_NAV', FALSE );

--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -1,14 +1,16 @@
 <?php
 
 /**
- * Check for active Sticky Nav
+ * DEPRECATED: Check the constant SHOW_STICKY_NAV.
  *
- * Checks both the option and the constant to see if the sticky nav is currently showing.
+ * Whether or not the sticky nav is displayed is determined by the javascript in js/navigation.js, since Largo 0.5.4.
  *
+ * @deprecated the constant SHOW_STICKY_NAV is deprecated
+ * @link https://github.com/INN/Largo/issues/1135
  * @since 0.5.2
  */
 function largo_sticky_nav_active() {
-    if ( SHOW_STICKY_NAV == true && of_get_option( 'show_sticky_nav' ) ) {
+    if ( SHOW_STICKY_NAV ) ) {
         return true;
     }
     return false;

--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -5,13 +5,15 @@
  *
  * Whether or not the sticky nav is displayed is determined by the javascript in js/navigation.js, since Largo 0.5.4.
  *
- * @return False
  * @deprecated the constant SHOW_STICKY_NAV is deprecated
  * @link https://github.com/INN/Largo/issues/1135
- * @since 0.5.5
+ * @since 0.5.2
  */
 function largo_sticky_nav_active() {
-	return false;
+    if ( SHOW_STICKY_NAV ) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -5,15 +5,16 @@
  *
  * Whether or not the sticky nav is displayed is determined by the javascript in js/navigation.js, since Largo 0.5.4.
  *
+ * @return Bool
  * @deprecated the constant SHOW_STICKY_NAV is deprecated
  * @link https://github.com/INN/Largo/issues/1135
- * @since 0.5.2
+ * @since 0.5.5
  */
 function largo_sticky_nav_active() {
-    if ( SHOW_STICKY_NAV ) {
-        return true;
-    }
-    return false;
+	if ( SHOW_STICKY_NAV ) {
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -10,7 +10,7 @@
  * @since 0.5.2
  */
 function largo_sticky_nav_active() {
-    if ( SHOW_STICKY_NAV ) ) {
+    if ( SHOW_STICKY_NAV ) {
         return true;
     }
     return false;

--- a/inc/header-footer.php
+++ b/inc/header-footer.php
@@ -5,15 +5,13 @@
  *
  * Whether or not the sticky nav is displayed is determined by the javascript in js/navigation.js, since Largo 0.5.4.
  *
+ * @return False
  * @deprecated the constant SHOW_STICKY_NAV is deprecated
  * @link https://github.com/INN/Largo/issues/1135
- * @since 0.5.2
+ * @since 0.5.5
  */
 function largo_sticky_nav_active() {
-    if ( SHOW_STICKY_NAV ) {
-        return true;
-    }
-    return false;
+	return false;
 }
 
 /**

--- a/inc/update.php
+++ b/inc/update.php
@@ -369,11 +369,6 @@ function largo_force_settings_update() {
 	$options = array();
 	// paste in default settings from options.php after this line;
 	$options[] = array(
-		'desc'  => __('Show the <strong>sticky nav</strong>? Default is to show, but in some cases you may want to hide it.'),
-		'id'    => 'show_sticky_nav',
-		'std' 	=> '1',
-		'type' 	=> 'checkbox');
-	$options[] = array(
 		'desc' 	=> __('Starting with version 0.4, Largo introduced a new single-post template that more prominently highlights article content, which is the default. For backward compatibility, the pre-0.3 version is also available.', 'largo'),
 		'id' 	=> 'single_template',
 		'std' 	=> 'normal',

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -359,7 +359,6 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 	function test_largo_force_settings_update() {
 		of_reset_options();
 		largo_force_settings_update();
-		$this->assertEquals('1', of_get_option('show_sticky_nav'));
 		$this->assertEquals('normal', of_get_option('single_template'));
 	}
 


### PR DESCRIPTION
## Changes

- Notes that `SHOW_STICKY_NAV` is deprecated in the constants list in the dev docs
- Since the theme option `show_sticky_nav` was removed in #1024, ~~uses `sticky_nav_display_article` as an approximation of whether or not the sticky nav should be displayed. This is a temporary fix, and is not meant to accurately reflect whether or not the sticky nav should be displayed. This is only to avoid the sticky nav never displaying.~~ this PR defines `SHOW_STICKY_NAV` as false.
- Removes the update function for `show_sticky_nav` in `inc/updates.php`
- Removes the test for the update function's `show_sticky_nav` updater
- Marks `largo_sticky_nav_active` as deprecated as well, because that function existed to return `SHOW_STICKY_NAV`. `largo_sticky_nav_active` has no tests.

## Why

This is a compatibility fix, to ensure that sites still using `SHOW_STICKY_NAV` will continue to work.

Because `SHOW_STICKY_NAV` no longer is an accurate descriptor of whether or not the sticky nav should be displayed, and because the decision on whether or not to show the sticky nav is made by `navigation.js` since #1024. 

We're keeping `SHOW_STICKY_NAV` to avoid undefined constant errors in child themes ~~and giving it a value that isn't false so that the navigation will continue to display,~~ to avoid problems on sites using `SHOW_STICKY_NAV`. [HELPDESK-568](http://jira.inn.org/browse/HELPDESK-568) is such a site.

See #1135 for the non-hotfix solution for this issue: 

- [x] check all child themes for `SHOW_STICKY_NAV` and remove those conditionals if and only if the child theme does not define `SHOW_STICKY_NAV` to true.
- [ ] mention that this is deprecated in the 0.5.5 release notes.

For [HELPDESK-568](http://jira.inn.org/browse/HELPDESK-568) and #1135