### PR TITLE
Use html_entity_decode on twitter title in share text

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -244,8 +244,8 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 
 			$output .= sprintf(
 				$twitter_share,
-				// Yes, rawurlencode. Otherwise, the link will break.
-				rawurlencode( get_the_title() ),
+				// Yes, rawurlencode. Otherwise, the link will break. Use html_entity_decode to handle wordpress saving smart quotes as &#1234; entities.
+				rawurlencode( html_entity_decode( get_the_title(), ENT_QUOTES, "UTF-8" ) ),
 				rawurlencode( get_permalink() ),
 				$via,
 				rawurlencode( __( 'Tweet', 'largo' ) )


### PR DESCRIPTION
## Changes

- Converts all HTML entities, including numeric ones, to their UTF-8 characters before encoding them with `rawurlencode`. The flags come from this comment: https://secure.php.net/manual/en/function.html-entity-decode.php#93378

## Why

#1134 and http://jira.inn.org/browse/WE-92