### PR TITLE
Fix series landing page footer using wrong global $post after the sidebar is output

### DIFF
--- a/series-landing.php
+++ b/series-landing.php
@@ -134,6 +134,7 @@ if ( isset( $wp_query->query_vars['term'] )
 	endwhile;
 	wp_reset_postdata();
 
+	// Enqueue the LMP data
 	$posts_term = of_get_option('posts_term_plural');
 	largo_render_template('partials/load-more-posts', array(
 		'nav_id' => 'nav-below',
@@ -171,7 +172,12 @@ endif;
 if ( 'none' != $opt['footer_style'] ) : ?>
 	<section id="series-footer">
 		<?php
-			//custom footer html
+			/*
+			 * custom footer html
+			 * If we don't reset the post meta here, then the footer HTML is from the wrong post. This doesn't mess with LMP, because it happens after LMP is enqueued in the main column.
+			 * @link http://jira.inn.org/browse/HELPDESK-590
+			 */
+			wp_reset_postdata();
 			if ( 'custom' == $opt['footer_style']) {
 				echo apply_filters( 'the_content', $opt['footerhtml'] );
 			} else if ( 'widget' == $opt['footer_style'] && is_active_sidebar( $post->post_name . "_footer" ) ) { ?>


### PR DESCRIPTION
## Changes

Resets the global $post with `wp_reset_postdata()` after the sidebar.

## Why

Widgets in the sidebar of the series landing page can mess with the global `$post` variable, causing the the series landing page footer to be drawn from a post that is not the series landing page. If the post mismatches, then contents of the footer are unreliable, and may not match the resired setting of non, sidebar, or custom HTML.

This doesn't affect the landing page's LMP query, because the LMP query is encoded into the page before the sidebar is output, when the LMP partial is gotten.

This doesn't account for protections to widgets in the footer, because as far as I know Largo doesn't recommend or support putting post-dependent widgets in the global footer context. Plus, post-dependent widgets wouldn't be put there.

For [HELPDESK-590](http://jira.inn.org/browse/HELPDESK-590).