### PR TITLE
Wordpress 4.5 compatibility for detection of term featured media post

### DIFF
--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -344,8 +344,14 @@ function largo_enqueue_featured_media_js($hook) {
 
 	global $post, $wp_query;
 
-	if ( in_array($hook, array('edit-tags.php')) && isset($_GET['action']) ) {
-		$post = get_post( largo_get_term_meta_post( $_GET['taxonomy'], $_GET['tag_ID'] ) );
+	// Run this action on term edit pages
+	// edit-tags.php for wordpress before 4.5
+	// term.php for 4.5 and after
+	if ( in_array($hook, array('edit-tags.php', 'term.php')) && is_numeric($_GET['tag_ID']) ) {
+		// After WordPress 4.5, the taxonomy is no longer in the URL
+		// So to compensate, we get the taxonomy from the current screen
+		$screen = get_current_screen();
+		$post = get_post( largo_get_term_meta_post( $screen->taxonomy, $_GET['tag_ID'] ) );
 	}
 
 	$featured_image_display = get_post_meta($post->ID, 'featured-image-display', true);


### PR DESCRIPTION
## Changes

- on the `admin_enqueue_scripts` action `largo_enqueue_featured_media_js`, if the passed hook is `term.php`, go ahead and try to find the term featured media post
- when doing that, don't assume anymore that the taxonomy will be in the URL parameters. Get the taxonomy from `get_current_screen` instead.

## Why

#1225 didn't go far enough. It [added term.php](https://github.com/INN/Largo/pull/1225/files) to when `largo_enqueue_featured_media_js` would fire, term.php being [introduced in 4.5](https://codex.wordpress.org/Version_4.5) ([discussion thread](https://core.trac.wordpress.org/ticket/34988)), but didn't add `term.php` to the match slightly further down inside that hook. And it didn't account for the `action` parameter being removed from the term edit url. 

This is a PR against master, and after this, master should be merged into develop again.