### PR TITLE
Re-enable term featured media after 4.5

### DIFF
--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -350,6 +350,9 @@ function largo_enqueue_featured_media_js($hook) {
 
 	$featured_image_display = get_post_meta($post->ID, 'featured-image-display', true);
 
+	// The scripts following depend upon the WordPress media APIs
+	wp_enqueue_media();
+
 	$suffix = (LARGO_DEBUG)? '' : '.min';
 	wp_enqueue_script(
 		'largo_featured_media', get_template_directory_uri() . '/js/featured-media' . $suffix . '.js',

--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -339,7 +339,7 @@ function largo_has_featured_media( $post = null ) {
  * @param array $hook The page that this function is being run on.
  */
 function largo_enqueue_featured_media_js($hook) {
-	if (!in_array($hook, array('edit.php', 'edit-tags.php', 'post-new.php', 'post.php')))
+	if (!in_array($hook, array('edit.php', 'edit-tags.php', 'post-new.php', 'post.php', 'term.php')))
 		return;
 
 	global $post, $wp_query;


### PR DESCRIPTION
## Changes

- Adds `term.php` to the list of admin URLs that the Largo featured media javascripts should be enqueued upon
- Makes sure that WordPress' Javascript media things are loaded: https://codex.wordpress.org/Function_Reference/wp_enqueue_media

## Why

Because the edit url in the admin changed for terms in 4.5, from one of `'edit.php', 'edit-tags.php', 'post-new.php', 'post.php'` to `'term.php'`.

## Post-merge tasks:

- [ ] update all production environments based on this `master` branch
- [ ] merge `master` back into `develop`