### PR TITLE
Fix for "Page not found" on categories with hierarchical header and < 5 posts

### DIFF
--- a/category.php
+++ b/category.php
@@ -75,6 +75,10 @@ $queried_object = get_queried_object();
 				get_template_part( 'partials/content', 'archive' );
 			}
 			largo_content_nav( 'nav-below' );
+		} elseif ( count($featured_posts) > 0 ) {
+			// do nothing
+			// We have n > 1 posts in the featured header
+			// It's not appropriate to display partials/content-not-found here.
 		} else {
 			get_template_part( 'partials/content', 'not-found' );
 		} ?>

--- a/partials/content-not-found.php
+++ b/partials/content-not-found.php
@@ -10,14 +10,17 @@ if ( is_404() ) {
 			wp_kses($_SERVER['REQUEST_URI'], array()) // The url, sanitized
 		);
 	}
+
+	$title = '<h1 class="entry-title">' . __( 'Page Not Found', 'largo' ) . '</h1>';
 } else if ( is_search() ) {
 	$apologies = __( 'Apologies, but no results were found. Perhaps searching for something else will help.', 'largo' );
+	$title = '';
 }
 
 ?>
 <article id="post-0" class="post no-results not-found">
 	<header class="entry-header">
-		<h1 class="entry-title"><?php _e( 'Page Not Found', 'largo' ); ?></h1>
+		<?php echo $title ?>
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">


### PR DESCRIPTION
## Changes

- If the category has posts in the featured header, do not output `partials/content-not-found.php` if there are n < 6 posts in the category and the featured header is displayed.
- In that partial, don't output `Page Not Found` if it's not a 404. Examples of where this situation may occur:
    - `index.php`
    - `archive.php` and `category.php` if no posts match the query
    - `partials/home-post-list.php`

Using the same site as the original screenshot in #898 for these screenshots.

This is why the changes to `partials/content-not-found.php`:

<img width="1098" alt="screen shot 2016-08-21 at 9 32 30 pm" src="https://cloud.githubusercontent.com/assets/1754187/17842153/e3f88330-67ed-11e6-91eb-b8289df62563.png">

After those changes: 

<img width="675" alt="screen shot 2016-08-21 at 9 49 55 pm" src="https://cloud.githubusercontent.com/assets/1754187/17842154/e3f91552-67ed-11e6-8f65-72bd9bec8c28.png">

A 404 in this PR; nothing's changed:

<img width="642" alt="screen shot 2016-08-21 at 9 49 44 pm" src="https://cloud.githubusercontent.com/assets/1754187/17842155/e3f9bb74-67ed-11e6-9a55-6c6a8436b8de.png">
