### PR TITLE
Make category.php use the largo_get_partial_by_post_type partial

### DIFF
--- a/category.php
+++ b/category.php
@@ -73,7 +73,7 @@ $queried_object = get_queried_object();
 				the_post();
 				$post_type = get_post_type();
 				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
-				get_template_part( 'partials/content', 'archive' );
+				get_template_part( 'partials/content', $partial );
 			}
 			largo_content_nav( 'nav-below' );
 		} else {


### PR DESCRIPTION
## Changes

- `category.php` will use the output of the `largo_get_partial_by_post_type` function instead of always rendering `partials/content-archive.php`

## Why

For consistency with `archive.php` and because this is the intended used of that function.