### PR TITLE
Revise sidebarwidgets.rst to add details on Largo widgets, and fix errors

### DIFF
--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -11,7 +11,7 @@ To add a content block to a widget area, simply drag and drop a widget from the 
 
 Note that some widgets are small and can easily fit in narrow columns. Other widgets can contain lots of content that doesn’t fit well in a small space. It’s important to see how a widget affects the page layout and adjust as needed.
 
-*For more about widgets and how WordPress handles them, see `the WordPress Codex article on widgets <http://codex.wordpress.org/WordPress_Widgets>`_*.
+For more about widgets and how WordPress handles them, see `the WordPress Codex article on widgets <http://codex.wordpress.org/WordPress_Widgets>`_.
 
 Widget Areas
 ============

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -5,52 +5,50 @@ Sidebars and Widgets
 Overview
 ========
 
-Largo adds a number of widget areas and custom widgets to allow for easy, drag and drop management of content blocks on your site.
+Largo adds a number of widget areas and custom widgets to allow for easy, drag and drop management of content blocks on your site. You can access and edit any of these widget areas from the **Appearance > Widgets** menu in the WordPress Dashboard.
 
-Access and edit any of the following widget areas from the Appearance > Widgets menu in the WordPress Dashboard.
+To add a content block to a widget area, simply drag and drop a widget from the available widgets on left to the widget area on the right where you want it to appear. Note that as soon as you add any widgets to a widget area, any default content will no longer display so you will need to completely populate the widget area with the content you want to display. Most widgets have additional settings to configure how they display  on the site.
 
-To add widgets to any of these areas, simply drag and drop a widget from the area on left to the widget area you want it to appear in. Note that as soon as you add any widgets to a widget area, the default will no longer display so you will need to completely populate the widget area with the widgets you want to display. Many widgets will have additional settings you can use to configure how they appear on your site.
+Note that some widgets are small and can easily fit in narrow columns. Other widgets can contain lots of content that doesn’t fit well in a small space. It’s important to see how a widget affects the page layout and adjust as needed.
 
-Note that some widgets are small and can easily fit in narrow columns. Other widgets might contain lots of content that doesn’t fit well within in a small space. It’s important to see how a widget affects the page layout and adjust as needed.
-
-For more about widgets and how WordPress handles them, see `the WordPress Codex article on widgets <http://codex.wordpress.org/WordPress_Widgets>`_.
+*For more about widgets and how WordPress handles them, see `the WordPress Codex article on widgets <http://codex.wordpress.org/WordPress_Widgets>`_*.
 
 Widget Areas
 ============
 
+The way some of these widget areas appear on your site will depend on the layout options you set in the **Appearance > Theme Options > Layout** menu.
+
 Sidebar Widget Areas
 --------------------
 
-Note that the way some of these widget area appear on your site will depend on the layout options you set in the **Appearance > Theme Options > Layout** menu.
-
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
 
-- **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the **Layout Options > Custom Sidebar** dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
-- **Topic Sidebar** - An optional widget area enabled from the **Appearance > Theme Options > Layout** menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
+- **Single Sidebar** - Used for single posts and pages, if you select a two-column template for single-post pages. As of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the **Layout Options > Custom Sidebar** dropdown menu when editing an individual post. Note that if you do not populate this widget area, Largo will fall back to using the Main Sidebar. 
+- **Topic Sidebar** - An optional widget area enabled from the **Appearance > Theme Options > Layout** menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy pages.
 
 Footer Widget Areas
 -------------------
 
-Depending on which layout you select in the **Appearance > Theme Options > Layout** menu for the Footer Layout option, you will see either three or four numbered footer widget areas (which are numbered left to right). These areas will typically be populated by some default widgets that you can modify or change by adding widgets of your choice in the **Appearance > Widgets** menu.
+Depending on which layout you select in the **Appearance > Theme Options > Layout** menu for the **Footer Layout** option, you will see either three or four numbered footer widget areas in **Appearance > Widgets**. The footer widget numbers reflect their order in the foot from left to right. These areas will typically be populated by some default widgets, but  you can change this by adding the widgets of your choice.
 
 The Article Bottom Widget Area
 ------------------------------
 
-Prior to version 0.4, Largo controlled the appearance of elements at the bottom of article pages using various settings from the **Appearance > Theme Options > Basic Settings** menu. In version 0.4 we have made this a widget area instead to allow for more flexibility in the type and order of elements that appear here.
+Prior to Largo 0.4, appearance of elements at the bottom of article pages was set from the **Appearance > Theme Options > Basic Settings** menu. With version 0.4 we made this a widget area instead to allow for more flexibility.
 
-By default, the only thing displayed at the bottom of an article is the comments section (when comments are enabled). Some of the elements you might consider adding to this area are the author bio, related posts and prev/next links widgets but many of the widgets in WordPress or those added by Largo are designed to be contextual and display well in this area so you can experiment and see what best suits your needs.
+By default, the only content displayed at the bottom of an article is the comments section (when comments are enabled). You can easily add other elements like the author bio, related posts, and prev/next links widgets. Many widgets are designed to be contextual based on the article's taxonomy, author, etc. With many different widgets and options, it's a good idea to experiment and see what works best.
 
 Less Common Widget Areas
 ------------------------
 
-- **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can add a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic so if you plan to use it you'll likely want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget to be used in this widget area.
-- **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the **Appearance > Theme Options > Advanced** tab then this would be the widget are you'll use to add an ad widget to appear in that position.
-- **Homepage Left Rail** - If you are using a three column homepage layout this will be a widget area to manage the contents of the skinny column to the far left.
+- **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can place a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic, so if you plan to use it you might want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget for this area.
+- **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the **Appearance > Theme Options > Advanced** tab, drop an ad widget to appear in this area.
+- **Homepage Left Rail** - If you are using a three column homepage layout (set in **Appearance > Theme Options >Layout**)this is the widget area for the contents of the left-side column.
 
 Custom Widget Areas
 -------------------
 
-Largo also enables you to add any number of **custom widget areas** you might need for display on certain pages of your site. For example, you might want to create a sidebar for a category or series that is only displayed on the archive page for that category/series and/or on the posts that appear in that category/series. Custom sidebars can be added from the **Appearance > Theme Options > Layout** tab under the "Sidebar Options" header. Instructions for settings these options can be found below.
+Largo also allows you to add any number of **custom widget areas** or display on certain pages of the site. For example, you could create a sidebar for a category or series that is only displayed on the archive page for that taxonomy, and/or on posts that appear in that taxonomy. Custom sidebars can be added from the **Appearance > Theme Options > Layout** tab under the **Sidebar Options** header. Instructions for setting these options are in `Sidebar Options <#sidebar-options>`_ below.
 
 Custom Widgets
 ==============

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -43,7 +43,7 @@ Less Common Widget Areas
 
 - **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can place a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic, so if you plan to use it you might want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget for this area.
 - **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the **Appearance > Theme Options > Advanced** tab, drop an ad widget to appear in this area.
-- **Homepage Left Rail** - If you are using a three column homepage layout (set in **Appearance > Theme Options >Layout**)this is the widget area for the contents of the left-side column.
+- **Homepage Left Rail** - If you are using a three column homepage layout (set in **Appearance > Theme Options >Layout**) this is the widget area for the contents of the left-side column.
 
 Custom Widget Areas
 -------------------
@@ -55,13 +55,13 @@ Custom Widgets
 
 Largo adds a number of custom widgets in addition to the `standard widgets <http://codex.wordpress.org/Widgets_SubPanel>`_ that come included with WordPress.
 
-All of our widgets have:
+All Largo custom widgets have:
 
