### PR TITLE
Don't display empty empty h5.top-term tags if largo_top_term() returns ''

### DIFF
--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -65,7 +65,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				while ( $substories->have_posts() ) : $substories->the_post(); $shown_ids[] = get_the_ID();
 					if ( $count <= 3 ) : ?>
 						<div <?php post_class( 'story' ); ?> >
-							<?php if ( largo_has_categories_or_tags() && $tags === 'top' ) : ?>
+							<?php if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?>
 								<h5 class="top-tag"><?php largo_top_term(); ?></h5>
 							<?php endif; ?>
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>

--- a/homepages/zones/zones.php
+++ b/homepages/zones/zones.php
@@ -27,7 +27,9 @@ function homepage_big_story_headline($moreLink=false) {
 	ob_start();
 ?>
 	<article>
-		<h5 class="top-tag"><?php largo_top_term(array('post'=> $bigStoryPost->ID)); ?></h5>
+		<?php if ( largo_top_term( array( 'post'=> $bigStoryPost->ID ) ) ) : ?>
+			<h5 class="top-tag"><?php largo_top_term( array( 'post'=> $bigStoryPost->ID ) ); ?></h5>
+		<?php endif; ?>
 		<h2><a href="<?php echo get_permalink($bigStoryPost->ID); ?>"><?php echo $bigStoryPost->post_title; ?></a></h2>
 		<h5 class="byline"><?php largo_byline(true, true, $bigStoryPost); ?></h5>
 		<section>

--- a/partials/content-roundup.php
+++ b/partials/content-roundup.php
@@ -15,14 +15,14 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 <article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
 
 	<?php
-		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails or videos.
-		$entry_classes = 'entry-content';
-		echo '<div class="' . $entry_classes . '">';
-
-		if ( largo_has_categories_or_tags() && $tags === 'top' ) {
-		 	echo '<h5 class="top-tag">' . largo_top_term( $args = array( 'echo' => FALSE ) ) . '</h5>';
-		}
+	// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails or videos.
+	$entry_classes = 'entry-content';
 	?>
+		<div class="<?php echo $entry_classes; ?>">
+
+		<?php if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?> 
+			<h5 class="top-tag"><?php largo_top_term( $args = array( 'echo' => FALSE ) ); ?></h5>
+		<?php endif; ?>
 
 		<h2 class="entry-title">
 			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>

--- a/partials/content-series.php
+++ b/partials/content-series.php
@@ -11,9 +11,9 @@ $tags = of_get_option ('tag_display');
 
 	<header>
 
- 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'top' ) { ?>
-    		<h5 class="top-tag"><?php largo_top_term(); ?></h5>
-    	<?php } ?>
+ 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?>
+			<h5 class="top-tag"><?php largo_top_term() ?></h5>
+		<?php endif ?>
 
  		<h2 class="entry-title">
  			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -10,7 +10,9 @@
 
 	<header>
 
-		<h5 class="top-tag"><?php largo_top_term(); ?></h5>
+		<?php if ( largo_top_term() ) : ?> 
+			<h5 class="top-tag"><?php largo_top_term() ?></h5>
+		<?php endif; ?>
 
 		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) )

--- a/partials/content.php
+++ b/partials/content.php
@@ -36,9 +36,9 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 		if ( $featured ) $entry_classes .= ' span10 with-hero';
 		echo '<div class="' . $entry_classes . '">';
 
-		if ( largo_has_categories_or_tags() && $tags === 'top' ) {
-		 	echo '<h5 class="top-tag">' . largo_top_term( $args = array( 'echo' => FALSE ) ) . '</h5>';
-		}
+		if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) { ?>
+			<h5 class="top-tag"><?php largo_top_term( $args = array( 'echo' => FALSE ) ) ?></h5>
+		<?php }
 
 		if ( !$featured ) {
 			echo '<div class="has-thumbnail '.$hero_class.'"><a href="' . get_permalink() . '">' . get_the_post_thumbnail() . '</a></div>';

--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -2,8 +2,8 @@
 
 // The top term
 $top_term_args = array('echo' => false);
-if ( isset($instance['show_top_term']) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) { ?>
-	<h5 class="top-tag"><?php echo largo_top_term($top_term_args); ?></h5>
+if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() && largo_top_term( $top_term_args ) ) { ?>
+	<h5 class="top-tag"><?php echo largo_top_term( $top_term_args ); ?></h5>
 <?php }
 
 // the thumbnail image (if we're using one)


### PR DESCRIPTION
solves #1092 

This PR adds checks to catch empty `largo_top_term()` results and suppress the `<h5 class="top-tag">` from being printed.