### PR TITLE
Update link to the new Knowledge Base url in Largo Dashboard

### DIFF
--- a/inc/dashboard.php
+++ b/inc/dashboard.php
@@ -86,7 +86,7 @@ function largo_dashboard_quick_links() {
 				<li><a href="http://largoproject.org/">Largo Project Website</a></li>
 				<li><a href="http://largo.readthedocs.io/">Largo Documentation</a></li>
 				<li><a href="http://support.largoproject.org">Help Desk</a></li>
-				<li><a href="http://confluence.inn.org/display/LKB/Largo+Knowledge+Base">Knowledge Base</a></li>
+				<li><a href="http://support.largoproject.org/support/solutions">Knowledge Base</a></li>
 				<li><a href="mailto:support@largoproject.org">Contact Us</a></li>
 			</ul>
 			<p>Developers can also log issues on <a href="https://github.com/INN/Largo">our public github repository</a> and if you would like to be included in our Largo users\' group, <a href="http://inn.us1.list-manage1.com/subscribe?u=81670c9d1b5fbeba1c29f2865&id=913028b23c">sign up here</a>.</p>


### PR DESCRIPTION
## Change

Updated the Knowledge Base link in the **Project Largo Help** section of the Largo Dashboard to point to the new Knowledge Base on FreshDesk (http://support.largoproject.org/support/solutions).

## Why

The Knowledge Base link was pointing to the deprecated Confluence knowledge base (http://confluence.inn.org/display/LKB/Largo+Knowledge+Base) which we're not using anymore.