-- The choice of three backgrounds (default, reverse and none) to give you a variety of styling options and classes to use for custom CSS.
-- The ability to be hidden on desktops, tablets and phones using the responsive utility classes `from Twitter Bootstrap <http://getbootstrap.com/2.3.2/scaffolding.html#responsive>`_. We recommend hiding less necessary widgets for users on smaller viewports such as mobile devices in order to create a cleaner, simpler experience that allows them to focus on your content without distraction.
+- The choice of three backgrounds (default, reverse and none) to provide styling options and classes for custom CSS.
+- The ability to hide the widget on desktops, tablets, and phones using the responsive utility classes `from Twitter Bootstrap <http://getbootstrap.com/2.3.2/scaffolding.html#responsive>`_. We recommend hiding less necessary widgets for users on smaller viewports such as mobile devices to create a cleaner experience that allows them to focus on your content.
 - The ability to set a link for the widget title.
 
-The widgets added by Largo include:
+Here is a complete list of the Largo custom widgets as of version 0.5.4:
 
 INN Member Stories
 ------------------

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -21,35 +21,39 @@ Widget Areas
 Sidebar Widget Areas
 --------------------
 
-Note that the way some of these widget area appear on your site will depend on the layout options you set in the Appearance > Theme Options > Layout Options menu.
+Note that the way some of these widget area appear on your site will depend on the layout options you set in the Appearance > Theme Options > Layout menu.
 
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
 
 - **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the Layout Options > Custom Sidebar dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
 - **Topic Sidebar** - An optional widget area enabled from the Appearance > Theme Options > Layout Options menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
 
-**Footer Widget Areas**
+Footer Widget Areas
+-------------------
 
 Depending on which layout you select in the Appearance > Theme Options > Layout Options menu for the Footer Layout option, you will see either three or four numbered footer widget areas (which are numbered left to right). These areas will typically be populated by some default widgets that you can modify or change by adding widgets of your choice in the Appearance > Widgets menu.
 
-**The Article Bottom Widget Area**
+The Article Bottom Widget Area
+------------------------------
 
 Prior to version 0.4, Largo controlled the appearance of elements at the bottom of article pages using various settings from the Appearance > Theme Options > Basic Settings menu. In version 0.4 we have made this a widget area instead to allow for more flexibility in the type and order of elements that appear here.
 
 By default, the only thing displayed at the bottom of an article is the comments section (when comments are enabled). Some of the elements you might consider adding to this area are the author bio, related posts and prev/next links widgets but many of the widgets in WordPress or those added by Largo are designed to be contextual and display well in this area so you can experiment and see what best suits your needs.
 
-**Less Common Widget Areas**
+Less Common Widget Areas
+------------------------
 
 - **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can add a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic so if you plan to use it you'll likely want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget to be used in this widget area.
 - **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the Appearance > Theme Options > Advanced tab then this would be the widget are you'll use to add an ad widget to appear in that position.
 - **Homepage Left Rail** - If you are using a three column homepage layout this will be a widget area to manage the contents of the skinny column to the far left.
 
-**Custom Widget Areas**
+Custom Widget Areas
+-------------------
 
-Largo also enables you to add any number of **custom widget areas** you might need for display on certain pages of your site. For example, you might want to create a sidebar for a category or series that is only displayed on the archive page for that category/series and/or on the posts that appear in that category/series. Custom sidebars can be added from the Appearance > Theme Options > Layout Options tab under the "Sidebar Options" header. Instructions for settings these options can be found below.
+Largo also enables you to add any number of **custom widget areas** you might need for display on certain pages of your site. For example, you might want to create a sidebar for a category or series that is only displayed on the archive page for that category/series and/or on the posts that appear in that category/series. Custom sidebars can be added from the Appearance > Theme Options > Layout tab under the "Sidebar Options" header. Instructions for settings these options can be found below.
 
 Custom Widgets
---------------
+==============
 
 Largo adds a number of custom widgets in addition to the `standard widgets <http://codex.wordpress.org/Widgets_SubPanel>`_ that come included with WordPress.
 
@@ -61,63 +65,77 @@ All of our widgets have:
 
 The widgets added by Largo include:
 
-**INN Member Stories**
+INN Member Stories
+------------------
 
 Shows a list of curated stories from other members of INN. By default this widget will display headlines, source, and date of the three recent stories from INN members. Options include showing excerpts and adjusting the number of stories to show.
 
-**Largo About Site**
+Largo About Site
+----------------
 
 Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
 
-**Largo Author Bio**
+Largo Author Bio
+----------------
 
 Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile). Also includes a "More by author" link to the landing page for all posts by the author. This widget only works on single-post pages.
 
-**Largo Disclaimer**
+Largo Disclaimer
+----------------
 
 When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options > Advanced menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
 
-**Largo Donate Widget**
+Largo Donate Widget
+-------------------
 
 Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
 
-**Largo Explore Related**
+Largo Explore Related
+---------------------
 
 A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained for backwards compatibility.
 
-**Largo Facebook Widget**
+Largo Facebook Widget
+---------------------
 
 Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook accounts. If you get an error message saying "Error: Not a valid Facebook Page url," it typically means the url is not a public Facebook Page.
 
-**Largo Featured Posts**
+Largo Featured Posts
+--------------------
 
 Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: *Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget*. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout menu > Sidebar Options), and set it to display posts assigned the Prominence Term of Featured in Category.
 
 In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
 
-**Largo Follow**
+Largo Follow
+------------
 
 Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
 
-**Largo Image Widget**
+Largo Image Widget
+------------------
 
 The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or to create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, and set the image alignment in relation to the caption text. 
 
 As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
 
-**Largo Post Series Widget**
+Largo Post Series Widget
+------------------------
 
 This widget is useful for single-post pages to show the title and description of the series the post belongs to. If the post has not been assigned to a series, the widget will display nothing.
 
-**Largo Prev/Next Links** 
+Largo Prev/Next Links
+---------------------
 
 Most commonly used in the Article Bottom widget area, this will show links to the next and previous posts ordered by published date.
 
-**Largo Recent Comments**
+Largo Recent Comments
+---------------------
 
 This widget simply shows recent comments, with links to the posts they appear on. Besides the standard widget options, you can set the number of comments to display in the widget.
 
-**Largo Recent Posts**
+Largo Recent Posts
+------------------
 
 This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
 
@@ -139,23 +157,28 @@ If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxono
 
 After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
 
-**Largo Related Posts**
+Largo Related Posts
+-------------------
 
 This widget works on single-post and Series pages. It shows the title and thumbnail image for related posts.  Related posts can be set manually by adding related post IDs in the Additional Options/Related Posts box of the post edit screen. If no related posts are set, the widget will back to a default algorithm that selects the most closely-related posts based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
 
-**Largo Series Posts**
+Largo Series Posts
+------------------
 
 Displays links to up to five posts in the series selected. The first link will include the post title and excerpt, and a thumbnail of the Featured Image if one is included in the post. You can also choose to show the date with the first post link. The remaining post links are displayed as a simple unordered list under a customizable heading, which defaults to "Explore". 
 
