### PR TITLE
add counters to main loop on archive pages

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -112,7 +112,7 @@ $queried_object = get_queried_object();
 					$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 					get_template_part( 'partials/content', $partial );
 					$counter++;
-					do_action( 'archive_loop_after_post_x', $counter );
+					do_action( 'archive_loop_after_post_x', $counter, $context = 'archive' );
 				endwhile;
 
 				largo_content_nav( 'nav-below' );

--- a/archive.php
+++ b/archive.php
@@ -105,9 +105,8 @@ $queried_object = get_queried_object();
 			<?php
 				// and finally wind the posts back so we can go through the loop as usual
 				rewind_posts();
-				
+				$counter = 1;
 				while ( have_posts() ) : the_post();
-					$counter = 1;
 					$post_type = get_post_type();
 					$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 					get_template_part( 'partials/content', $partial );

--- a/archive.php
+++ b/archive.php
@@ -107,12 +107,12 @@ $queried_object = get_queried_object();
 				rewind_posts();
 				
 				while ( have_posts() ) : the_post();
-					$counter = 0;
+					$counter = 1;
 					$post_type = get_post_type();
 					$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 					get_template_part( 'partials/content', $partial );
-					$counter++;
 					do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
+					$counter++;
 				endwhile;
 
 				largo_content_nav( 'nav-below' );

--- a/archive.php
+++ b/archive.php
@@ -105,11 +105,14 @@ $queried_object = get_queried_object();
 			<?php
 				// and finally wind the posts back so we can go through the loop as usual
 				rewind_posts();
-
+				
 				while ( have_posts() ) : the_post();
+					$counter = 0;
 					$post_type = get_post_type();
-					$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
+					$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 					get_template_part( 'partials/content', $partial );
+					$counter++;
+					do_action( 'archive_loop_after_post_x', $counter );
 				endwhile;
 
 				largo_content_nav( 'nav-below' );

--- a/archive.php
+++ b/archive.php
@@ -112,7 +112,7 @@ $queried_object = get_queried_object();
 					$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 					get_template_part( 'partials/content', $partial );
 					$counter++;
-					do_action( 'archive_loop_after_post_x', $counter, $context = 'archive' );
+					do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
 				endwhile;
 
 				largo_content_nav( 'nav-below' );

