### PR TITLE
Do better detection of no related topics in Largo's category template

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -5,6 +5,7 @@
  * Used on category.php to display a list of related terms
  *
  * @since 1.0
+ * @return String HTML '' if there are no related topics or a UL if there are related topics
  */
 
 function largo_get_related_topics_for_category( $obj ) {
@@ -18,21 +19,16 @@ function largo_get_related_topics_for_category( $obj ) {
         if ( $obj->post_type == 'nav_menu_item' ) {
             $cat_id = $obj->object_id;
         }
-
-    }else {
-    $cat_id = $obj->cat_ID;
+    } else {
+		$cat_id = $obj->cat_ID;
     }
 
-    $out = "<ul>";
-	
-	$title_ul = apply_filters( 'largo_related_topics_title_ul', __( 'Related Topics:' , 'largo' ) );
-	$out .= '<li><strong>' . $title_ul . '</strong></li>';
-         
     // spit out the subcategories
+	$outarray = array();
     $cats = _subcategories_for_category( $cat_id );
 
     foreach ( $cats as $c ) {
-        $out .= sprintf( '<li><a href="%s">%s</a></li>',
+        $outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
             get_category_link( $c->term_id ), $c->name
         );
     }
@@ -42,13 +38,23 @@ function largo_get_related_topics_for_category( $obj ) {
             $MAX_RELATED_TOPICS - count( $cats ) );
 
         foreach ( $tags as $t ) {
-            $out .= sprintf( '<li><a href="%s">%s</a></li>',
+            $outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
                 get_tag_link( $t->term_id ), $t->name
             );
         }
     }
 
-    $out .= "</ul>";
+	$out = '';
+
+	// Generate the <ul>
+	if ( count( $outarray ) > 0 ) {
+		$out = "<ul>";
+		$title_ul = apply_filters( 'largo_related_topics_title_ul', __( 'Related Topics:' , 'largo' ) );
+		$out .= '<li><strong>' . $title_ul . '</strong></li>';
+		$out .= join( '', $outarray );
+		$out .= "</ul>";
+	}
+
     return $out;
 }
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -9,40 +9,40 @@
  */
 
 function largo_get_related_topics_for_category( $obj ) {
-    $MAX_RELATED_TOPICS = 5;
+	$MAX_RELATED_TOPICS = 5;
 
-    if (!isset($obj->post_type)) {
-    	$obj->post_type = 0;
-    }
+	if (!isset($obj->post_type)) {
+		$obj->post_type = 0;
+	}
 
-    if ( $obj->post_type ) {
-        if ( $obj->post_type == 'nav_menu_item' ) {
-            $cat_id = $obj->object_id;
-        }
-    } else {
+	if ( $obj->post_type ) {
+		if ( $obj->post_type == 'nav_menu_item' ) {
+			$cat_id = $obj->object_id;
+		}
+	} else {
 		$cat_id = $obj->cat_ID;
-    }
+	}
 
-    // spit out the subcategories
+	// spit out the subcategories
 	$outarray = array();
-    $cats = _subcategories_for_category( $cat_id );
+	$cats = _subcategories_for_category( $cat_id );
 
-    foreach ( $cats as $c ) {
-        $outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
-            get_category_link( $c->term_id ), $c->name
-        );
-    }
+	foreach ( $cats as $c ) {
+		$outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
+			get_category_link( $c->term_id ), $c->name
+		);
+	}
 
-    if ( count( $cats ) < $MAX_RELATED_TOPICS ) {
-        $tags = _tags_associated_with_category( $cat_id,
-            $MAX_RELATED_TOPICS - count( $cats ) );
+	if ( count( $cats ) < $MAX_RELATED_TOPICS ) {
+		$tags = _tags_associated_with_category( $cat_id,
+			$MAX_RELATED_TOPICS - count( $cats ) );
 
-        foreach ( $tags as $t ) {
-            $outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
-                get_tag_link( $t->term_id ), $t->name
-            );
-        }
-    }
+		foreach ( $tags as $t ) {
+			$outarray[] = sprintf( '<li><a href="%s">%s</a></li>',
+				get_tag_link( $t->term_id ), $t->name
+			);
+		}
+	}
 
 	$out = '';
 
@@ -55,7 +55,7 @@ function largo_get_related_topics_for_category( $obj ) {
 		$out .= "</ul>";
 	}
 
-    return $out;
+	return $out;
 }
 
 function _tags_associated_with_category( $cat_id, $max = 5 ) {

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -4,7 +4,7 @@
  * Show related tags and subcategories for each main category
  * Used on category.php to display a list of related terms
  *
- * @since 1.0
+ * @since 0.5.5
  * @return String HTML '' if there are no related topics or a UL if there are related topics
  */
 

--- a/partials/archive-category-related.php
+++ b/partials/archive-category-related.php
@@ -2,10 +2,10 @@
 
 // category pages show a list of related terms
 if ( defined( 'SHOW_CATEGORY_RELATED_TOPICS' ) && SHOW_CATEGORY_RELATED_TOPICS ) {
-	if ( is_category() && largo_get_related_topics_for_category( get_queried_object() ) != '<ul></ul>' ) { ?>
+	if ( is_category() && largo_get_related_topics_for_category( get_queried_object() ) != '' ) { ?>
 		<div class="related-topics">
 			<?php echo largo_get_related_topics_for_category( get_queried_object() ); ?>
 		</div>
-<?php
+	<?php
 	}
 }

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -10,6 +10,10 @@ class RelatedContentTestFunctions extends wp_UnitTestCase{
 	function test_largo_get_related_topics_for_category() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 
+		// if a category has no related topics (in cats or tags), it outputs empty string
+		// if a category has fewer than 5 related categories, and it has tags, it backfills with tags
+		// if it has 5 related categories and any number of tags, it just outputs categories
+		// in any case where there are related terms, the output contains apply_filters( 'largo_related_topics_title_ul', __( 'Related Topics:' , 'largo' ) );
 	}
 
 	function test__tags_associated_with_category() {


### PR DESCRIPTION
## Changes

- `largo_get_related_topics_for_category()` now outputs empty string if there are no related topics
- `partials/archive-category-related.php` is changed to match
- spaces converted to tabs in `largo_get_related_topics_for_category()`.

## Why

Changes in `largo_get_related_topics_for_category` for #1288:
- outputs empty string instead of an empty `<ul></ul>` because if we wanted to keep detecting the HTML elements in the partial, `partials/archive-category-related.php` would have to match the output of that function to the output of `apply_filters( 'largo_related_topics_title_ul', __( 'Related Topics:' , 'largo' ) );`, wrapped in a `ul li strong`.
- added some notes to stubbed test for this function.

Spaces to tabs to align this with the WordPress PHP code standards.