### PR TITLE
updated filter to fire on any menu name in that dont-miss location

### DIFF
--- a/inc/nav-menus.php
+++ b/inc/nav-menus.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'largo_add_dont_miss_label' ) ) {
 
 		// Get theme options label
 		$theme_option = esc_html( of_get_option( 'dont_miss_label') );
-		if ( !empty( $theme_option ) ) {
+		if ( ! empty( $theme_option ) ) {
 			return '<li class="menu-label">' . $theme_option . '</li>' . $items;
 		} else {
 			return $items;

--- a/inc/nav-menus.php
+++ b/inc/nav-menus.php
@@ -24,10 +24,30 @@ if ( ! function_exists( 'largo_donate_button' ) ) {
  */
 if ( ! function_exists( 'largo_add_dont_miss_label' ) ) {
 	function largo_add_dont_miss_label( $items, $args ) {
-	    return '<li class="menu-label">' . esc_html( of_get_option( 'dont_miss_label') ) . '</li>' . $items;
+
+		// Get theme options label
+		$theme_option = esc_html( of_get_option( 'dont_miss_label') );
+		if ( !empty( $theme_option ) ) {
+			return '<li class="menu-label">' . esc_html( $theme_option ) . '</li>' . $items;
+		} else {
+			return $items;
+		}	
 	}
 }
-add_filter( 'wp_nav_menu_dont-miss_items', 'largo_add_dont_miss_label', 10, 2 );
+
+/**
+ * Catch the build process on the menu in the Don't Miss location and trigger the filter for it
+ *
+ * @since .5.5
+ */
+function largo_modify_nav_menu_args( $items, $args) {
+	if ( 'dont-miss' == $args->theme_location ) {
+		add_filter( 'wp_nav_menu_' . $args->menu->slug . '_items', 'largo_add_dont_miss_label', 10, 2 );
+	}
+
+	return $items;
+}
+add_filter( 'wp_nav_menu_objects', 'largo_modify_nav_menu_args', 10, 2 );
 
 if ( ! function_exists( 'largo_add_footer_menu_label' ) ) {
 	function largo_add_footer_menu_label( $items, $args ) {

--- a/inc/nav-menus.php
+++ b/inc/nav-menus.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'largo_add_dont_miss_label' ) ) {
 		// Get theme options label
 		$theme_option = esc_html( of_get_option( 'dont_miss_label') );
 		if ( !empty( $theme_option ) ) {
-			return '<li class="menu-label">' . esc_html( $theme_option ) . '</li>' . $items;
+			return '<li class="menu-label">' . $theme_option . '</li>' . $items;
 		} else {
 			return $items;
 		}	


### PR DESCRIPTION
Fixes #1083 

This PR adds a function that fires on the `wp_nav_menu_objects` hook, checks if we're building the `dont-miss` location's menu, and then fires the existing `wp_nav_menu_{$menu->slug}_items` filter call, using the dynamically selected menu slug.

I'm not in love with this solution, but it's very functional and I think can solve the current issue in #1083 until we're able to loop back and rethink this on a larger scale.