### PR TITLE
Ensure term featured media don't display if override display option is checked.

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -66,7 +66,10 @@ $queried_object = get_queried_object();
 				}
 
 				$post_id = largo_get_term_meta_post( $queried_object->taxonomy, $queried_object->term_id );
-				largo_hero($post_id);
+				$term_post_custom = get_post_meta($post_id, 'featured-image-display');
+				if ( empty( $term_post_custom ) ) {
+					largo_hero($post_id);
+				}
 
 				if ( isset( $title ) ) {
 					echo '<h1 class="page-title">' . $title . '</h1>';

--- a/category.php
+++ b/category.php
@@ -22,7 +22,10 @@ $queried_object = get_queried_object();
 		<a class="rss-link rss-subscribe-link" href="<?php echo $rss_link; ?>"><?php echo __( 'Subscribe', 'largo' ); ?> <i class="icon-rss"></i></a>
 		<?php
 			$post_id = largo_get_term_meta_post( $queried_object->taxonomy, $queried_object->term_id );
-			largo_hero($post_id);
+			$term_post_custom = get_post_meta($post_id, 'featured-image-display');
+			if ( empty( $term_post_custom ) ) {
+				largo_hero($post_id);
+			}
 		?>
 		<h1 class="page-title"><?php echo $title; ?></h1>
 		<div class="archive-description"><?php echo $description; ?></div>


### PR DESCRIPTION
## Changes

- Make doubly sure that term featured media doesn't display on category/term archive pages, if the option to override display is checked in the featured media editor on the term's edit page.

## How

If the option to hide is unchecked, `get_post_meta($post_id, 'featured-image-display')` returns empty array.

If the option to hide is checked, indicating intent to hide, `get_post_meta($post_id, 'featured-image-display')` returns 

```php
array (
  0 => 'false',
)
```

Thus, an empty `$term_post_custom` here means that it should be displayed, and not-empty means that it should be hidden.

## Why

- For http://jira.inn.org/browse/RNS-162