### PR TITLE
Update get current user to wp get current user

### DIFF
--- a/inc/users.php
+++ b/inc/users.php
@@ -140,8 +140,13 @@ function largo_edit_permission_check() {
     global $current_user, $profileuser;
 
     $screen = get_current_screen();
-
-    wp_get_current_user();
+    
+    global $wp_version; 
+    if ( !substr( $wp_version, 0, 3 ) === "4.5" ) {
+    	get_currentuserinfo();
+    } else {
+    	wp_get_current_user();
+    }
 
     if( ! is_super_admin( $current_user->ID ) && in_array( $screen->base, array( 'user-edit', 'user-edit-network' ) ) ) { // editing a user profile
         if ( is_super_admin( $profileuser->ID ) ) { // trying to edit a superadmin while less than a superadmin

--- a/inc/users.php
+++ b/inc/users.php
@@ -142,7 +142,7 @@ function largo_edit_permission_check() {
     $screen = get_current_screen();
     
     global $wp_version; 
-    if ( !substr( $wp_version, 0, 3 ) === "4.5" ) {
+    if ( $wp_version < 4.5 ) {
     	get_currentuserinfo();
     } else {
     	wp_get_current_user();

--- a/inc/users.php
+++ b/inc/users.php
@@ -141,7 +141,7 @@ function largo_edit_permission_check() {
 
     $screen = get_current_screen();
 
-    get_currentuserinfo();
+    wp_get_current_user();
 
     if( ! is_super_admin( $current_user->ID ) && in_array( $screen->base, array( 'user-edit', 'user-edit-network' ) ) ) { // editing a user profile
         if ( is_super_admin( $profileuser->ID ) ) { // trying to edit a superadmin while less than a superadmin


### PR DESCRIPTION
Fixes "Required" item listed in issue #844 `get_currentuserinfo()` found in the file users.php. Deprecated since version 4.5. Use `wp_get_current_user()` instead. Line 144"

Checks that current WP version is 4.5 or higher only uses `wp_get_current_user()` if true, otherwise still uses `get_currentuserinfo()`.

Performed a diff of the var_dump of both get_currentuserinfo() and wp_get_current_user(), and they're identical (as expected).