### PR TITLE
Ignore posts from main query in Largo Recent Posts widget

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -97,6 +97,10 @@ $queried_object = get_queried_object();
 				rewind_posts();
 
 				while ( have_posts() ) : the_post();
+					// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
+					// See 
+					// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
+					// $shown_ids[] = get_the_ID();
 					$post_type = get_post_type();
 					$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 					get_template_part( 'partials/content', $partial );

--- a/archive.php
+++ b/archive.php
@@ -98,7 +98,7 @@ $queried_object = get_queried_object();
 
 				while ( have_posts() ) : the_post();
 					// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-					// See 
+					// See https://github.com/INN/Largo/pull/1150
 					// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
 					// $shown_ids[] = get_the_ID();
 					$post_type = get_post_type();

--- a/category.php
+++ b/category.php
@@ -70,7 +70,10 @@ $queried_object = get_queried_object();
 		if ( have_posts() ) {
 			while ( have_posts() ) {
 				the_post();
-				//$shown_ids[] = get_the_ID();
+				// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
+				// See 
+				// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
+				// $shown_ids[] = get_the_ID();
 				$post_type = get_post_type();
 				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 				get_template_part( 'partials/content', 'archive' );

--- a/category.php
+++ b/category.php
@@ -71,7 +71,7 @@ $queried_object = get_queried_object();
 			while ( have_posts() ) {
 				the_post();
 				// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-				// See 
+				// See https://github.com/INN/Largo/pull/1150
 				// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
 				// $shown_ids[] = get_the_ID();
 				$post_type = get_post_type();

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -27,6 +27,9 @@ class largo_recent_posts_widget extends WP_Widget {
 	 *
 	 * @param array $args widget arguments.
 	 * @param array $instance saved values from databse.
+	 * @global $post
+	 * @global $shown_ids An array of post IDs already on the page, to avoid duplicating posts
+	 * @global $wp_query Used to get posts on the page not in $shown_ids, to avoid duplicating posts
 	 */
 	function widget( $args, $instance ) {
 
@@ -59,6 +62,7 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
 			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
+			// https://github.com/INN/Largo/pull/1150
 			$duplicates = (array) $shown_ids;
 			foreach($wp_query->posts as $post) {
 				$duplicates[] = $post->ID;

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -30,7 +30,9 @@ class largo_recent_posts_widget extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 
-		global $post, $shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
+		global $post,
+			$wp_query, // grab this to copy posts in the main column
+			$shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
 		
 		// Preserve global $post
 		$preserve = $post;
@@ -55,7 +57,15 @@ class largo_recent_posts_widget extends WP_Widget {
 			'post_status'	=> 'publish'
 		);
 
-		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) $query_args['post__not_in'] = $shown_ids;
+		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
+			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
+			$duplicates = (array) $shown_ids;
+			foreach($wp_query->posts as $post) {
+				$duplicates[] = $post->ID;
+			}
+			var_log($duplicates);
+			$query_args['post__not_in'] = $duplicates;
+		}
 		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
 		if ( $instance['tag'] != '') $query_args['tag'] = $instance['tag'];
 		if ( $instance['author'] != '') $query_args['author'] = $instance['author'];


### PR DESCRIPTION
## Changes

- Add posts from the global `$wp_query` to the list of posts from `$shown_ids`, and use the combined list as the `post__not_in` argument on the Recent Posts query.

## Why

Adding posts in archive pages to `$shown_ids` will add those posts to the posts excluded from the Load More Posts query by the `largo_load_more_posts_data` JSON object. If posts from the initial page load are excluded from the LMP query, it has the effect of removing the first page of results from the LMP query, causing the second page to be considered the first page. The posts returned by the first LMP button-press will then be the third page of result.

Therefore, instead of getting posts from `$shown_ids`, get them from the `$wp_query->posts` array.

For [RNS-172](http://jira.inn.org/browse/RNS-172) and #1149.

## Questions

- [ ] Do we need to add this check anywhere else? Where else does Largo exclude `$shown_ids`?