-**Largo Staff Roster**
+Largo Staff Roster
+------------------
 
 Displays a list of users on your site, with a thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting specific user groups, and changing the title displayed with the widget ( defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
 
-**Largo Tag List**
+Largo Tag List
+--------------
 
 Typically used in the Article Bottom widget area, this will display a list of categories and tags associated with a given post. Each term in this list links to the archive page for the term. Widget options include changing title of the list, and setting the maximum number of terms to show.
 
-**Largo Taxonomy List**
+Largo Taxonomy List
+-------------------
 
 List all of the terms in a given taxonomy with links to their archive pages. This is most commonly used to generate a list of series/projects with links to their project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for Post Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
 
@@ -167,7 +190,8 @@ For example, in this URL for the term "Bacon" the term ID is 482:
 
 After setting the taxonomy slug, count, and optionally limiting by term ID, you choose to display thumbnails and a headline of the most recent post in the taxonomy, or display the taxonomy list as as dropdown menu. The Title of the widget defaults to Categories, but you can override this with a title of your choice.
 
-**Largo Twitter Widget**
+Largo Twitter Widget
+--------------------
 
 Allows for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget and grab its ID from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. 
 
@@ -175,21 +199,22 @@ On Twitter you can create widgets for a user timeline, favorites, list, or searc
 
 *Note: In most cases the Largo Twitter Widget will work fine if you just set the Twitter Widget ID. As a fallback in case of errors loading scripts from Twitter, it's a good idea to also add the Twitter Username, List slug, and search query in the settings*.
 
-**Largo Roundups Widget**
+Largo Roundups Widget
+---------------------
 
 If you have the **Link Roundups** plugin installed, this widget will display the most recent Link Roundup posts. You can change the number of posts to show, limit display to a category, and add a More link at the bottom of the widget. 
 
 For more on how this works see the `Link Roundups widget documentation <https://github.com/INN/link-roundups/blob/master/README.md>`_.
 
 
-Widgets Deprecated in 0.4:
---------------------------
+Widgets Deprecated in 0.4
+=========================
 
 - **Largo Footer Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
 - **Largo Sidebar Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
 
 Sidebar Options
----------------
+===============
 
 Under the Appearance > Theme Options > Layout menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -23,7 +23,7 @@ Note that the way some of these widget area appear on your site will depend on t
 
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
 - **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the Layout Options > Custom Sidebar dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
-- **Topic Sidebar** - An optional widget area enabled from the Appearance > Theme Options > Layout Options menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag and custom taxonomy (e.g. - series) pages.
+- **Topic Sidebar** - An optional widget area enabled from the Appearance > Theme Options > Layout Options menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
 
 **Footer Widget Areas**
 
@@ -58,20 +58,37 @@ All of our widgets have:
 
 The widgets added by Largo include:
 
-- **INN Member Stories** - Shows a list of curated stories from other member of INN.
-- **Largo Author Bio** - Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile).
-- **Largo Explore Related** - A tabbed widget to show related stories by category/tag. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.4 for backwards compatibility.
-- **Largo Featured Posts** - Show recent featured posts with thumbnails and excerpts.
-- **Largo Recent Comments** - Show recent comments with links to the posts they appear on.
-- **Largo Related Posts** - Show related posts that are either editorially determined (by adding related post IDs in the Additional Options box of the post edit screen) or using a default related algorithm that tries to surface the most closely-related post(s) to a given post by series, category or tag.
-- **Largo Staff Roster** - Display a list of the users on your site with options to limit by user role or exclude particular users by setting an option in their user profile.
-- **Largo Taxonomy List** - List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages.
+- **INN Member Stories** - Shows a list of curated stories from other members of INN. By default this widget will display headlines, source, and date of the three recent stories from INN members. Options include showing excerpts and adjusting the number of stories to show.
+- **Largo Author Bio** - Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile). Also includes a "More by author" link to the landing page for all posts by the author. This widget only works on single-post pages.
+- **Largo Explore Related** - A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.5 for backwards compatibility.
+- **Largo Featured Posts** - Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout Options menu), and set it to display posts assigned the Prominence Term of Featured in Category. In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
+- **Largo Recent Comments** - Shows recent comments with links to the posts they appear on.
+- **Largo Related Posts** - This widget works on single-post and Series pages. It shows the title, thumbnail image, related posts that are either set manually (by adding related post IDs in the Additional Options/Related Posts box of the post edit screen) or by falling back to a default algorithm that selects the most closely-related post(s) based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
+- **Largo Staff Roster** - Displays a list of users on your site, with the thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting to include specific user groups, and changing the title displayed with the widget (which defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
+
+- **Largo Taxonomy List** - List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
+
+By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. For example, in this URL for the term "Bacon": 
+
+/wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=482&post_type=post
+
+the term ID is 482.
+
+After setting the taxonomy slug, count, and optionally limiting by term ID, you choose to display thumbnails and a headline of the most recent post in the taxonomy, or display the taxonomy list as as dropdown menu. The Title of the widget defaults to Categories, but you can override this with a title of your choice.
+
 - **Largo About Site** - Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
-- **Largo Donate Widget** - Shows a donate message and button. The default message and link used in this widget can be configured in the Appearance > Theme Options > Basic Settings menu but can be overridden on a per-widget basis if you want to show different messages on different pages/sections of your site.
-- **Largo Facebook Widget** - Shows a Facebook "like" box/feed.
-- **Largo Follow** - Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks
+- **Largo Donate Widget** - Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
+- **Largo Facebook Widget** - Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
+- **Largo Follow** - Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
 - **Largo Prev/Next Links** - Most commonly used in the Article Bottom widget area, this will show links to the next/prev post ordered by published date.
-- **Largo Recent Posts** - A powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author.
+
+- **Largo Recent Posts** - A powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
+
+Limiting by tags, taxonomies, and terms requires using the "slug" for each. For example, the slug for a tag of "social media" would be "social-media". Likewise with the Custom Taxonomies (Post Prominence, Series, and Post Types), the slugs are "prominence", "series", and "post-type". If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and the slug for the term in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. You can find the slugs for any taxonomy by checking its settings page which lists the names and slugs for each taxonomy.
+
+After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
+
+
 - **Largo Tag List** - Typically used in the Article Bottom widget area, this will display a list of tags associated with a given post.
 - **Largo Twitter Widget** - Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a widget (and grab the widget ID) from https://twitter.com/settings/widgets.
 - **Largo Disclaimer Site** - When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. Optionally, you can override the disclaimer on a per-article basis by modifying it from the post edit screen.

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -59,11 +59,29 @@ All of our widgets have:
 The widgets added by Largo include:
 
 - **INN Member Stories** - Shows a list of curated stories from other members of INN. By default this widget will display headlines, source, and date of the three recent stories from INN members. Options include showing excerpts and adjusting the number of stories to show.
+
+- **Largo About Site** - Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
+
 - **Largo Author Bio** - Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile). Also includes a "More by author" link to the landing page for all posts by the author. This widget only works on single-post pages.
+
+- **Largo Disclaimer** - When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
+
+- **Largo Donate Widget** - Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
+
 - **Largo Explore Related** - A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.5 for backwards compatibility.
+
+- **Largo Facebook Widget** - Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
+
 - **Largo Featured Posts** - Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout Options menu), and set it to display posts assigned the Prominence Term of Featured in Category. In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
-- **Largo Recent Comments** - Shows recent comments with links to the posts they appear on.
+
+- **Largo Follow** - Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
+
+- **Largo Image Widget** - The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, set the image alignment in relation to the caption text. As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
+
+- **Largo Recent Comments** - Shows recent comments with links to the posts they appear on. 
+
 - **Largo Related Posts** - This widget works on single-post and Series pages. It shows the title, thumbnail image, related posts that are either set manually (by adding related post IDs in the Additional Options/Related Posts box of the post edit screen) or by falling back to a default algorithm that selects the most closely-related post(s) based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
