### PR TITLE
404 page improvements

### DIFF
--- a/404.php
+++ b/404.php
@@ -9,6 +9,16 @@ get_header(); ?>
 
 <div id="content" class="span8" role="main">
 	<?php get_template_part( 'partials/content', 'not-found' ); ?>
+	<p><?php
+		echo wp_kses(of_get_option('404_message'), array(
+			'a' => array(),
+			'b' => array(),
+			'br' => array(),
+			'i' => array(),
+			'em' => array(),
+			'strong' => array(),
+		));
+	?></p>
 </div><!--#content -->
 
 <?php get_sidebar(); ?>

--- a/404.php
+++ b/404.php
@@ -19,6 +19,25 @@ get_header(); ?>
 			'strong' => array(),
 		));
 	?></p>
+
+	<?php
+		/*
+		 * Display the Recent Posts widget
+		 *
+		 * @since 0.5.5
+		 * @link http://jira.inn.org/browse/WE-103
+		 * @link https://codex.wordpress.org/Function_Reference/the_widget
+		 */
+		if ( class_exists( 'largo_recent_posts_widget' ) ) {
+			the_widget(
+				'largo_recent_posts_widget',
+				array (
+				),
+				array(
+				)
+			);
+		}
+	?>
 </div><!--#content -->
 
 <?php get_sidebar(); ?>

--- a/options.php
+++ b/options.php
@@ -688,6 +688,12 @@ function optionsframework_options() {
 		'type' 	=> 'checkbox');
 
 	$options[] = array(
+		'desc' 	=> __('<strong>404 page text.</strong> This will be displayed on the 404 page, which is shown when people try to navigate to a page on your site that does not exist. Allowed HTML tags are <code>a</code>, <code>b</code>, <code>br</code>, <code>em</code>, <code>i</code> and <code>strong</code>.', 'largo'),
+		'id' 	=> '404_message',
+		'std' 	=> '',
+		'type' 	=> 'textarea');
+
+	$options[] = array(
 		'name' 	=> __('Byline Options', 'largo'),
 		'type'	=> 'info');
 

--- a/partials/content-not-found.php
+++ b/partials/content-not-found.php
@@ -3,9 +3,11 @@ $apologies = __('Apologies, but no results were found. Perhaps searching will he
 
 if ( is_404() ) {
 	$apologies = sprintf(
-		__("Apologies, but <code>%s</code> was not found. Perhaps wearching will help.", 'largo'),
-		wp_kses($_SERVER['REQUEST_URI'], array()) // The url
+		__("Apologies, but <code>%s</code> was not found. Perhaps searching will help.", 'largo'),
+		wp_kses($_SERVER['REQUEST_URI'], array()) // The url, sanitized
 	);
+} else if ( is_search() ) {
+	$apologies = __("Apologies, but no results were found. Perhaps searching for something else will help.", 'largo');
 }
 
 ?>

--- a/partials/content-not-found.php
+++ b/partials/content-not-found.php
@@ -1,10 +1,21 @@
+<?php
+$apologies = __('Apologies, but no results were found. Perhaps searching will help.', 'largo');
+
+if ( is_404() ) {
+	$apologies = sprintf(
+		__("Apologies, but <code>%s</code> was not found. Perhaps wearching will help.", 'largo'),
+		wp_kses($_SERVER['REQUEST_URI'], array()) // The url
+	);
+}
+
+?>
 <article id="post-0" class="post no-results not-found">
 	<header class="entry-header">
 		<h1 class="entry-title"><?php _e('Nothing Found', 'largo'); ?></h1>
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">
-		<p><?php _e('Apologies, but no results were found. Perhaps searching will help.', 'largo'); ?></p>
+		<p><?php echo $apologies; ?></p>
 		<?php get_search_form(); ?>
 	</div><!-- .entry-content -->
 </article><!-- #post-0 -->

--- a/searchform.php
+++ b/searchform.php
@@ -5,7 +5,7 @@
 ?>
 <form class="form-search" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<div>
-		<input type="text" placeholder="<?php _e('Search', 'largo'); ?>" class="searchbox search-query" value="" name="s" />
+		<input type="text" placeholder="<?php _e('Search', 'largo'); ?>" class="searchbox search-query" value="<?php the_search_query(); ?>" name="s" />
 		<input type="submit" value="<?php _e('Go', 'largo'); ?>" name="search submit" class="search-submit btn">
 	</div>
 </form>


### PR DESCRIPTION
## Changes

- When used on a search page, the search form partial will display the search query. (Does not affect the header search; that does not use `searchform.php`
- The 404 page shows an optional text message supporting basic HTML under the search form, which is set in the theme options under Advanced options.
- `partials/content-not-found` displays the 404'd URL in a `<code>` element before the search box if the page is a 404. Otherwise, it continues to display "Apologies, but no results were found. Perhaps searching will help.'"

Here's an example with a successful search, showing the query in the search box:

<img width="685" alt="screen shot 2016-03-10 at 5 13 31 pm" src="https://cloud.githubusercontent.com/assets/1754187/13689090/773de7e8-e6e3-11e5-8b92-07af14cca2d9.png">

An unsuccessful search, showing a different text suggesting running a different search:

<img width="673" alt="screen shot 2016-03-10 at 5 18 01 pm" src="https://cloud.githubusercontent.com/assets/1754187/13689140/1425b2f2-e6e4-11e5-80f7-9adffd68d81c.png">

A 404 page, showing the requested URL:

<img width="670" alt="screen shot 2016-03-10 at 5 19 52 pm" src="https://cloud.githubusercontent.com/assets/1754187/13689176/556e043a-e6e4-11e5-9594-b12f1a9cb3f9.png">

A 404 page on a child theme, showing custom text and HTML tags in use:

<img width="632" alt="screen shot 2016-03-10 at 5 22 08 pm" src="https://cloud.githubusercontent.com/assets/1754187/13689222/a76c85fe-e6e4-11e5-993e-6de245b303c3.png">

A hierarchical taxonomy term, showing the `content-not-found` partial used on 404 and empty search pages in the river, because the term has fewer than 5 posts.

## Why

For #692 and [WE-103](http://jira.inn.org/browse/WE-103).

This is a hotfix because of the rapidity with which it is desired.