### PR TITLE
Add the "By" text for coauthors plus bylines

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -273,7 +273,7 @@ class Largo_CoAuthors_Byline extends Largo_Byline {
 
 		// Now assemble the One True Byline
 		ob_start();
-		echo $authors;
+		echo '<span class="by-author"><span class="by">' . __( 'By', 'largo' ) . '</span> <span class="author vcard" itemprop="author">' . $authors . '</span></span>';
 		$this->maybe_updated_date();
 		$this->edit_link();
 


### PR DESCRIPTION
For #1310, and for Chicago Reporter where this was noticed.

Before:

```html
<h5 class="byline"><a class="url fn n" href="http://chicagoreporte.wpengine.com/author/leeandra-khan/" title="Read All Posts By LeeAndra Khan" rel="author">LeeAndra Khan</a> <time class="entry-date updated dtstamp pubdate" datetime="2016-07-27T10:19:01+00:00"><span class="published">Published </span>July 27, 2016</time> <span class="edit-link"><a href="http://chicagoreporte.wpengine.com/wp-admin/post.php?post=919103&amp;action=edit">Edit This Post</a></span></h5>
```

After:
```html
<h5 class="byline"><span class="by-author"><span class="by">By</span> <span class="author vcard" itemprop="author"> <a class="url fn n" href="http://chicagoreporter.vagrant.dev/author/leeandra-khan/" title="Read All Posts By LeeAndra Khan" rel="author">LeeAndra Khan</a> <span class="twitter"><a href="https://twitter.com/"><i class="icon-twitter"></i></a></span></span></span> <time class="entry-date updated dtstamp" datetime="2016-08-15T13:48:06+00:00"><span class="last-modified">Updated August 15, 2016 at 1:48 pm</span></time>  <span class="edit-link"><a href="http://chicagoreporter.vagrant.dev/wp-admin/post.php?post=919103&amp;action=edit">Edit This Post</a></span></h5>
```

The change is that instead of outputting the plain generated author markup, we output:

```php
'<span class="by-author"><span class="by">' . __( 'By', 'largo' ) . '</span> <span class="author vcard" itemprop="author">' . $authors . '</span></span>';
```

Marked critical because of crunch.