### PR TITLE
adding padding around Theme Options tab headers

### DIFF
--- a/lib/options-framework/css/optionsframework.css
+++ b/lib/options-framework/css/optionsframework.css
@@ -12,6 +12,7 @@
 }
 #optionsframework h3 {
 	cursor: default;
+	padding: 0 10px;
 }
 #optionsframework p {
 	margin-bottom:0;


### PR DESCRIPTION
Headings in Theme Options were missing padding

**Before:**
![screen shot 2016-08-31 at 12 48 02 pm](https://cloud.githubusercontent.com/assets/2522431/18138343/3e209616-6f7a-11e6-92cf-5e6473c34aeb.png)

**After:**
![screen shot 2016-08-31 at 12 52 46 pm](https://cloud.githubusercontent.com/assets/2522431/18138327/2fa21c86-6f7a-11e6-90b2-d2ab1f2d30c8.png)
