### PR TITLE
Replace deprecated arguments in largo_excerpt with null

### DIFF
--- a/feed-mailchimp.php
+++ b/feed-mailchimp.php
@@ -45,7 +45,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
   <item>
     <title><?php the_title_rss(); ?></title>
     <link><?php the_permalink(); ?></link>
-    <description><?php echo '<![CDATA[' . largo_excerpt( $post, 5, false, '', false ) . ']]>';  ?></description>
+    <description><?php echo '<![CDATA[' . largo_excerpt( $post, 5, null, '', false ) . ']]>';  ?></description>
     <pubDate><?php rss_date( strtotime( $post->post_date_gmt ) ); ?></pubDate>
     <guid><?php the_permalink(); ?></guid>
     <dc:creator><?php $curuser = get_user_by( 'id', $post->post_author ); echo $curuser->first_name . ' ' . $curuser->last_name; ?></dc:creator>

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -29,7 +29,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'large' ); ?></a>
 				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 				<h5 class="byline"><?php largo_byline(); ?></h5>
-				<?php largo_excerpt( $post, 4, false ); ?>
+				<?php largo_excerpt( $post, 4 ); ?>
 				<?php if ( largo_post_in_series() ):
 					$feature = largo_get_the_main_feature();
 					$feature_posts = largo_get_recent_posts_for_term( $feature, 1, 1 );
@@ -70,7 +70,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 							<?php endif; ?>
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
 							<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail(); ?></a>
-							<?php largo_excerpt( $post, 3, false ); ?>
+							<?php largo_excerpt( $post, 3 ); ?>
 						</div>
 					<?php elseif ( $count == 4 ) : ?>
 						<h4 class="subhead"><?php _e('More Headlines', 'largo'); ?></h4>