+
 - **Largo Staff Roster** - Displays a list of users on your site, with the thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting to include specific user groups, and changing the title displayed with the widget (which defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
 
 - **Largo Taxonomy List** - List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
@@ -78,10 +96,6 @@ the term ID is 482.
 
 After setting the taxonomy slug, count, and optionally limiting by term ID, you choose to display thumbnails and a headline of the most recent post in the taxonomy, or display the taxonomy list as as dropdown menu. The Title of the widget defaults to Categories, but you can override this with a title of your choice.
 
-- **Largo About Site** - Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
-- **Largo Donate Widget** - Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
-- **Largo Facebook Widget** - Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
-- **Largo Follow** - Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
 - **Largo Prev/Next Links** - Most commonly used in the Article Bottom widget area, this will show links to the next/prev post ordered by published date.
 
 - **Largo Recent Posts** - A powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
@@ -90,10 +104,10 @@ Limiting by tags, taxonomies, and terms requires using the "slug" for each. For 
 
 After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
 
+- **Largo Tag List** - Typically used in the Article Bottom widget area, this will display a list of categories and tags associated with a given post. Each term in this list links to the archive page for the term. Widget options include changing title of the list, and setting the maximum number of terms to show.
+- **Largo Twitter Widget** - Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget (and grab the widget ID) from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. On Twitter you can create widgets for a user timeline, favorites, list, or search. In the Largo Twitter Widget, set the Widget Type for the type you want and paste in the Twitter Widget ID.
 
-- **Largo Tag List** - Typically used in the Article Bottom widget area, this will display a list of tags associated with a given post.
-- **Largo Twitter Widget** - Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a widget (and grab the widget ID) from https://twitter.com/settings/widgets.
-- **Largo Disclaimer Site** - When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. Optionally, you can override the disclaimer on a per-article basis by modifying it from the post edit screen.
+_Note: In most cases the Largo Twitter Widget will work fine if you just set the Twitter Widget ID. As a fallback in case of errors loading scripts from Twitter, it's a good idea to also add the Twitter Username, List slug, and search query in the settings._
 
 Deprecated in 0.4:
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -1,3 +1,4 @@
+====================
 Sidebars and Widgets
 ====================
 
@@ -22,6 +23,7 @@ Widget Areas
 Note that the way some of these widget area appear on your site will depend on the layout options you set in the Appearance > Theme Options > Layout Options menu.
 
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
+
 - **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the Layout Options > Custom Sidebar dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
 - **Topic Sidebar** - An optional widget area enabled from the Appearance > Theme Options > Layout Options menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
 
@@ -72,22 +74,23 @@ Shows a bio of the author(s) for a given post including their photo and social m
 
 **Largo Disclaimer**
 
-When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
+When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options > Advanced menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
 
 **Largo Donate Widget**
+
 Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
 
 **Largo Explore Related**
 
-A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.5 for backwards compatibility.
+A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained for backwards compatibility.
 
 **Largo Facebook Widget**
 
-Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
+Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook accounts. If you get an error message saying "Error: Not a valid Facebook Page url," it typically means the url is not a public Facebook Page.
 
 **Largo Featured Posts**
 
-Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout Options menu), and set it to display posts assigned the Prominence Term of Featured in Category.
+Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: *Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget*. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout menu > Sidebar Options), and set it to display posts assigned the Prominence Term of Featured in Category.
 
 In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
 
@@ -97,39 +100,55 @@ Uses the social media links provided for your site in the Appearance > Theme Opt
 
 **Largo Image Widget**
 
-The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, set the image alignment in relation to the caption text. As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
+The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or to create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, and set the image alignment in relation to the caption text. 
+
+As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
 
 **Largo Post Series Widget**
 
-This widget is useful for single-post pages to show the title and description of the series the post belongs to. If the post has not been assigned to a series, the widge will display nothing.
+This widget is useful for single-post pages to show the title and description of the series the post belongs to. If the post has not been assigned to a series, the widget will display nothing.
 
 **Largo Prev/Next Links** 
 
-Most commonly used in the Article Bottom widget area, this will show links to the next/prev post ordered by published date.
+Most commonly used in the Article Bottom widget area, this will show links to the next and previous posts ordered by published date.
 
 **Largo Recent Comments**
 
-This widget simply shows recent comments, with links to the posts they appear on. Beside the standard widget options, you can set the number of comments to display in the widget.
+This widget simply shows recent comments, with links to the posts they appear on. Besides the standard widget options, you can set the number of comments to display in the widget.
 
 **Largo Recent Posts**
 
 This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
 
-Limiting by tags, taxonomies, and terms requires using the "slug" for each. For example, the slug for a tag of "social media" would be "social-media". Likewise with the Custom Taxonomies (Post Prominence, Series, and Post Types), the slugs are "prominence", "series", and "post-type". If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and the slug for the term in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. You can find the slugs for any taxonomy by checking its settings page which lists the names and slugs for each taxonomy.
+Limiting by taxonomies and their terms requires using the "slug" for each. To start with, here are the available taxonomies with their names and slugs:
+
+===============   ======================================================
+Taxonomy Name     Taxonomy Slug
+===============   ======================================================
+Categories        category
+Tags              post_tag
+Post Prominence   prominence
+Series            series
+Post Types        post-type
+===============   ======================================================
+
+Each term within a taxonomy also has a name and a slug. For example, the slug for a tag of "social media" would be "social-media". You can find the slugs for the terms in any taxonomy by checking its settings page, which lists the names and their slugs.
+
+If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and then the term's slug in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. 
 
 After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
 
 **Largo Related Posts**
 
-This widget works on single-post and Series pages. It shows the title, thumbnail image, related posts that are either set manually (by adding related post IDs in the Additional Options/Related Posts box of the post edit screen) or by falling back to a default algorithm that selects the most closely-related post(s) based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
+This widget works on single-post and Series pages. It shows the title and thumbnail image for related posts.  Related posts can be set manually by adding related post IDs in the Additional Options/Related Posts box of the post edit screen. If no related posts are set, the widget will back to a default algorithm that selects the most closely-related posts based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
 
 **Largo Series Posts**
 
-Displays links to up to 5 posts in the series selected. The first include the title and excerpt, and a thumbnail of the Featured Image if one is included in the post. You can also choose to show the date on the first post. The remaining post links are displayed as a simple unordered list under a customizable heading, which defaults to "Explore". 
+Displays links to up to five posts in the series selected. The first link will include the post title and excerpt, and a thumbnail of the Featured Image if one is included in the post. You can also choose to show the date with the first post link. The remaining post links are displayed as a simple unordered list under a customizable heading, which defaults to "Explore". 
 
 **Largo Staff Roster**
 
