### PR TITLE
Add name and job title to the alt attribute of images in the Largo Staff Widget

### DIFF
--- a/inc/widgets/largo-staff.php
+++ b/inc/widgets/largo-staff.php
@@ -43,8 +43,10 @@ class largo_staff_widget extends WP_Widget {
 			if ($hide == 'on')
 				continue;
 
-			$job_title = get_user_meta($user->ID, 'job_title', true);
-			$avatar_alt = esc_attr( $user->first_name . ' ' . $user->last_name . ', ' . $job_title );
+			$avatar_alt = esc_attr( $user->first_name . ' ' . $user->last_name );
+			if ( $job_title = get_user_meta( $user->ID, 'job_title', true ) ) {
+				$avatar_alt .= ' (' . $job_title . ')';
+			}
 			$avatar = get_avatar($user->ID, '65', null, $avatar_alt);
 			$author_url = get_author_posts_url($user->ID);
 

--- a/inc/widgets/largo-staff.php
+++ b/inc/widgets/largo-staff.php
@@ -47,7 +47,7 @@ class largo_staff_widget extends WP_Widget {
 			if ( $job_title = get_user_meta( $user->ID, 'job_title', true ) ) {
 				$avatar_alt .= ' (' . $job_title . ')';
 			}
-			$avatar = get_avatar($user->ID, '65', null, $avatar_alt);
+			$avatar = get_avatar($user->ID, '65', null, esc_attr($avatar_alt));
 			$author_url = get_author_posts_url($user->ID);
 
 			$user_posts_link = '';

--- a/inc/widgets/largo-staff.php
+++ b/inc/widgets/largo-staff.php
@@ -43,9 +43,10 @@ class largo_staff_widget extends WP_Widget {
 			if ($hide == 'on')
 				continue;
 
-			$avatar = get_avatar($user->ID, '65');
-			$author_url = get_author_posts_url($user->ID);
 			$job_title = get_user_meta($user->ID, 'job_title', true);
+			$avatar_alt = esc_attr( $user->first_name . ' ' . $user->last_name . ', ' . $job_title );
+			$avatar = get_avatar($user->ID, '65', null, $avatar_alt);
+			$author_url = get_author_posts_url($user->ID);
 
 			$user_posts_link = '';
 			if (count_user_posts($user->ID) > 0)


### PR DESCRIPTION
## Changes

- Adds the authors' first name, last name, comma, job title to the alt attribute of avatars in the staff list widget. (get_avatar does not respect the image's alt text, for whatever reason. :black_joker:)

## why

http://jira.inn.org/browse/HELPDESK-576