--- a/homepages/zones/zones.php
+++ b/homepages/zones/zones.php
@@ -32,9 +32,9 @@ function homepage_big_story_headline($moreLink=false) {
 		<h5 class="byline"><?php largo_byline(true, true, $bigStoryPost); ?></h5>
 		<section>
 			<?php if (empty($moreLink)) {
-					largo_excerpt($bigStoryPost, 2, false);
+					largo_excerpt($bigStoryPost, 2 );
 				} else {
-					largo_excerpt($bigStoryPost, 2, true, __('Continue&nbsp;Reading&nbsp;&rarr;', 'largo'), true, false);
+					largo_excerpt($bigStoryPost, 2, null, null, true, false);
 				} ?>
 		</section>
 	</article>

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -467,11 +467,11 @@ if ( ! function_exists( 'largo_custom_wp_link_pages' ) ) {
  * @since 0.3
  */
 if ( ! function_exists( 'largo_excerpt' ) ) {
-	function largo_excerpt( $the_post=null, $sentence_count = 5, $use_more = false, $more_link = '', $echo = true, $strip_tags = true, $strip_shortcodes = true ) {
+	function largo_excerpt( $the_post=null, $sentence_count = 5, $use_more = null, $more_link = null, $echo = true, $strip_tags = true, $strip_shortcodes = true ) {
 		if (!empty($use_more))
-			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $use_more is deprecated.');
+			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $use_more is deprecated. Please use null as the argument.');
 		if (!empty($more_link))
-			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $more_link is deprecated.');
+			_deprecated_argument(__FUNCTION__, '0.5.1', 'Parameter $more_link is deprecated. Please use null as the argument.');
 
 		$the_post = get_post($the_post); // Normalize it into a post object
 
@@ -777,7 +777,7 @@ if ( ! function_exists( 'largo_hero_with_caption' ) ) {
  */
 if ( ! function_exists( 'largo_post_metadata' ) ) {
 	function largo_post_metadata( $post_id, $echo = TRUE ) {
-		$out = '<meta itemprop="description" content="' . strip_tags( largo_excerpt( get_post( $post_id ), 5, false, '', false ) ) . '" />' . "\n";
+		$out = '<meta itemprop="description" content="' . strip_tags( largo_excerpt( get_post( $post_id ), 5, null, null, false ) ) . '" />' . "\n";
 	 	$out .= '<meta itemprop="datePublished" content="' . get_the_date( 'c', $post_id ) . '" />' . "\n";
 	 	$out .= '<meta itemprop="dateModified" content="' . get_the_modified_date( 'c', $post_id ) . '" />' . "\n";
 

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -51,7 +51,7 @@ class largo_related_posts_widget extends WP_Widget {
 					<span class="by-author"><?php largo_byline( true, false ); ?></span>
 				</h5>
 				<?php // post excerpt/summary
-				largo_excerpt(get_the_ID(), 2, false, '', true);
+				largo_excerpt(get_the_ID(), 2, null, null, true);
 		 		echo '</li>';
 	 		}
 

--- a/partials/archive-category-primary-feature.php
+++ b/partials/archive-category-primary-feature.php
@@ -19,7 +19,7 @@
 		</header>
 
 		<div class="entry-content">
-			<?php largo_excerpt($featured_post, 5, true, '', true, false); ?>
+			<?php largo_excerpt($featured_post, 5, null, null, true, false); ?>
 		</div>
 	</div>
 </article>

--- a/partials/content-search.php
+++ b/partials/content-search.php
@@ -16,7 +16,7 @@ $entry_classes = 'entry-content';
 			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
 		</h2>
 
-		<?php largo_excerpt( $post, 1, true, __('Continue&nbsp;Reading', 'largo'), true, false ); ?>
+		<?php largo_excerpt( $post, 1, null, null, true, false ); ?>
 
 		<?php if ( !is_home() && largo_has_categories_or_tags() && $tags === 'btm' ) { ?>
 			<h5 class="tag-list"><strong><?php _e('More about:', 'largo'); ?></strong> <?php largo_categories_and_tags( 8 ); ?></h5>

--- a/partials/content-series.php
+++ b/partials/content-series.php
@@ -34,7 +34,7 @@ $tags = of_get_option ('tag_display');
 		<?php endif; ?>
 
  		<?php if ( isset($opt['show']['excerpt']) && $opt['show']['excerpt'] ) :
-			largo_excerpt( $post, 5, true, __('Continue&nbsp;Reading&nbsp;&rarr;', 'largo'), true, false );
+			largo_excerpt( $post, 5, null, null, true, false );
 		endif; ?>
 
 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'btm' ) { ?>

--- a/partials/content.php
+++ b/partials/content.php
@@ -51,7 +51,7 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 
 	 	<h5 class="byline"><?php largo_byline(); ?></h5>
 
-		<?php largo_excerpt( $post, 5, true, __('Continue&nbsp;Reading', 'largo'), true, false ); ?>
+		<?php largo_excerpt( $post, 5, null, null, true, false ); ?>
 
 		<?php if ( !is_home() && largo_has_categories_or_tags() && $tags === 'btm' ) { ?>
 			<h5 class="tag-list"><strong><?php _e('More about:', 'largo'); ?></strong> <?php largo_categories_and_tags( 8 ); ?></h5>

--- a/partials/sticky-posts.php
+++ b/partials/sticky-posts.php
@@ -54,7 +54,7 @@ if ( $query->have_posts() ) {
 
 						<div class="entry-content">
 						<?php
-							largo_excerpt( $post, 2, false );
+							largo_excerpt( $post, 2 );
 							$shown_ids[] = get_the_ID();
 
 						if ( $feature_posts ) { //if the sticky post is in a series, show up to 3 other posts in that series ?>


### PR DESCRIPTION
## Changes

In all places where Largo calls `largo_excerpt` with more than 2 args, the 3rd and 4th args are set to `null`

The default args are set to `null` as well.

This prevents every page load causing a long repetitive list of the debug message listed in #1214, when `WP_DEBUG` is true.