-Displays a list of users on your site, with the thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting to include specific user groups, and changing the title displayed with the widget (which defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
+Displays a list of users on your site, with a thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting specific user groups, and changing the title displayed with the widget ( defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
 
 **Largo Tag List**
 
@@ -137,9 +156,9 @@ Typically used in the Article Bottom widget area, this will display a list of ca
 
 **Largo Taxonomy List**
 
-List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
+List all of the terms in a given taxonomy with links to their archive pages. This is most commonly used to generate a list of series/projects with links to their project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for Post Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
 
-By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. 
+By default the widget will pull in *all* posts in the taxonomy, which could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term's ID by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. 
 
 For example, in this URL for the term "Bacon" the term ID is 482:
 
@@ -149,13 +168,15 @@ After setting the taxonomy slug, count, and optionally limiting by term ID, you 
 
 **Largo Twitter Widget**
 
-Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget (and grab the widget ID) from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. On Twitter you can create widgets for a user timeline, favorites, list, or search. In the Largo Twitter Widget, set the Widget Type for the type you want and paste in the Twitter Widget ID.
+Allows for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget and grab its ID from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. 
 
-_Note: In most cases the Largo Twitter Widget will work fine if you just set the Twitter Widget ID. As a fallback in case of errors loading scripts from Twitter, it's a good idea to also add the Twitter Username, List slug, and search query in the settings._
+On Twitter you can create widgets for a user timeline, favorites, list, or search. In the Largo Twitter Widget, set the Widget Type for the type you want and paste in the Twitter Widget ID.
+
+*Note: In most cases the Largo Twitter Widget will work fine if you just set the Twitter Widget ID. As a fallback in case of errors loading scripts from Twitter, it's a good idea to also add the Twitter Username, List slug, and search query in the settings*.
 
 **Largo Roundups Widget**
 
-If you have the Link Roundups plugin installed, this widget will display the most recent Link Roundup posts. You can change the number of posts to show, limit display to a category, and add a More link at the bottom of the widget. 
+If you have the **Link Roundups** plugin installed, this widget will display the most recent Link Roundup posts. You can change the number of posts to show, limit display to a category, and add a More link at the bottom of the widget. 
 
 For more on how this works see the `Link Roundups widget documentation <https://github.com/INN/link-roundups/blob/master/README.md>`_.
 
@@ -172,10 +193,10 @@ Sidebar Options
 Under the Appearance > Theme Options > Layout menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
 
 - A checkbox to activate the "Topic Sidebar" as described above.
-- An option to include an optional widget area directly above the footer (used by a few sites to add sponsor logos or additional ad units).
+- An option to include an optional widget region ("sidebar") just above the site footer. This can be used by a few sites to add sponsor logos or additional ad units, etc.
 
-You can also easily register custom sidebar regions, which will then be available as Widget Areas in Appearance > Widgets, and as sidebars in posts. This is useful if you want to create additional widget areas for particular categories or projects on your site. 
+You can also easily register custom sidebar regions, which will then be available as widget regions in Appearance > Widgets, and as sidebars in posts. This is useful if you want to create additional widget areas for particular categories or special projects on your site. 
 
-To add a new widget area, simply add the name of the widget area to the textbox with each widget area you'd like to register on a new line and then click "Save Options".
+To add a new widget area, simply add a name in the textbox with each widget area you'd like to register on a new line and then click "Save Options".
 
-Once you have added custom widget areas you can add widgets to them from the Appearance > Widgets menu.  Then on the post edit page you can select them as sidebars from the Layout Options > Custom Sidebar dropdown, or from the Archive Sidebar dropdown when adding or managing a category, tag, or series.
+Once you have added custom widget areas you can add widgets to them from the Appearance > Widgets menu. On the post edit page you can select them as sidebars from the Layout Options > Custom Sidebar dropdown, or from the Archive Sidebar dropdown when adding or managing a category, tag, or series.

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -22,7 +22,6 @@ Sidebar Widget Areas
 --------------------
 
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
-
 - **Single Sidebar** - Used for single posts and pages, if you select a two-column template for single-post pages. As of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the **Layout Options > Custom Sidebar** dropdown menu when editing an individual post. Note that if you do not populate this widget area, Largo will fall back to using the Main Sidebar. 
 - **Topic Sidebar** - An optional widget area enabled from the **Appearance > Theme Options > Layout** menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy pages.
 
@@ -58,7 +57,7 @@ Largo adds a number of custom widgets in addition to the `standard widgets <http
 All Largo custom widgets have:
 
 - The choice of three backgrounds (default, reverse and none) to provide styling options and classes for custom CSS.
-- The ability to hide the widget on desktops, tablets, and phones using the responsive utility classes `from Twitter Bootstrap <http://getbootstrap.com/2.3.2/scaffolding.html#responsive>`_. We recommend hiding less necessary widgets for users on smaller viewports such as mobile devices to create a cleaner experience that allows them to focus on your content.
+- The ability to hide the widget on desktops, tablets, and phones using the responsive utility classes `from Twitter Bootstrap <http://getbootstrap.com/2.3.2/scaffolding.html#responsive>`_. We recommend hiding less-necessary widgets for users on smaller viewports such as mobile devices to create a cleaner experience that allows them to focus on your content.
 - The ability to set a link for the widget title.
 
 Here is a complete list of the Largo custom widgets as of version 0.5.4:
@@ -71,7 +70,7 @@ Shows a list of curated stories from other members of INN. By default this widge
 Largo About Site
 ----------------
 
-Displays the site description provided in the **Appearance > Theme Options > Basic Settings** menu.
+Displays the site description provided in the **Appearance > Theme Options > Basic Settings** menu. This description can include some HTML elements (such as links, bold text, etc.).
 
 Largo Author Bio
 ----------------
@@ -86,7 +85,7 @@ When the "Enable Disclaimer Widget" option is enabled from the **Appearance > Th
 Largo Donate Widget
 -------------------
 
-Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
+Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site. By default, the link used in this widget is the one set under the **Appearance > Theme Options > Basic Settings** menu (also used for the donate button in the site header).
 
 Largo Explore Related
 ---------------------
@@ -97,13 +96,6 @@ Largo Facebook Widget
 ---------------------
 
 Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook accounts. If you get an error message saying "Error: Not a valid Facebook Page url," it typically means the url is not a public Facebook Page.
-
-Largo Featured Posts
---------------------
-
-Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: *Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget*. (You can add new Post Prominence terms in **Posts > Post Prominence**.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the **Appearance > Theme Options > Layout > Sidebar Options**), and set it to display posts assigned the Prominence Term of Featured in Category.
-
-In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
 
 Largo Follow
 ------------
@@ -125,7 +117,7 @@ This widget is useful for single-post pages to show the title and description of
 Largo Prev/Next Links
 ---------------------
 
-Most commonly used in the Article Bottom widget area, this will show links to the next and previous posts ordered by published date.
+Most commonly used in the Article Bottom widget area, this will show links to the next and previous posts ordered by published date. Optionally, you can choose to limit the posts shown to the next/previous stories in the same category as the current post.
 
 Largo Recent Comments
 ---------------------
@@ -153,7 +145,7 @@ Each term within a taxonomy also has a name and a slug. For example, the slug fo
 
 If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and then the term's slug in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. 
 
-After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
+After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts which will cause this widget to skip any posts that are already shown elsewhere on the page.
 
 Largo Related Posts
 -------------------
@@ -205,11 +197,16 @@ If you have the **Link Roundups** plugin installed, this widget will display the
 For more on how this works see the `Link Roundups widget documentation <https://github.com/INN/link-roundups/blob/master/README.md>`_.
 
 
-Widgets Deprecated in 0.4
+Widgets Deprecated in 0.4x
 =========================
 
 - **Largo Footer Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
 - **Largo Sidebar Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
+
+Widgets Deprecated in 0.5x
+=========================
+
+- **Largo Featured Posts** - Now just use the Largo Recent Posts widget and limit to the desired term in the Prominence taxonomy.
 
 Sidebar Options
 ===============

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -16,9 +16,10 @@ Note that some widgets are small and can easily fit in narrow columns. Other wid
 For more about widgets and how WordPress handles them, see `the WordPress Codex article on widgets <http://codex.wordpress.org/WordPress_Widgets>`_.
 
 Widget Areas
-------------
+============
 
-**Sidebar Widget Areas**
+Sidebar Widget Areas
+--------------------
 
 Note that the way some of these widget area appear on your site will depend on the layout options you set in the Appearance > Theme Options > Layout Options menu.
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -58,58 +58,110 @@ All of our widgets have:
 
 The widgets added by Largo include:
 
-- **INN Member Stories** - Shows a list of curated stories from other members of INN. By default this widget will display headlines, source, and date of the three recent stories from INN members. Options include showing excerpts and adjusting the number of stories to show.
+**INN Member Stories**
 
-- **Largo About Site** - Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
+Shows a list of curated stories from other members of INN. By default this widget will display headlines, source, and date of the three recent stories from INN members. Options include showing excerpts and adjusting the number of stories to show.
 
-- **Largo Author Bio** - Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile). Also includes a "More by author" link to the landing page for all posts by the author. This widget only works on single-post pages.
+**Largo About Site**
 
-- **Largo Disclaimer** - When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
+Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
 
-- **Largo Donate Widget** - Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
+**Largo Author Bio**
 
-- **Largo Explore Related** - A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.5 for backwards compatibility.
+Shows a bio of the author(s) for a given post including their photo and social media links (when filled out in their user profile). Also includes a "More by author" link to the landing page for all posts by the author. This widget only works on single-post pages.
 
-- **Largo Facebook Widget** - Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
+**Largo Disclaimer**
 
-- **Largo Featured Posts** - Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout Options menu), and set it to display posts assigned the Prominence Term of Featured in Category. In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
+When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
 
-- **Largo Follow** - Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
+**Largo Donate Widget**
+Shows a donate message and button with a link to a donation page. You can change the message, button text, and/or link on a per-widget basis if you need to for different pages/sections of your site.
 
