### PR TITLE
Prevent sticky hav container from having height set before the nav is set to display

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -113,7 +113,7 @@
       ( Largo.sticky_nav_options.main_nav_hide_article && ($('body').hasClass('single') || $('body').hasClass('page')) )
     ) {
       this.stickyNavScrollTopHide();
-      this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
+      this.stickyNavEl.parent().css('height', '');
     } else {
       this.stickyNavEl.parent().css('height', '');
     }

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -109,9 +109,15 @@
       this.stickyNavEl.addClass('show');
       this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
     } else if (
-      Largo.sticky_nav_options.sticky_nav_display ||
       ( Largo.sticky_nav_options.main_nav_hide_article && ($('body').hasClass('single') || $('body').hasClass('page')) )
     ) {
+      console.log("That's not right");
+      this.stickyNavEl.addClass('show');
+      this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
+    } else if (
+      Largo.sticky_nav_options.sticky_nav_display
+    ) {
+      console.log("This");
       this.stickyNavScrollTopHide();
       this.stickyNavEl.parent().css('height', '');
     } else {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -104,20 +104,14 @@
 
   Navigation.prototype.stickyNavResizeCallback = function() {
     if (
-      $(window).width() <= 768
-    ) {
-      this.stickyNavEl.addClass('show');
-      this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
-    } else if (
+      $(window).width() <= 768 ||
       ( Largo.sticky_nav_options.main_nav_hide_article && ($('body').hasClass('single') || $('body').hasClass('page')) )
     ) {
-      console.log("That's not right");
       this.stickyNavEl.addClass('show');
       this.stickyNavEl.parent().css('height', this.stickyNavEl.outerHeight());
     } else if (
       Largo.sticky_nav_options.sticky_nav_display
     ) {
-      console.log("This");
       this.stickyNavScrollTopHide();
       this.stickyNavEl.parent().css('height', '');
     } else {


### PR DESCRIPTION
## Changes

- When the sticky nav is set to display on the homepage, the height of the container element shall be nothing. 
- Merge the cases for "It's a phone" and "We're hiding the main nav on an article and only displaying the sticky nav" because they're doing the same things.
    - but continue running `this.stickyNavScrollTopHide()` on the "Always show sticky navs" case

## Noticed bug:

- No matter the value of `Largo.sticky_nav_options.sticky_nav_display`, sticky nav displays. This is true in current `develop` branch. I'm going to add this note to #1260 for another PR's fix.