### PR TITLE
Travis CI: Simplify config and update tested WordPress versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ php:
 
 # WordPress version used in first build configuration.
 env:
-    - WP_VERSION=4.1.10 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.2.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.3.3 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-    - WP_VERSION=4.4.2 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+    - WP_VERSION=master
+    - WP_VERSION=4.5
+    - WP_VERSION=4.4
+    - WP_VERSION=4.3
+    - WP_VERSION=4.2
+    - WP_VERSION=4.1
 
 # Only test the unittests branch for now
 branches:
@@ -30,7 +32,9 @@ branches:
 # Clones WordPress and configures our testing environment.
 before_script:
     - export SLUG=$(basename $(pwd))
-    - svn co --quiet http://develop.svn.wordpress.org/tags/$WP_VERSION $WP_CORE_DIR
+    - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
+    - export WP_CORE_DIR=/tmp/wordpress/
+    - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_CORE_DIR
     - cd ..
     - mv $SLUG "$WP_CORE_DIR/src/wp-content/themes/$SLUG"
     - cd $WP_CORE_DIR


### PR DESCRIPTION
• Simplifys the build matrix to use WordPress branches rather than tags so the most recent version of each branch is tested
• Adds WordPress versions 4.5.x and "trunk", branch `4.5` and `master` respectively
• Switches from SVN to Git checkout of WordPress "develop" repo as the Git clone is ~25% faster than an SVN checkout
• Moves the "common" environment variables `WP_TESTS_DIR` and `WP_CORE_DIR` from the the build matrix to export during `before_script` 

Hopefully this speeds up your Travis CI tests a little and facilitates a little less maintenance of `.travis.yml` as WordPress releases new versions 😄 