-- **Largo Image Widget** - The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, set the image alignment in relation to the caption text. As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
+**Largo Explore Related**
 
-- **Largo Recent Comments** - Shows recent comments with links to the posts they appear on. 
+A tabbed widget to show related stories by category/tag. This widget works only on single-post pages, and fits best in the Article Bottom widget area. We recommend using the Largo Related posts widget instead but this widget is retained in Largo version 0.5 for backwards compatibility.
 
-- **Largo Related Posts** - This widget works on single-post and Series pages. It shows the title, thumbnail image, related posts that are either set manually (by adding related post IDs in the Additional Options/Related Posts box of the post edit screen) or by falling back to a default algorithm that selects the most closely-related post(s) based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
+**Largo Facebook Widget**
 
-- **Largo Staff Roster** - Displays a list of users on your site, with the thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting to include specific user groups, and changing the title displayed with the widget (which defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
+Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which are by default public, not personal Facebook account. If you get an error message saying "Error: Not a valid Facebook Page url," the url is not a public Facebook Page.
 
-- **Largo Taxonomy List** - List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
+**Largo Featured Posts**
 
-By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. 
+Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout Options menu), and set it to display posts assigned the Prominence Term of Featured in Category.
 
-For example, in this URL for the term "Bacon": 
+In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
 
-:: /wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=482&post_type=post
+**Largo Follow**
 
-the term ID is 482.
+Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
 
-After setting the taxonomy slug, count, and optionally limiting by term ID, you choose to display thumbnails and a headline of the most recent post in the taxonomy, or display the taxonomy list as as dropdown menu. The Title of the widget defaults to Categories, but you can override this with a title of your choice.
+**Largo Image Widget**
 
-- **Largo Prev/Next Links** - Most commonly used in the Article Bottom widget area, this will show links to the next/prev post ordered by published date.
+The Largo Image Widget allows you to place an image in any widget area, along with a title and text caption. This can be useful to promote something else on your website or on another site, or create a custom message or ad. To begin just select an image in the widget settings and begin configuring. You can add a hyperlink from the image to any url, and choose to have the url open in the same window or a new window. You can choose a preset image size or set a custom size, set the image alignment in relation to the caption text. As with all images on your website, please be sure to add Alternate Text to tell visually impaired users what the image is. This should be a short phrase or sentence, similar to how you would describe the image to someone over the phone.
 
-- **Largo Recent Posts** - A powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
+**Largo Post Series Widget**
+
+This widget is useful for single-post pages to show the title and description of the series the post belongs to. If the post has not been assigned to a series, the widge will display nothing.
+
+**Largo Prev/Next Links** 
+
+Most commonly used in the Article Bottom widget area, this will show links to the next/prev post ordered by published date.
+
+**Largo Recent Comments**
+
+This widget simply shows recent comments, with links to the posts they appear on. Beside the standard widget options, you can set the number of comments to display in the widget.
+
+**Largo Recent Posts**
+
+This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
 
 Limiting by tags, taxonomies, and terms requires using the "slug" for each. For example, the slug for a tag of "social media" would be "social-media". Likewise with the Custom Taxonomies (Post Prominence, Series, and Post Types), the slugs are "prominence", "series", and "post-type". If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and the slug for the term in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. You can find the slugs for any taxonomy by checking its settings page which lists the names and slugs for each taxonomy.
 
 After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
 
-- **Largo Tag List** - Typically used in the Article Bottom widget area, this will display a list of categories and tags associated with a given post. Each term in this list links to the archive page for the term. Widget options include changing title of the list, and setting the maximum number of terms to show.
-- **Largo Twitter Widget** - Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget (and grab the widget ID) from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. On Twitter you can create widgets for a user timeline, favorites, list, or search. In the Largo Twitter Widget, set the Widget Type for the type you want and paste in the Twitter Widget ID.
+**Largo Related Posts**
+
+This widget works on single-post and Series pages. It shows the title, thumbnail image, related posts that are either set manually (by adding related post IDs in the Additional Options/Related Posts box of the post edit screen) or by falling back to a default algorithm that selects the most closely-related post(s) based on series, category or tag. Widget options include changing its title (defaults to "Read Next"), the number of related posts to display, and the related post Thumbnail position.
+
+**Largo Series Posts**
+
+Displays links to up to 5 posts in the series selected. The first include the title and excerpt, and a thumbnail of the Featured Image if one is included in the post. You can also choose to show the date on the first post. The remaining post links are displayed as a simple unordered list under a customizable heading, which defaults to "Explore". 
+
+**Largo Staff Roster**
+
+Displays a list of users on your site, with the thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting to include specific user groups, and changing the title displayed with the widget (which defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
+
+**Largo Tag List**
+
+Typically used in the Article Bottom widget area, this will display a list of categories and tags associated with a given post. Each term in this list links to the archive page for the term. Widget options include changing title of the list, and setting the maximum number of terms to show.
+
+**Largo Taxonomy List**
+
+List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
+
+By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. 
+
+For example, in this URL for the term "Bacon" the term ID is 482:
+
+	``/wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=482&post_type=post``
+
+After setting the taxonomy slug, count, and optionally limiting by term ID, you choose to display thumbnails and a headline of the most recent post in the taxonomy, or display the taxonomy list as as dropdown menu. The Title of the widget defaults to Categories, but you can override this with a title of your choice.
+
+**Largo Twitter Widget**
+
+Allow for the display of a Twitter profile, list or search widget. Note that to use this widget you'll need to create a Twitter widget (and grab the widget ID) from https://twitter.com/settings/widgets. Each widget on Twitter has a URL with a long string of numbers. That's the Twitter Widget ID, so copy and past that number into the Largo Twitter Widget. On Twitter you can create widgets for a user timeline, favorites, list, or search. In the Largo Twitter Widget, set the Widget Type for the type you want and paste in the Twitter Widget ID.
 
 _Note: In most cases the Largo Twitter Widget will work fine if you just set the Twitter Widget ID. As a fallback in case of errors loading scripts from Twitter, it's a good idea to also add the Twitter Username, List slug, and search query in the settings._
 
-Deprecated in 0.4:
+**Largo Roundups Widget**
+
+If you have the Link Roundups plugin installed, this widget will display the most recent Link Roundup posts. You can change the number of posts to show, limit display to a category, and add a More link at the bottom of the widget. 
+
+For more on how this works see the `Link Roundups widget documentation <https://github.com/INN/link-roundups/blob/master/README.md>`_.
+
+
+Widgets Deprecated in 0.4:
+--------------------------
 
 - **Largo Footer Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
 - **Largo Sidebar Featured Posts** - Works similarly to the Featured Widget above but limited to the "footer featured" term in the prominence taxonomy.
@@ -117,14 +169,13 @@ Deprecated in 0.4:
 Sidebar Options
 ---------------
 
-Under the Appearance > Theme Options > Layout Options menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
+Under the Appearance > Theme Options > Layout menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
 
-- A checkbox to activate the "Topic Sidebar" as described above
+- A checkbox to activate the "Topic Sidebar" as described above.
 - An option to include an optional widget area directly above the footer (used by a few sites to add sponsor logos or additional ad units).
-- An option to fade the sidebar on single post pages with a user scrolls
 
-And most importantly, a way to register custom widget areas. This is useful if you want to easily create additional widget areas for particular categories or projects on your site.
+You can also easily register custom sidebar regions, which will then be available as Widget Areas in Appearance > Widgets, and as sidebars in posts. This is useful if you want to create additional widget areas for particular categories or projects on your site. 
 
 To add a new widget area, simply add the name of the widget area to the textbox with each widget area you'd like to register on a new line and then click "Save Options".
 
-Once you have added custom widget areas you can add widgets to them from the Appearance > Widgets menu and then you will be able to select them from the Layout Options > Custom Sidebar dropdown from the post edit page or from the Archive Sidebar dropdown when adding or managing a category, tag or series from the Posts menu.
+Once you have added custom widget areas you can add widgets to them from the Appearance > Widgets menu.  Then on the post edit page you can select them as sidebars from the Layout Options > Custom Sidebar dropdown, or from the Archive Sidebar dropdown when adding or managing a category, tag, or series.

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -7,7 +7,7 @@ Overview
 
 Largo adds a number of widget areas and custom widgets to allow for easy, drag and drop management of content blocks on your site. You can access and edit any of these widget areas from the **Appearance > Widgets** menu in the WordPress Dashboard.
 
-To add a content block to a widget area, simply drag and drop a widget from the available widgets on left to the widget area on the right where you want it to appear. Note that as soon as you add any widgets to a widget area, any default content will no longer display so you will need to completely populate the widget area with the content you want to display. Most widgets have additional settings to configure how they display  on the site.
+To add a content block to a widget area, simply drag and drop a widget from the available widgets on left to the widget area on the right where you want it to appear. Note that as soon as you add any widgets to a widget area, any default content in that widget area will no longer display so you'll need to completely populate that area with the content you want. Most widgets have additional settings to configure how they display on the site.
 
 Note that some widgets are small and can easily fit in narrow columns. Other widgets can contain lots of content that doesn’t fit well in a small space. It’s important to see how a widget affects the page layout and adjust as needed.
 
@@ -43,7 +43,7 @@ Less Common Widget Areas
 
 - **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can place a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic, so if you plan to use it you might want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget for this area.
 - **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the **Appearance > Theme Options > Advanced** tab, drop an ad widget to appear in this area.
-- **Homepage Left Rail** - If you are using a three column homepage layout (set in **Appearance > Theme Options >Layout**) this is the widget area for the contents of the left-side column.
+- **Homepage Left Rail** - If you are using a three column homepage layout (set in **Appearance > Theme Options > Layout**) this is the widget area for the contents of the left-side column.
 
 Custom Widget Areas
 -------------------
@@ -135,7 +135,7 @@ This widget simply shows recent comments, with links to the posts they appear on
 Largo Recent Posts
 ------------------
 
-This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in **Appearance > Theme Options > Advanced**), and you can combine these filters as needed. 
+This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by a custom taxonomy like Post Prominence, Series, or Post Types (the latter two need to be enabled in **Appearance > Theme Options > Advanced**), and you can combine these filters as needed. 
 
 Limiting by taxonomies and their terms requires using the "slug" for each. To start with, here are the available taxonomies with their names and slugs:
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -3,7 +3,7 @@ Sidebars and Widgets
 ====================
 
 Overview
