### PR TITLE
making Post Prominence tax items created via wp-admin visible on post add/edit screens

### DIFF
--- a/inc/post-metaboxes.php
+++ b/inc/post-metaboxes.php
@@ -312,20 +312,10 @@ add_action( 'admin_enqueue_scripts', 'largo_top_terms_js' );
  *
  */
 function largo_prominence_meta_box($post, $args) {
-	$largoProminenceTerms = $args['args'];
-
-	$terms = get_terms('prominence', array(
+	$termList = get_terms('prominence', array(
 		'hide_empty' => false,
 		'fields' => 'all'
 	));
-
-	$slugs = array_map(function($arg) { return $arg['slug']; }, $largoProminenceTerms);
-
-	$termList = array();
-	foreach ($terms as $k => $v) {
-		if (in_array($v->slug, $slugs))
-			$termList[] = $v;
-	}
 
 	$tax = get_taxonomy('prominence');
 	$args = array(


### PR DESCRIPTION
*This PR is an update of https://github.com/INN/Largo/pull/1252, but applied against the master branch as a hotfix*

Fixes issue identified in #956 

Prominence Terms added via `/wp-admin/edit-tags.php?taxonomy=prominence` are not displayed in the add/edit post screens.

This appears to be caused by the for loop that creates $termList in https://github.com/INN/Largo/blob/master/inc/post-metaboxes.php#L314
 
`$largoProminenceTerms` and by extension, `$slugs` only pull the default options set in the theme at https://github.com/INN/Largo/blob/master/inc/taxonomies.php#L90, so the for loop is only adding items to the display which exist in the default theme set.

I'm not sure if this loop was intended for something else, but removing it entirely and renaming `$terms` to `$termList` fixes the issue.