### PR TITLE
Add a case for the generic post_type in archive.php

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -54,6 +54,9 @@ $queried_object = get_queried_object();
 				 */
 				$title = apply_filters( 'largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
 				$rss_link = '/rounduplink/feed';
+			} elseif ( is_post_type_archive() )  {
+				$title = post_type_archive_title( '', false );
+				$rss_link = '/feed/?post_type=' . urlencode($wp_query->query_vars['post_type']);
 			}
 		?>
 

--- a/archive.php
+++ b/archive.php
@@ -46,17 +46,26 @@ $queried_object = get_queried_object();
 				} else {
 					$title = _e( 'Blog Archives', 'largo' );
 				}
-			} elseif ( is_post_type_archive( 'rounduplink' ) ) {
+			} elseif ( is_post_type_archive() )  {
+				$post_type = $wp_query->query_vars['post_type'];
 				/**
-				 * Make the title of the rounduplink archive filterable
+				 * Make the title of the post_type archive filterable
 				 * @param string $title The title of the archive page
 				 * @since 0.5.4
 				 */
-				$title = apply_filters( 'largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
-				$rss_link = site_url('/rounduplink/feed');
-			} elseif ( is_post_type_archive() )  {
-				$title = post_type_archive_title( '', false );
-				$rss_link = site_url('/feed/?post_type=' . urlencode($wp_query->query_vars['post_type']));
+				$title = apply_filters(
+					'largo_archive_' . $post_type . '_title',
+					__( post_type_archive_title( '', false ), 'largo' )
+				);
+				/**
+				 * Make the feed url of the post_type archive filterable
+				 * @param string $title The title of the archive page
+				 * @since 0.5.5
+				 */
+				$rss_link = apply_filters(
+					'largo_archive_' . $post_type . '_feed',
+					site_url('/feed/?post_type=' . urlencode($post_type))
+				);
 			}
 		?>
 

--- a/archive.php
+++ b/archive.php
@@ -53,10 +53,10 @@ $queried_object = get_queried_object();
 				 * @since 0.5.4
 				 */
 				$title = apply_filters( 'largo_archive_rounduplink_title', __( 'Saved Links' , 'largo' ) );
-				$rss_link = '/rounduplink/feed';
+				$rss_link = site_url('/rounduplink/feed');
 			} elseif ( is_post_type_archive() )  {
 				$title = post_type_archive_title( '', false );
-				$rss_link = '/feed/?post_type=' . urlencode($wp_query->query_vars['post_type']);
+				$rss_link = site_url('/feed/?post_type=' . urlencode($wp_query->query_vars['post_type']));
 			}
 		?>
 

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -37,16 +37,28 @@ filter: **largo_homepage_topstories_post_count**
 Other filters and actions
 -------------------------
 
-filter: **largo_archive_rounduplink_title**
+filter: **largo_archive_{$post_type}_title**
 
-    Called in `archive.php` to filter the page title for posts in the `rounduplink` post type.
+    Called in `archive.php` to filter the page title for posts in the ``$post_type`` `post type <https://codex.wordpress.org/Post_Types>`_.
 
     **Usage:** ::
 
     function filter_rounduplink_title($title) {
-        return "Custom title here";
+        return __("Custom title here", 'largo');
     }
     add_action('largo_archive_rounduplink_title', 'filter_rounduplink_title');
+
+filter: **largo_archive_{$post_type}_feed**
+
+    Called in `archive.php` to filter the feed url for posts in the ``$post_type`` `post type <https://codex.wordpress.org/Post_Types>`_.
+post type.
+
+    **Usage:** ::
+
+    function filter_column_feed($title) {
+        return "http://example.com/custom_feed_url/feed.xml";
+    }
+    add_action('largo_archive_column_feed', 'filter_column_feed');
 
 filter: **largo_registration_extra_fields**
 


### PR DESCRIPTION
## Changes

- adds a conditional `elseif ( is_post_type_archive() )  {` to the section at the start of the file:
    - sets the title to `post_type_archive_title()`
    - sets the feed url to `'/feed/?post_type=' . urlencode($wp_query->query_vars['post_type'])`, which will look like `http://example.com/feed/?post_type=roundup`
- wraps the feed url for both the rounduplink and generic cases with [`site_url()`](https://codex.wordpress.org/Function_Reference/site_url), to make them point to the correct URL if the site is not hosted at the root of its domain.

## Why

For #1231, makes sure there's a title for all `post_type` archives.

Adds site_url because it's a better practice than to rely on `/` being the root of the site.

