### PR TITLE
Separate coauthors and non-coauthors byline functions

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -205,6 +205,8 @@ if ( ! function_exists( 'largo_byline_normal_or_custom' ) ) {
 		$values = get_post_custom( $post_id );
 
 		$authors = largo_author_link( false, $post_id );
+
+		// add the author's job title
 		$author_id = get_post_meta( $post_id, 'post_author', true );
 		$show_job_titles = of_get_option('show_job_titles');
 		if ( !isset( $values['largo_byline_text'] ) && $show_job_titles && $job = get_the_author_meta( 'job_title' , $author_id ) ) {


### PR DESCRIPTION
## Changes

- Create function to generate byline text when coauthors plugin is enabled
- Create function to generate byline text when normal WordPress users are used, or when the custom byline text/link option is used
- Replace relevant sections of `largo_byline` with those functions, to make `largo_byline` more readable

## Why

The normal user and the custom byline are conjoined because `largo_author_link` already handles both cases. The function `largo_byline_normal_or_custom` is a wrapper around `largo_author_link` that adds job titles to the output.

This is progress in #1126.

## Questions:

- Should we implement the full #1126 proposed plan, of making `largo_byline()` into a wrapper around an action hook, upon which the various things are placed? For example, the action hook approach would make it easier to add twitter handles or similar in the middle of the byline.