### PR TITLE
Add 5 new actions to the search form, and docs

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -305,9 +305,19 @@ These actions are run on all homepage templates, including the Legacy Three Colu
  - **largo_after_page_header** - just after the closing post <header> element
  - **largo_before_page_content** - directly inside the .entry-content <div> tag
  - **largo_after_page_content** - directly before the .entry-content closing <div> tag
- 
- **category.php**
- 
+
+**category.php**
+
  - **largo_category_after_description_in_header** - between the ``div.archive-description`` and before ``get_template_part('partials/archive', 'category-related');``.
  - **largo_before_category_river** - just before the river of stories at the bottom of the category archive page (for adding a header to this column, for example)
  - **largo_after_category_river** - immediately after the river of stories at the bottom of the category archive page, after the Load More Posts button (for adding a footer to this column, for example.)
+
+**search.php**
+
+The Largo search page has two main modes: Google Custom Search Engine and the standard WordPress search emgine. Because the dispalyed layouts are so different, each has their own set of actions.
+
+- **largo_search_gcs_before_container**: If Google Custom Search is enabled, fires before the GCS container
+- **largo_search_gcs_after_container**: If Google Custom Search is enabled, fires after the GCS container
+- **largo_search_normal_before_form**: Fires before the ouput from ``get_search_form()``
+- **largo_search_normal_before_results**: Fires between ``get_search_from`` and "Your search for %s returned %s results", and runs even if there were no search results.
+- **largo_search_normal_after_results**: Fires after the search results or ``partials/content-not-found`` are displayed.

--- a/search.php
+++ b/search.php
@@ -13,6 +13,15 @@ get_header();
 			?>
 		</h1>
 
+		<?
+			/**
+			 * Fires before the Google Custom Search container
+			 *
+			 * @since Largo 0.5.5
+			 */
+			do_action('largo_search_gcs_before_container');
+		?>
+
 		<div class="gcs_container">
 			<script>
 				(function() {
@@ -57,10 +66,37 @@ get_header();
 			</script>
 			<?php } ?>
 		</div>
+
+		<?
+			/**
+			 * Fires after the Google Custom Search container
+			 *
+			 * @since Largo 0.5.5
+			 */
+			do_action('largo_search_gcs_after_container');
+		?>
+
 	<?php } else { ?>
 
 		<?php if ( have_posts() ) {
-			get_search_form(); ?>
+
+			/**
+			 * Fires before the non-GCS search form
+			 *
+			 * @since Largo 0.5.5
+			 */
+			do_action('largo_search_normal_before_form');
+
+			get_search_form();
+
+			/**
+			 * Fires after the non-GCS search form, before the search results counter
+			 *
+			 * @since Largo 0.5.5
+			 */
+			do_action('largo_search_normal_before_results');
+
+			?>
 
 			<h3 class="recent-posts clearfix">
 				<?php
@@ -79,6 +115,13 @@ get_header();
 			} else {
 				get_template_part( 'partials/content', 'not-found' );
 			}
+
+			/**
+			 * Fires after the non-GCS search results or lack-of-results
+			 *
+			 * @since Largo 0.5.5
+			 */
+			do_action('largo_search_normal_after_results');
 		} ?>
 </div><!-- #content -->
 


### PR DESCRIPTION
## Changes

- two actions for GCSE searches: before and after
- three actions for non-GCSE searches: before, in middle and after
- docs for above

## Why

#1235, to lessen reasons for modifying the search page.

In the future, we may want to break the search page up even further.