--- a/category.php
+++ b/category.php
@@ -68,11 +68,14 @@ $queried_object = get_queried_object();
 	<?php 
 		do_action( 'largo_before_category_river' );
 		if ( have_posts() ) {
+			$counter = 0;
 			while ( have_posts() ) {
 				the_post();
 				$post_type = get_post_type();
-				$partial = largo_get_partial_by_post_type('archive', $post_type, 'archive');
+				$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 				get_template_part( 'partials/content', 'archive' );
+				$counter++;
+				do_action( 'category_archive_loop_after_post_x', $counter );
 			}
 			largo_content_nav( 'nav-below' );
 		} else {

--- a/category.php
+++ b/category.php
@@ -75,7 +75,7 @@ $queried_object = get_queried_object();
 				$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 				get_template_part( 'partials/content', 'archive' );
 				$counter++;
-				do_action( 'category_archive_loop_after_post_x', $counter, $context = 'archive' );
+				do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
 			}
 			largo_content_nav( 'nav-below' );
 		} else {

--- a/category.php
+++ b/category.php
@@ -68,14 +68,14 @@ $queried_object = get_queried_object();
 	<?php 
 		do_action( 'largo_before_category_river' );
 		if ( have_posts() ) {
-			$counter = 0;
+			$counter = 1;
 			while ( have_posts() ) {
 				the_post();
 				$post_type = get_post_type();
 				$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 				get_template_part( 'partials/content', 'archive' );
-				$counter++;
 				do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
+				$counter++;
 			}
 			largo_content_nav( 'nav-below' );
 		} else {

--- a/category.php
+++ b/category.php
@@ -75,7 +75,7 @@ $queried_object = get_queried_object();
 				$partial = largo_get_partial_by_post_type( 'archive', $post_type, 'archive' );
 				get_template_part( 'partials/content', 'archive' );
 				$counter++;
-				do_action( 'category_archive_loop_after_post_x', $counter );
+				do_action( 'category_archive_loop_after_post_x', $counter, $context = 'archive' );
 			}
 			largo_content_nav( 'nav-below' );
 		} else {

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -254,7 +254,7 @@ This action takes a couple of arguments that may come in handy:
 an example of this in use might look like:
 
 	function mytheme_interstitial( $counter, $context ) {
-		if ( $counter === 2  && c$ontext === 'home' ) {
+		if ( $counter === 2  && $context === 'home' ) {
 			// do homepage stuff
 		} elseif ( $counter === 2 && $context === 'archive' ) {
 			// do something different in the same spot on archive pages

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -239,6 +239,29 @@ Here is the current list of hooks available in Largo (available as of v.0.4):
 
  - **largo_header_before_largo_header** - immediately before ``largo_header()`` is output
  - **largo_header_after_largo_header** - immediately after ``largo_header()`` is output. By default, ``largo_header_widget_sidebar`` is hooked here.
+ 
+**for all lists of posts**
+
+-  **largo_loop_after_post_x** - fires after ever post in a river of posts on the homepage or archive pages. This is helpful if you want to insert interstitial content in a river of posts (typically things like newsletter subscription widgets, donation messages, etc.). 
+
+This action takes a couple of arguments that may come in handy:
+
+	do_action( 'largo_loop_after_post_x', $counter, $context );
+	
+	- **$counter** tracks the number of posts in any given loop
+	- **$context** is presently either 'archive' or 'home' to give you flexibility to insert different interstitials for different page types. 
+	
+an example of this in use might look like:
+
+	function mytheme_interstitial( $counter, $context ) {
+		if ( $counter === 2  && c$ontext === 'home' ) {
+			// do homepage stuff
+		} elseif ( $counter === 2 && $context === 'archive' ) {
+			// do something different in the same spot on archive pages
+		}
+	}
+	add_action( 'largo_loop_after_post_x', 'mytheme_interstitial', 10, 2 );	
+	
 
 **home.php**
 
@@ -288,3 +311,4 @@ These actions are run on all homepage templates, including the Legacy Three Colu
  **category.php**
  
  - **largo_before_category_river** - just before the river of stories at the bottom of the category archive page (for adding a header to this column, for example)
+ 

--- a/partials/home-post-list.php
+++ b/partials/home-post-list.php
@@ -11,25 +11,31 @@ $args = array(
 	'ignore_sticky_posts' => true
 );
 
-if (of_get_option('num_posts_home'))
-	$args['posts_per_page'] = of_get_option('num_posts_home');
-if (of_get_option('cats_home'))
-	$args['cat'] = of_get_option('cats_home');
+if ( of_get_option( 'num_posts_home' ) ) {
+	$args['posts_per_page'] = of_get_option( 'num_posts_home', 10 );
+}
+if ( of_get_option( 'cats_home' ) ) {
+	$args['cat'] = of_get_option( 'cats_home', '' );
+}
 
 $query = new WP_Query($args);
-if ($query->have_posts()) {
+
+if ( $query->have_posts() ) {
+	$counter = 0;
 	while ($query->have_posts()) : $query->the_post();
 		//if the post is in the array of post IDs already on this page, skip it. Just a double-check
-		if (in_array(get_the_ID(), $shown_ids))
+		if ( in_array( get_the_ID(), $shown_ids))
 			continue;
 		else {
 			$shown_ids[] = get_the_ID();
-			do_action('largo_before_home_list_post', $post, $query);
+			do_action( 'largo_before_home_list_post', $post, $query );
 			get_template_part('partials/content', 'home');
-			do_action('largo_after_home_list_post', $post, $query);
+			do_action( 'largo_after_home_list_post', $post, $query );
+			$counter++;
+			do_action( 'homepage_loop_after_post_x', $counter, $context = 'home' );
 		}
 	endwhile;
-	largo_content_nav('nav-below');
+	largo_content_nav( 'nav-below' );
 } else {
-	get_template_part('partials/content', 'not-found');
+	get_template_part( 'partials/content', 'not-found' );
 }

--- a/partials/home-post-list.php
+++ b/partials/home-post-list.php
@@ -32,7 +32,7 @@ if ( $query->have_posts() ) {
 			get_template_part('partials/content', 'home');
 			do_action( 'largo_after_home_list_post', $post, $query );
 			$counter++;
-			do_action( 'homepage_loop_after_post_x', $counter, $context = 'home' );
+			do_action( 'largo_loop_after_post_x', $counter, $context = 'home' );
 		}
 	endwhile;
 	largo_content_nav( 'nav-below' );

--- a/partials/home-post-list.php
+++ b/partials/home-post-list.php
@@ -21,7 +21,7 @@ if ( of_get_option( 'cats_home' ) ) {
 $query = new WP_Query($args);
 
 if ( $query->have_posts() ) {
-	$counter = 0;
+	$counter = 1;
 	while ($query->have_posts()) : $query->the_post();
 		//if the post is in the array of post IDs already on this page, skip it. Just a double-check
 		if ( in_array( get_the_ID(), $shown_ids))
@@ -31,8 +31,8 @@ if ( $query->have_posts() ) {
 			do_action( 'largo_before_home_list_post', $post, $query );
 			get_template_part('partials/content', 'home');
 			do_action( 'largo_after_home_list_post', $post, $query );
-			$counter++;
 			do_action( 'largo_loop_after_post_x', $counter, $context = 'home' );
+			$counter++;
 		}
 	endwhile;
 	largo_content_nav( 'nav-below' );

--- a/series-landing.php
+++ b/series-landing.php
@@ -129,8 +129,11 @@ if ( isset( $wp_query->query_vars['term'] )
 	}
 
 	$series_query = new WP_Query($args);
+	$counter = 0;
 	while ( $series_query->have_posts() ) : $series_query->the_post();
 		get_template_part( 'partials/content', 'series' );
+		$counter++;
+		do_action( 'largo_loop_after_post_x', $counter, $context = 'archive' );
 	endwhile;
 	wp_reset_postdata();
 


### PR DESCRIPTION
give ourselves a hook to add content at arbitrary locations in archive page loops (after the Nth post, insert an ad or signup box, etc.)

This is needed for MS Today so it will be a hotfix in the master branch