### PR TITLE
Display posts hidden in Recent Stories list when "Avoid Duplicate Posts" is checked

### DIFF
--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -61,12 +61,7 @@ class largo_recent_posts_widget extends WP_Widget {
 		);
 
 		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
-			// Create a temporary array and fill it with posts from $shown_ids and from the page's original query
-			$duplicates = (array) $shown_ids;
-			foreach( $wp_query->posts as $post ) {
-				$duplicates[] = $post->ID;
-			}
-			$query_args['post__not_in'] = $duplicates;
+			$query_args['post__not_in'] = $shown_ids;
 		}
 		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
 		if ( $instance['tag'] != '') $query_args['tag'] = $instance['tag'];


### PR DESCRIPTION
solves #1219 

## The Problem
If a post is displayed in the Recent Stories / River View, then it will not display on the Regular / Top Stories view in Related Posts Widgets if "Avoid Duplicate Posts" is checked.

Posts in the Recent Stories / River View should not affect the display of stories in the widget areas of the Regular / Top Stories view.

## The Solution
The `$shown_ids` variable is already being passed to `widget()`, containing the post IDs that have been displayed thus far on the page.

This PR removes the additional check against `$wp_query->posts` which is adding posts from the river view into the list of excluded ids.