---------
+========
 
 Largo adds a number of widget areas and custom widgets to allow for easy, drag and drop management of content blocks on your site.
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -68,9 +68,11 @@ The widgets added by Largo include:
 
 - **Largo Taxonomy List** - List all of the terms in a given taxonomy with links to their archive pages. This is mostly commonly used to generate a list of series/projects with links to the project pages. To use this widget begin by entering in the Taxonomy field the slug of the taxonomy you want to use. For example, the slug for Categories is "category"; the slug for Tags is "post_tag"; the slug for P:ost Prominence is "prominence"; and the slug for Series is "series". You must enter one of these slugs for the widget to function correctly. 
 
-By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. For example, in this URL for the term "Bacon": 
+By default the widget will pull in *all* posts in the taxonomy, and this could be a very large number of posts. Use the Count field to limit the number of posts displayed. You can also limit the display to specific terms in the taxonomy. To do this you must find the term IDs by visiting the list of terms in the taxonomy (under Posts in the dashboard), then hover over or click on the term and find the tag_ID number in the URL for that term. 
 
-/wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=482&post_type=post
+For example, in this URL for the term "Bacon": 
+
+:: /wp-admin/edit-tags.php?action=edit&taxonomy=post_tag&tag_ID=482&post_type=post
 
 the term ID is 482.
 

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -21,22 +21,22 @@ Widget Areas
 Sidebar Widget Areas
 --------------------
 
-Note that the way some of these widget area appear on your site will depend on the layout options you set in the Appearance > Theme Options > Layout menu.
+Note that the way some of these widget area appear on your site will depend on the layout options you set in the **Appearance > Theme Options > Layout** menu.
 
 - **Main Sidebar** - By default this is the sidebar used for all non-single pages (homepage, category pages, date archive pages, etc.)
 
-- **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the Layout Options > Custom Sidebar dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
-- **Topic Sidebar** - An optional widget area enabled from the Appearance > Theme Options > Layout Options menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
+- **Single Sidebar** - Used on single posts and pages. Note that if you do not populate this widget area, Largo will fallback to using the Main Sidebar instead. Additionally, as of Largo version 0.4, the recommended default layout for single posts and pages is a single column layout that does **not** include a sidebar unless you explicitly set one from the **Layout Options > Custom Sidebar** dropdown menu when editing an individual post. If you select a sidebar from this dropdown menu, it typically appear as a skinny column floated to the left of your content.
+- **Topic Sidebar** - An optional widget area enabled from the **Appearance > Theme Options > Layout** menu. When enabled, this widget area will be used in the place of the main sidebar on all category, tag, and custom taxonomy (e.g. - series) pages.
 
 Footer Widget Areas
 -------------------
 
-Depending on which layout you select in the Appearance > Theme Options > Layout Options menu for the Footer Layout option, you will see either three or four numbered footer widget areas (which are numbered left to right). These areas will typically be populated by some default widgets that you can modify or change by adding widgets of your choice in the Appearance > Widgets menu.
+Depending on which layout you select in the **Appearance > Theme Options > Layout** menu for the Footer Layout option, you will see either three or four numbered footer widget areas (which are numbered left to right). These areas will typically be populated by some default widgets that you can modify or change by adding widgets of your choice in the **Appearance > Widgets** menu.
 
 The Article Bottom Widget Area
 ------------------------------
 
-Prior to version 0.4, Largo controlled the appearance of elements at the bottom of article pages using various settings from the Appearance > Theme Options > Basic Settings menu. In version 0.4 we have made this a widget area instead to allow for more flexibility in the type and order of elements that appear here.
+Prior to version 0.4, Largo controlled the appearance of elements at the bottom of article pages using various settings from the **Appearance > Theme Options > Basic Settings** menu. In version 0.4 we have made this a widget area instead to allow for more flexibility in the type and order of elements that appear here.
 
 By default, the only thing displayed at the bottom of an article is the comments section (when comments are enabled). Some of the elements you might consider adding to this area are the author bio, related posts and prev/next links widgets but many of the widgets in WordPress or those added by Largo are designed to be contextual and display well in this area so you can experiment and see what best suits your needs.
 
@@ -44,13 +44,13 @@ Less Common Widget Areas
 ------------------------
 
 - **Homepage Alert** - For sites that cover breaking news, this is an optional widget area where you can add a text widget to add a "breaking" banner to the top of the homepage. The styling for this widget area is very basic so if you plan to use it you'll likely want to create either some custom CSS for a text widget and/or create and register your own "breaking news" widget to be used in this widget area.
-- **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the Appearance > Theme Options > Advanced tab then this would be the widget are you'll use to add an ad widget to appear in that position.
+- **Header Ad Zone** -  If you have enabled the optional header leaderboard ad zone from the **Appearance > Theme Options > Advanced** tab then this would be the widget are you'll use to add an ad widget to appear in that position.
 - **Homepage Left Rail** - If you are using a three column homepage layout this will be a widget area to manage the contents of the skinny column to the far left.
 
 Custom Widget Areas
 -------------------
 
