### PR TITLE
only remove <span> if it has no class & no style attribute

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -47,9 +47,9 @@ add_shortcode( 'module', 'largo_module_shortcode' );
  */
 function largo_tinymce_config( $init ) {
 	if ( isset( $init['extended_valid_elements'] ) ) {
-		$init['extended_valid_elements'] .= "span[!class]";
+		$init['extended_valid_elements'] .= "span[!class|!style]";
 	} else {
-		$init['extended_valid_elements'] = "span[!class]";
+		$init['extended_valid_elements'] = "span[!class|!style]";
 	}
 	return $init;
 }


### PR DESCRIPTION
fixes #790 

## Problem

Span tags used to markup underline and text colors via TinyMCE are being stripped in https://github.com/INN/Largo/blob/6a4eb174c54ddf3dcbf3c3aba36f7a1efc6d7b46/inc/editor.php#L71-L80

## Solution

Update logic to remove span tags if they have no class _and_ no style attribute - leaving the style markup for underline & text color alone