### PR TITLE
Ignore posts from main query in Largo Recent Posts widget

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -97,6 +97,10 @@ $queried_object = get_queried_object();
 				rewind_posts();
 
 				while ( have_posts() ) : the_post();
+					// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
+					// See 
+					// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
+					// $shown_ids[] = get_the_ID();
 					$post_type = get_post_type();
 					$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 					get_template_part( 'partials/content', $partial );

--- a/archive.php
+++ b/archive.php
@@ -98,7 +98,7 @@ $queried_object = get_queried_object();
 
 				while ( have_posts() ) : the_post();
 					// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-					// See 
+					// See https://github.com/INN/Largo/pull/1150
 					// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
 					// $shown_ids[] = get_the_ID();
 					$post_type = get_post_type();

--- a/archive.php
+++ b/archive.php
@@ -49,8 +49,6 @@ $queried_object = get_queried_object();
 			} elseif ( is_post_type_archive( 'rounduplink' ) ) {
 				/**
 				 * Make the title of the rounduplink archive filterable
-				 *
-				 * @link https://github.com/INN/Largo/issues/1123
 				 * @param string $title The title of the archive page
 				 * @since 0.5.4
 				 */
@@ -97,10 +95,6 @@ $queried_object = get_queried_object();
 				rewind_posts();
 
 				while ( have_posts() ) : the_post();
-					// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-					// See https://github.com/INN/Largo/pull/1150
-					// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
-					// $shown_ids[] = get_the_ID();
 					$post_type = get_post_type();
 					$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 					get_template_part( 'partials/content', $partial );

--- a/category.php
+++ b/category.php
@@ -70,7 +70,10 @@ $queried_object = get_queried_object();
 		if ( have_posts() ) {
 			while ( have_posts() ) {
 				the_post();
-				//$shown_ids[] = get_the_ID();
+				// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
+				// See 
+				// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
+				// $shown_ids[] = get_the_ID();
 				$post_type = get_post_type();
 				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 				get_template_part( 'partials/content', 'archive' );

--- a/category.php
+++ b/category.php
@@ -71,7 +71,7 @@ $queried_object = get_queried_object();
 			while ( have_posts() ) {
 				the_post();
 				// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-				// See 
+				// See https://github.com/INN/Largo/pull/1150
 				// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
 				// $shown_ids[] = get_the_ID();
 				$post_type = get_post_type();

--- a/category.php
+++ b/category.php
@@ -10,10 +10,10 @@ get_header();
 
 global $tags, $paged, $post, $shown_ids;
 
-$title = single_cat_title('', false);
+$title = single_cat_title( '', false );
 $description = category_description();
-$rss_link = get_category_feed_link(get_queried_object_id());
-$posts_term = of_get_option('posts_term_plural', 'Stories');
+$rss_link = get_category_feed_link( get_queried_object_id() );
+$posts_term = of_get_option( 'posts_term_plural', 'Stories' );
 $queried_object = get_queried_object();
 ?>
 
@@ -22,14 +22,14 @@ $queried_object = get_queried_object();
 		<a class="rss-link rss-subscribe-link" href="<?php echo $rss_link; ?>"><?php echo __( 'Subscribe', 'largo' ); ?> <i class="icon-rss"></i></a>
 		<?php
 			$post_id = largo_get_term_meta_post( $queried_object->taxonomy, $queried_object->term_id );
-			largo_hero($post_id);
+			largo_hero( $post_id );
 		?>
 		<h1 class="page-title"><?php echo $title; ?></h1>
 		<div class="archive-description"><?php echo $description; ?></div>
-		<?php get_template_part('partials/archive', 'category-related'); ?>
+		<?php get_template_part( 'partials/archive', 'category-related' ); ?>
 	</header>
 
-	<?php if ( $paged < 2 && of_get_option('hide_category_featured') == '0' ) {
+	<?php if ( $paged < 2 && of_get_option( 'hide_category_featured' ) == '0' ) {
 		$featured_posts = largo_get_featured_posts_in_category( $wp_query->query_vars['category_name'] );
 		if ( count( $featured_posts ) > 0 ) {
 			$top_featured = $featured_posts[0];
@@ -43,8 +43,8 @@ $queried_object = get_queried_object();
 				); ?>
 			</div>
 
-			<?php $secondary_featured = array_slice($featured_posts, 1);
-			if ( count($secondary_featured) > 0 ) { ?>
+			<?php $secondary_featured = array_slice( $featured_posts, 1 );
+			if ( count( $secondary_featured ) > 0 ) { ?>
 				<div class="secondary-featured-post">
 					<div class="row-fluid clearfix"><?php
 						foreach ( $secondary_featured as $idx => $featured_post ) {
@@ -70,10 +70,6 @@ $queried_object = get_queried_object();
 		if ( have_posts() ) {
 			while ( have_posts() ) {
 				the_post();
-				// Do not add posts in the main river to $shown_ids; doing so will mess up Load More Posts
-				// See https://github.com/INN/Largo/pull/1150
-				// See https://github.com/INN/Largo/blob/master/inc/ajax-functions.php#L49-L52
-				// $shown_ids[] = get_the_ID();
 				$post_type = get_post_type();
 				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
 				get_template_part( 'partials/content', 'archive' );

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -27,6 +27,9 @@ class largo_recent_posts_widget extends WP_Widget {
 	 *
 	 * @param array $args widget arguments.
 	 * @param array $instance saved values from databse.
+	 * @global $post
+	 * @global $shown_ids An array of post IDs already on the page, to avoid duplicating posts
+	 * @global $wp_query Used to get posts on the page not in $shown_ids, to avoid duplicating posts
 	 */
 	function widget( $args, $instance ) {
 
@@ -59,6 +62,7 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
 			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
+			// https://github.com/INN/Largo/pull/1150
 			$duplicates = (array) $shown_ids;
 			foreach($wp_query->posts as $post) {
 				$duplicates[] = $post->ID;

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -30,7 +30,9 @@ class largo_recent_posts_widget extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 
-		global $post, $shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
+		global $post,
+			$wp_query, // grab this to copy posts in the main column
+			$shown_ids; // an array of post IDs already on a page so we can avoid duplicating posts;
 		
 		// Preserve global $post
 		$preserve = $post;
@@ -55,7 +57,15 @@ class largo_recent_posts_widget extends WP_Widget {
 			'post_status'	=> 'publish'
 		);
 
-		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) $query_args['post__not_in'] = $shown_ids;
+		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
+			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
+			$duplicates = (array) $shown_ids;
+			foreach($wp_query->posts as $post) {
+				$duplicates[] = $post->ID;
+			}
+			var_log($duplicates);
+			$query_args['post__not_in'] = $duplicates;
+		}
 		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
 		if ( $instance['tag'] != '') $query_args['tag'] = $instance['tag'];
 		if ( $instance['author'] != '') $query_args['author'] = $instance['author'];

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -12,11 +12,11 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		$widget_ops = array(
 			'classname' => 'largo-recent-posts',
-			'description' => __('Show your most recent posts with thumbnails and excerpts', 'largo')
+			'description' => __( 'A flexible widget to display recent posts (optionally limited by category, author, tag or taxonomy) in various formats', 'largo' )
 		);
 		parent::__construct(
 			'largo-recent-posts-widget', // Base ID
-			__('Largo Recent Posts', 'largo'), // Name
+			__( 'Largo Recent Posts', 'largo' ), // Name
 			$widget_ops // Args
 		);
 
@@ -45,7 +45,7 @@ class largo_recent_posts_widget extends WP_Widget {
 		$posts_term = of_get_option( 'posts_term_plural', 'Posts' );
 
 		// Add the link to the title.
-		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Recent ' . $posts_term, 'largo') : $instance['title'], $instance, $this->id_base);
+		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? __( 'Recent ' . $posts_term, 'largo' ) : $instance['title'], $instance, $this->id_base );
 
 		echo $before_widget;
 
@@ -62,9 +62,8 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
 			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
-			// https://github.com/INN/Largo/pull/1150
 			$duplicates = (array) $shown_ids;
-			foreach($wp_query->posts as $post) {
+			foreach( $wp_query->posts as $post ) {
 				$duplicates[] = $post->ID;
 			}
 			$query_args['post__not_in'] = $duplicates;
@@ -102,7 +101,7 @@ class largo_recent_posts_widget extends WP_Widget {
 				);
 
 				ob_start();
-				largo_render_template('partials/widget', 'content', $context);
+				largo_render_template( 'partials/widget', 'content', $context );
 				$output .= ob_get_clean();
 
 				// close the item
@@ -114,13 +113,13 @@ class largo_recent_posts_widget extends WP_Widget {
 			echo $output;
 
 		} else {
-			printf(__('<p class="error"><strong>You don\'t have any recent %s.</strong></p>', 'largo'), strtolower( $posts_term ) );
+			printf( __( '<p class="error"><strong>You don\'t have any recent %s.</strong></p>', 'largo' ), strtolower( $posts_term ) );
 		} // end more featured posts
 
 		// close the ul if we're just showing a list of headlines
-		if ($excerpt == 'none') echo '</ul>';
+		if ( $excerpt == 'none' ) echo '</ul>';
 
-		if($instance['linkurl'] !='') {
+		if( $instance['linkurl'] !='' ) {
 			echo '<p class="morelink"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
 		}
 		echo $after_widget;
@@ -154,23 +153,23 @@ class largo_recent_posts_widget extends WP_Widget {
 
 	function form( $instance ) {
 		$defaults = array(
-			'title' 			=> __('Recent ' . of_get_option( 'posts_term_plural', 'Posts' ), 'largo'),
-			'num_posts' 		=> 5,
-			'avoid_duplicates'	=> '',
+			'title' => __( 'Recent ' . of_get_option( 'posts_term_plural', 'Posts' ), 'largo' ),
+			'num_posts' => 5,
+			'avoid_duplicates' => '',
 			'thumbnail_display' => 'small',
-			'image_align'		=> 'left',
-			'excerpt_display' 	=> 'num_sentences',
-			'num_sentences' 	=> 2,
-			'show_byline'	   => '',
-			'show_top_term'	 => '',
-			'show_icon'	 => '',
-			'cat' 				=> 0,
-			'tag'				=> '',
-			'taxonomy'			=> '',
-			'term'				=> '',
-			'author' 			=> '',
-			'linktext' 			=> '',
-			'linkurl' 			=> ''
+			'image_align' => 'left',
+			'excerpt_display' => 'num_sentences',
+			'num_sentences' => 2,
+			'show_byline' => '',
+			'show_top_term' => '',
+			'show_icon' => '',
+			'cat' => 0,
+			'tag' => '',
+			'taxonomy' => '',
+			'term' => '',
+			'author' => '',
+			'linktext' => '',
+			'linkurl' => ''
 		);
 		$instance = wp_parse_args( (array) $instance, $defaults );
 		$duplicates = $instance['avoid_duplicates'] ? 'checked="checked"' : '';
@@ -180,7 +179,7 @@ class largo_recent_posts_widget extends WP_Widget {
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e('Title:', 'largo'); ?></label>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo $instance['title']; ?>" style="width:90%;" />
 		</p>
 
@@ -190,48 +189,48 @@ class largo_recent_posts_widget extends WP_Widget {
 		</p>
 
 		<p>
-			<input class="checkbox" type="checkbox" <?php echo $duplicates; ?> id="<?php echo $this->get_field_id('avoid_duplicates'); ?>" name="<?php echo $this->get_field_name('avoid_duplicates'); ?>" /> <label for="<?php echo $this->get_field_id('avoid_duplicates'); ?>"><?php _e('Avoid Duplicate Posts?', 'largo'); ?></label>
+			<input class="checkbox" type="checkbox" <?php echo $duplicates; ?> id="<?php echo $this->get_field_id( 'avoid_duplicates' ); ?>" name="<?php echo $this->get_field_name( 'avoid_duplicates' ); ?>" /> <label for="<?php echo $this->get_field_id( 'avoid_duplicates' ); ?>"><?php _e( 'Avoid Duplicate Posts?', 'largo' ); ?></label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'thumbnail_display' ); ?>"><?php _e('Thumbnail Image', 'largo'); ?></label>
-			<select id="<?php echo $this->get_field_id('thumbnail_display'); ?>" name="<?php echo $this->get_field_name('thumbnail_display'); ?>" class="widefat" style="width:90%;">
-				<option <?php selected( $instance['thumbnail_display'], 'small'); ?> value="small"><?php _e('Small (60x60)', 'largo'); ?></option>
-				<option <?php selected( $instance['thumbnail_display'], 'medium'); ?> value="medium"><?php _e('Medium (140x140)', 'largo'); ?></option>
-				<option <?php selected( $instance['thumbnail_display'], 'large'); ?> value="large"><?php _e('Large (Full width of the widget)', 'largo'); ?></option>
-				<option <?php selected( $instance['thumbnail_display'], 'none'); ?> value="none"><?php _e('None', 'largo'); ?></option>
+			<label for="<?php echo $this->get_field_id( 'thumbnail_display' ); ?>"><?php _e( 'Thumbnail Image', 'largo' ); ?></label>
+			<select id="<?php echo $this->get_field_id( 'thumbnail_display' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_display' ); ?>" class="widefat" style="width:90%;">
+				<option <?php selected( $instance['thumbnail_display'], 'small'); ?> value="small"><?php _e( 'Small (60x60)', 'largo' ); ?></option>
+				<option <?php selected( $instance['thumbnail_display'], 'medium'); ?> value="medium"><?php _e( 'Medium (140x140)', 'largo' ); ?></option>
+				<option <?php selected( $instance['thumbnail_display'], 'large'); ?> value="large"><?php _e( 'Large (Full width of the widget)', 'largo' ); ?></option>
+				<option <?php selected( $instance['thumbnail_display'], 'none'); ?> value="none"><?php _e( 'None', 'largo' ); ?></option>
 			</select>
 		</p>
 
 		<!-- Image alignment -->
 		<p>
-			<label for="<?php echo $this->get_field_id( 'image_align' ); ?>"><?php _e('Image Alignment', 'largo'); ?></label>
-			<select id="<?php echo $this->get_field_id( 'image_align' ); ?>" name="<?php echo $this->get_field_name('image_align'); ?>" class="widefat" style="width:90%;">
-				<option <?php selected( $instance['image_align'], 'left'); ?> value="left"><?php _e('Left align', 'largo'); ?></option>
-				<option <?php selected( $instance['image_align'], 'right'); ?> value="right"><?php _e('Right align', 'largo'); ?></option>
+			<label for="<?php echo $this->get_field_id( 'image_align' ); ?>"><?php _e( 'Image Alignment', 'largo' ); ?></label>
+			<select id="<?php echo $this->get_field_id( 'image_align' ); ?>" name="<?php echo $this->get_field_name( 'image_align' ); ?>" class="widefat" style="width:90%;">
+				<option <?php selected( $instance['image_align'], 'left'); ?> value="left"><?php _e( 'Left align', 'largo' ); ?></option>
+				<option <?php selected( $instance['image_align'], 'right'); ?> value="right"><?php _e( 'Right align', 'largo' ); ?></option>
 			</select>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'excerpt_display' ); ?>"><?php _e('Excerpt Display', 'largo'); ?></label>
-			<select id="<?php echo $this->get_field_id('excerpt_display'); ?>" name="<?php echo $this->get_field_name('excerpt_display'); ?>" class="widefat" style="width:90%;">
-				<option <?php selected( $instance['excerpt_display'], 'num_sentences'); ?> value="num_sentences"><?php _e('Use # of Sentences', 'largo'); ?></option>
-				<option <?php selected( $instance['excerpt_display'], 'custom_excerpt'); ?> value="custom_excerpt"><?php _e('Use Custom Post Excerpt', 'largo'); ?></option>
-				<option <?php selected( $instance['excerpt_display'], 'none'); ?> value="none"><?php _e('None', 'largo'); ?></option>
+			<label for="<?php echo $this->get_field_id( 'excerpt_display' ); ?>"><?php _e( 'Excerpt Display', 'largo' ); ?></label>
+			<select id="<?php echo $this->get_field_id( 'excerpt_display' ); ?>" name="<?php echo $this->get_field_name( 'excerpt_display' ); ?>" class="widefat" style="width:90%;">
+				<option <?php selected( $instance['excerpt_display'], 'num_sentences' ); ?> value="num_sentences"><?php _e( 'Use # of Sentences', 'largo' ); ?></option>
+				<option <?php selected( $instance['excerpt_display'], 'custom_excerpt' ); ?> value="custom_excerpt"><?php _e( 'Use Custom Post Excerpt', 'largo' ); ?></option>
+				<option <?php selected( $instance['excerpt_display'], 'none' ); ?> value="none"><?php _e( 'None', 'largo' ); ?></option>
 			</select>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'num_sentences' ); ?>"><?php _e('Excerpt Length (# of Sentences):', 'largo'); ?></label>
+			<label for="<?php echo $this->get_field_id( 'num_sentences' ); ?>"><?php _e( 'Excerpt Length (# of Sentences):', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'num_sentences' ); ?>" name="<?php echo $this->get_field_name( 'num_sentences' ); ?>" value="<?php echo (int) $instance['num_sentences']; ?>" style="width:90%;" />
 		</p>
 
 		<p>
-			<input class="checkbox" type="checkbox" <?php echo $showbyline; ?> id="<?php echo $this->get_field_id('show_byline'); ?>" name="<?php echo $this->get_field_name('show_byline'); ?>" /> <label for="<?php echo $this->get_field_id('show_byline'); ?>"><?php _e('Show byline on posts?', 'largo'); ?></label>
+			<input class="checkbox" type="checkbox" <?php echo $showbyline; ?> id="<?php echo $this->get_field_id( 'show_byline' ); ?>" name="<?php echo $this->get_field_name( 'show_byline' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_byline' ); ?>"><?php _e( 'Show byline on posts?', 'largo' ); ?></label>
 		</p>
 
 		<p>
-			<input class="checkbox" type="checkbox" <?php echo $show_top_term; ?> id="<?php echo $this->get_field_id('show_top_term'); ?>" name="<?php echo $this->get_field_name('show_top_term'); ?>" /> <label for="<?php echo $this->get_field_id('show_top_term'); ?>"><?php _e('Show the top term on posts?', 'largo'); ?></label>
+			<input class="checkbox" type="checkbox" <?php echo $show_top_term; ?> id="<?php echo $this->get_field_id( 'show_top_term' ); ?>" name="<?php echo $this->get_field_name( 'show_top_term' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_top_term' ); ?>"><?php _e( 'Show the top term on posts?', 'largo' ); ?></label>
 		</p>
 
 		<?php 
@@ -239,46 +238,46 @@ class largo_recent_posts_widget extends WP_Widget {
 			if ( taxonomy_exists('post-type') && of_get_option('post_types_enabled') ) {
 		?>
 		<p>
-			<input class="checkbox" type="checkbox" <?php echo $show_icon; ?> id="<?php echo $this->get_field_id('show_icon'); ?>" name="<?php echo $this->get_field_name('show_icon'); ?>" /> <label for="<?php echo $this->get_field_id('show_icon'); ?>"><?php _e('Show the post type icon?', 'largo'); ?></label>
+			<input class="checkbox" type="checkbox" <?php echo $show_icon; ?> id="<?php echo $this->get_field_id( 'show_icon' ); ?>" name="<?php echo $this->get_field_name( 'show_icon' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_icon' ); ?>"><?php _e( 'Show the post type icon?', 'largo' ); ?></label>
 		</p>
 		<?php
 			}
 		?>
 
-		<p><strong><?php _e('Limit by Author, Categories or Tags', 'largo'); ?></strong><br /><small><?php _e('Select an author or category from the dropdown menus or enter post tags separated by commas (\'cat,dog\')', 'largo'); ?></small></p>
+		<p><strong><?php _e( 'Limit by Author, Categories or Tags', 'largo' ); ?></strong><br /><small><?php _e( 'Select an author or category from the dropdown menus or enter post tags separated by commas (\'cat,dog\')', 'largo' ); ?></small></p>
 		<p>
-			<label for="<?php echo $this->get_field_id('author'); ?>"><?php _e('Limit to author: ', 'largo'); ?><br />
-			<?php wp_dropdown_users(array('name' => $this->get_field_name('author'), 'show_option_all' => __('None (all authors)', 'largo'), 'selected'=>$instance['author'])); ?></label>
+			<label for="<?php echo $this->get_field_id( 'author' ); ?>"><?php _e( 'Limit to author: ', 'largo' ); ?><br />
+			<?php wp_dropdown_users( array( 'name' => $this->get_field_name( 'author' ), 'show_option_all' => __( 'None (all authors)', 'largo' ), 'selected'=>$instance['author'])); ?></label>
 
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id('cat'); ?>"><?php _e('Limit to category: ', 'largo'); ?>
-			<?php wp_dropdown_categories(array('name' => $this->get_field_name('cat'), 'show_option_all' => __('None (all categories)', 'largo'), 'hide_empty'=>0, 'hierarchical'=>1, 'selected'=>$instance['cat'])); ?></label>
+			<?php wp_dropdown_categories( array( 'name' => $this->get_field_name( 'cat' ), 'show_option_all' => __( 'None (all categories)', 'largo' ), 'hide_empty'=>0, 'hierarchical'=>1, 'selected'=>$instance['cat'] ) ); ?></label>
 		</p>
 		<p>
-			<label for="<?php echo $this->get_field_id('tag'); ?>"><?php _e('Limit to tags:', 'largo'); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id('tag'); ?>" name="<?php echo $this->get_field_name('tag'); ?>" type="text" value="<?php echo $instance['tag']; ?>" />
-		</p>
-
-		<p><strong><?php _e('Limit by Custom Taxonomy', 'largo'); ?></strong><br /><small><?php _e('Enter the slug for the custom taxonomy you want to query and the term within that taxonomy to display', 'largo'); ?></small></p>
-		<p>
-			<label for="<?php echo $this->get_field_id('taxonomy'); ?>"><?php _e('Taxonomy:', 'largo'); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id('taxonomy'); ?>" name="<?php echo $this->get_field_name('taxonomy'); ?>" type="text" value="<?php echo $instance['taxonomy']; ?>" />
-		</p>
-		<p>
-			<label for="<?php echo $this->get_field_id('term'); ?>"><?php _e('Term:', 'largo'); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id('term'); ?>" name="<?php echo $this->get_field_name('term'); ?>" type="text" value="<?php echo $instance['term']; ?>" />
+			<label for="<?php echo $this->get_field_id( 'tag' ); ?>"><?php _e( 'Limit to tags:', 'largo' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'tag' ); ?>" name="<?php echo $this->get_field_name( 'tag' ); ?>" type="text" value="<?php echo $instance['tag']; ?>" />
 		</p>
 
-		<p><strong><?php _e('More Link', 'largo'); ?></strong><br /><small><?php _e('If you would like to add a more link at the bottom of the widget, add the link text and url here.', 'largo'); ?></small></p>
+		<p><strong><?php _e( 'Limit by Custom Taxonomy', 'largo' ); ?></strong><br /><small><?php _e( 'Enter the slug for the custom taxonomy you want to query and the term within that taxonomy to display', 'largo' ); ?></small></p>
 		<p>
-			<label for="<?php echo $this->get_field_id('linktext'); ?>"><?php _e('Link text:', 'largo'); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id('linktext'); ?>" name="<?php echo $this->get_field_name('linktext'); ?>" type="text" value="<?php echo esc_attr( $instance['linktext'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'taxonomy' ); ?>"><?php _e( 'Taxonomy:', 'largo' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'taxonomy' ); ?>" name="<?php echo $this->get_field_name( 'taxonomy' ); ?>" type="text" value="<?php echo $instance['taxonomy']; ?>" />
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'term' ); ?>"><?php _e( 'Term:', 'largo' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'term' ); ?>" name="<?php echo $this->get_field_name( 'term' ); ?>" type="text" value="<?php echo $instance['term']; ?>" />
+		</p>
+
+		<p><strong><?php _e( 'More Link', 'largo' ); ?></strong><br /><small><?php _e( 'If you would like to add a more link at the bottom of the widget, add the link text and url here.', 'largo' ); ?></small></p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'linktext' ); ?>"><?php _e( 'Link text:', 'largo' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'linktext' ); ?>" name="<?php echo $this->get_field_name( 'linktext' ); ?>" type="text" value="<?php echo esc_attr( $instance['linktext'] ); ?>" />
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id('linkurl'); ?>"><?php _e('URL:', 'largo'); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id('linkurl'); ?>" name="<?php echo $this->get_field_name('linkurl'); ?>" type="text" value="<?php echo esc_attr( $instance['linkurl'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'linkurl' ); ?>"><?php _e( 'URL:', 'largo' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'linkurl' ); ?>" name="<?php echo $this->get_field_name( 'linkurl' ); ?>" type="text" value="<?php echo esc_attr( $instance['linkurl'] ); ?>" />
 		</p>
 
 	<?php

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -67,7 +67,6 @@ class largo_recent_posts_widget extends WP_Widget {
 			foreach($wp_query->posts as $post) {
 				$duplicates[] = $post->ID;
 			}
-			var_log($duplicates);
 			$query_args['post__not_in'] = $duplicates;
 		}
 		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];


### PR DESCRIPTION
## Changes

- Add posts from the global `$wp_query` to the list of posts from `$shown_ids`, and use the combined list as the `post__not_in` argument on the Recent Posts query.

## Why

Adding posts in archive pages to `$shown_ids` will add those posts to the posts excluded from the Load More Posts query by the `largo_load_more_posts_data` JSON object. If posts from the initial page load are excluded from the LMP query, it has the effect of removing the first page of results from the LMP query, causing the second page to be considered the first page. The posts returned by the first LMP button-press will then be the third page of result.

Therefore, instead of getting posts from `$shown_ids`, get them from the `$wp_query->posts` array.

For [RNS-172](http://jira.inn.org/browse/RNS-172) and #1149.

## Questions

- [ ] Do we need to add this check anywhere else? Where else does Largo exclude `$shown_ids`?