-Largo also enables you to add any number of **custom widget areas** you might need for display on certain pages of your site. For example, you might want to create a sidebar for a category or series that is only displayed on the archive page for that category/series and/or on the posts that appear in that category/series. Custom sidebars can be added from the Appearance > Theme Options > Layout tab under the "Sidebar Options" header. Instructions for settings these options can be found below.
+Largo also enables you to add any number of **custom widget areas** you might need for display on certain pages of your site. For example, you might want to create a sidebar for a category or series that is only displayed on the archive page for that category/series and/or on the posts that appear in that category/series. Custom sidebars can be added from the **Appearance > Theme Options > Layout** tab under the "Sidebar Options" header. Instructions for settings these options can be found below.
 
 Custom Widgets
 ==============
@@ -73,7 +73,7 @@ Shows a list of curated stories from other members of INN. By default this widge
 Largo About Site
 ----------------
 
-Displays the site description provided in the Appearance > Theme Options > Basic Settings menu.
+Displays the site description provided in the **Appearance > Theme Options > Basic Settings** menu.
 
 Largo Author Bio
 ----------------
@@ -83,7 +83,7 @@ Shows a bio of the author(s) for a given post including their photo and social m
 Largo Disclaimer
 ----------------
 
-When the "Enable Disclaimer Widget" option is enabled from the Appearance > Theme Options > Advanced menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
+When the "Enable Disclaimer Widget" option is enabled from the **Appearance > Theme Options > Advanced** menu, this widget will show the article disclaimer you have provided. You can change the disclaimer on a per-article basis by modifying it in the post edit screen.
 
 Largo Donate Widget
 -------------------
@@ -103,14 +103,14 @@ Shows a Facebook "like" box/feed. This will only work for Facebook Pages, which 
 Largo Featured Posts
 --------------------
 
-Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: *Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget*. (You can add new Post Prominence terms in Posts > Post Prominence.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the Appearance > Theme Options > Layout menu > Sidebar Options), and set it to display posts assigned the Prominence Term of Featured in Category.
+Show posts assigned a Post Prominence, with titles, thumbnails and excerpts. By default Largo has five Post Prominence terms: *Featured in Category, Featured in Series, Footer Featured Widget, Homepage Featured, and Sidebar Featured Widget*. (You can add new Post Prominence terms in **Posts > Post Prominence**.) Use these to display posts you want to feature on different pages. For example you can place this widget in the Main Sidebar, and set it to display posts assigned to Homepage Featured. Posts assigned the Prominence Term of Homepage Featured will then display in this widget. You could then place another Largo Featured Posts widget in the Topic Sidebar (after enabling it from the **Appearance > Theme Options > Layout > Sidebar Options**), and set it to display posts assigned the Prominence Term of Featured in Category.
 
 In short, you can use the Featured Posts widget to feature different posts in various types of pages. Other options for this widget include changing the title (defaults to "In Case You Missed It"), changing the number of posts to show and the excerpt length, and Thumbnail location.
 
 Largo Follow
 ------------
 
-Uses the social media links provided for your site in the Appearance > Theme Options > Basic Settings menu to show buttons to follow you on select social networks. 
+Uses the social media links provided for your site in the **Appearance > Theme Options > Basic Settings** menu to show buttons to follow you on select social networks. 
 
 Largo Image Widget
 ------------------
@@ -137,7 +137,7 @@ This widget simply shows recent comments, with links to the posts they appear on
 Largo Recent Posts
 ------------------
 
-This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in Appearance > Theme Options > Advanced), and you can combine these filters as needed. 
+This is a powerful widget to show recent posts in various formats with the option to limit by category, tag, custom taxonomy term and/or author. This widget has many options that enable display of a filtered set of articles or excerpts based on criteria of your choosing. You can limit by author and/or category, and then further limit by tag. You can limit by custom taxonomy (Post Prominence, Series, or Post Types (the latter two need to be enabled in **Appearance > Theme Options > Advanced**), and you can combine these filters as needed. 
 
 Limiting by taxonomies and their terms requires using the "slug" for each. To start with, here are the available taxonomies with their names and slugs:
 
@@ -170,7 +170,7 @@ Displays links to up to five posts in the series selected. The first link will i
 Largo Staff Roster
 ------------------
 
-Displays a list of users on your site, with a thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting specific user groups, and changing the title displayed with the widget ( defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to Users > Edit User and in the Staff Status setting selecting "Hide in roster". 
+Displays a list of users on your site, with a thumbnail image, name, and a link to a page containing each user's posts. Widget options include selecting specific user groups, and changing the title displayed with the widget ( defaults to "Staff Members").  Note that you can exclude specific users from being displayed in the widget by going to **Users > Edit User** and in the Staff Status setting selecting "Hide in roster". 
 
 Largo Tag List
 --------------
@@ -216,13 +216,13 @@ Widgets Deprecated in 0.4
 Sidebar Options
 ===============
 
-Under the Appearance > Theme Options > Layout menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
+Under the **Appearance > Theme Options > Layout** menu you will find a section labelled "Sidebar Options". This area has a few options to configure the widget areas on your site:
 
 - A checkbox to activate the "Topic Sidebar" as described above.
 - An option to include an optional widget region ("sidebar") just above the site footer. This can be used by a few sites to add sponsor logos or additional ad units, etc.
 
-You can also easily register custom sidebar regions, which will then be available as widget regions in Appearance > Widgets, and as sidebars in posts. This is useful if you want to create additional widget areas for particular categories or special projects on your site. 
+You can also easily register custom sidebar regions, which will then be available as widget regions in **Appearance > Widgets**, and as sidebars in posts. This is useful if you want to create additional widget areas for particular categories or special projects on your site. 
 
 To add a new widget area, simply add a name in the textbox with each widget area you'd like to register on a new line and then click "Save Options".
 
-Once you have added custom widget areas you can add widgets to them from the Appearance > Widgets menu. On the post edit page you can select them as sidebars from the Layout Options > Custom Sidebar dropdown, or from the Archive Sidebar dropdown when adding or managing a category, tag, or series.
+Once you have added custom widget areas you can add widgets to them from the **Appearance > Widgets** menu. On the post edit page you can select them as sidebars from the **Layout Options > Custom Sidebar** dropdown, or from the Archive Sidebar dropdown when adding or managing a category, tag, or series.

--- a/docs/users/sidebarswidgets.rst
+++ b/docs/users/sidebarswidgets.rst
@@ -153,7 +153,7 @@ Each term within a taxonomy also has a name and a slug. For example, the slug fo
 
 If you want to limit by custom taxonomy, enter the taxonomy's slug in the Taxonomy field, and then the term's slug in the Term field. For example if you want to display Post Prominence content assigned to "Featured in Series", you'll enter "prominence" as the Taxonomy and "series-featured" as the Term. 
 
-After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bbylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
+After setting the limits on the content you want displayed, you can adjust how it's displayed.  You can set how thumbnails, excerpts, bylines, and top terms are displayed, and add a More link to a URL. One additional setting may be very helpful: Depending on how you limit by taxonomy etc., you may want to select the option to Avoid Duplicate Posts.
 
 Largo Related Posts
 -------------------


### PR DESCRIPTION
The sidebarwidgets page on http://largo.readthedocs.org/users/sidebarswidgets.html was woefully incomplete and out of date, and revising it has been a high priority prior to the coming release of Largo 0.5.5. (see: https://github.com/INN/Largo/issues/847)

Legacy language and formatting was cleaned up considerably and normalized. Sections were added for Largo widgets that weren't in the docs, and other sections were revised for accuracy, spelling, language, etc. Formatting was applied for better usability. Basically this is a complete revamp of the page.

It was suggested to create pages for each widget, so as to provide more details, screenshots, etc., and that can certainly be done. Since it was a high priority to fill in missing information and to correct errors, I chose to first make these changes to the existing page.

A readable version of the revised page can be found here: https://github.com/inn/docs/blob/master/how-to-work-with-us/pull-requests.md