### PR TITLE
Per issue #844 - adds theme support for <title> , as reported by Theme Check

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -415,6 +415,9 @@ if ( ! function_exists( 'largo_setup' ) ) {
 
 		// Add support for localization (this is a work in progress)
 		load_theme_textdomain('largo', get_template_directory() . '/lang');
+		
+		//Add support for <title> tags
+		add_theme_support( 'title-tag' );
 
 	}
 }


### PR DESCRIPTION
Per issue #844 I ran Theme Check on Largo. 

This pull request addresses a "Required" item reported by Theme Check, noting that the theme uses the <title> tag but doesn't include theme support in functions.php. So I've made that small change where I hope it makes sense (just let me know if it would be better elsewhere in the file and I'll fix).

I tested this using the WP test content library and see no issues.

It's a fairly trivial improvement, so I'm sure it can wait.