### PR TITLE
remove Heading 1 from format dropdown

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -23,6 +23,14 @@ function largo_add_mce_buttons() {
 }
 add_action( 'init', 'largo_add_mce_buttons' );
 
+// Modify TinyMCE editor to remove H1.
+function tiny_mce_remove_unused_formats($init) {
+	// Add block format elements you want to show in dropdown
+	$init['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;Heading 5=h5;Heading 6=h6;Pre=pre';
+	return $init;
+}
+add_filter('tiny_mce_before_init', 'tiny_mce_remove_unused_formats' );
+
 /**
  * Add the module shortcode (used for pullquotes and asides within posts)
  * This is no longer used but is included here for backwards compatibility

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -3,7 +3,7 @@
 /**
  * Add the tinymce plugin to insert modules into posts
  *
- * @since 1.0
+ * @since 0.3
  */
 function largo_add_mce_plugin( $plugin_array ) {
 	$plugin_array['modulize'] = get_template_directory_uri() . '/js/tinymce/plugins/largo/editor_plugin.js';
@@ -23,19 +23,11 @@ function largo_add_mce_buttons() {
 }
 add_action( 'init', 'largo_add_mce_buttons' );
 
-// Modify TinyMCE editor to remove H1.
-function tiny_mce_remove_unused_formats($init) {
-	// Add block format elements you want to show in dropdown
-	$init['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;Heading 5=h5;Heading 6=h6;Pre=pre';
-	return $init;
-}
-add_filter('tiny_mce_before_init', 'tiny_mce_remove_unused_formats' );
-
 /**
  * Add the module shortcode (used for pullquotes and asides within posts)
  * This is no longer used but is included here for backwards compatibility
  *
- * @since 1.0
+ * @since 0.3
  */
 function largo_module_shortcode( $atts, $content, $code ) {
     extract( shortcode_atts( array(
@@ -49,9 +41,21 @@ function largo_module_shortcode( $atts, $content, $code ) {
 add_shortcode( 'module', 'largo_module_shortcode' );
 
 /**
+ * Modify TinyMCE editor to remove H1.
+ *
+ * @since 0.5.5
+ */
+function tiny_mce_remove_unused_formats($init) {
+	// Add block format elements you want to show in dropdown
+	$init['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;Heading 5=h5;Heading 6=h6;Pre=pre';
+	return $init;
+}
+add_filter( 'tiny_mce_before_init', 'tiny_mce_remove_unused_formats' );
+
+/**
  * Remove weird span tags inserted by TinyMCE
  *
- * @since 1.0
+ * @since 0.3
  */
 function largo_tinymce_config( $init ) {
 	if ( isset( $init['extended_valid_elements'] ) ) {
@@ -61,4 +65,4 @@ function largo_tinymce_config( $init ) {
 	}
 	return $init;
 }
-add_filter('tiny_mce_before_init', 'largo_tinymce_config');
+add_filter( 'tiny_mce_before_init', 'largo_tinymce_config' );


### PR DESCRIPTION
per #670 

## Why

There is no need to use an H1 in the body of a post with this theme. Doing so can only negatively effect the site's SEO rankings.

## What

Removing the Heading 1 formatting option from the format dropdown entirely