### PR TITLE
Use the output of the largo_post_social_links filter

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -336,7 +336,7 @@ EOD;
 		 * @since 0.5.3
 		 * @param string $output A div containing a number of spans containing social links and other utilities.
 		 */
-		apply_filters( 'largo_post_social_links', $output );
+		$output = apply_filters( 'largo_post_social_links', $output );
 
 		if ( $echo ) {
 			echo $output;


### PR DESCRIPTION
## Changes

- Sets the variable containing the future output of `largo_post_social_links()` to the return of the filter `largo_post_social_links`

## Why

Because we had a filter that wasn't actually affecting the output on the page.

For http://jira.inn.org/browse/NQ-127