### PR TITLE
Update deprecated showposts parameter to posts_per_page

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -28,7 +28,7 @@ filter: **largo_homepage_series_stories_list_maximum**
 
 filter: **largo_homepage_topstories_post_count**
 
-    *args: $showposts*
+    *args: $posts_per_page*
 
     Filter the number of posts that are displayed in the right-hand side of the Top Stories homepage template.
 

--- a/feed-mailchimp.php
+++ b/feed-mailchimp.php
@@ -14,7 +14,7 @@
  */
 $numposts = 20;
 $posts = query_posts( array(
-  'showposts' => $numposts
+  'posts_per_page' => $numposts
 ) );
 $lastpost = $numposts - 1;
 

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -21,7 +21,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 					'terms' 	=> 'top-story'
 				)
 			),
-			'showposts' => 1
+			'posts_per_page' => 1
 		) );
 		if ( $topstory->have_posts() ) :
 			while ( $topstory->have_posts() ) : $topstory->the_post(); $shown_ids[] = get_the_ID();
@@ -47,8 +47,8 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 	<?php if ( largo_get_active_homepage_layout() !== 'LegacyThreeColumn' ) { ?>
 		<div class="sub-stories span4">
 			<?php
-			$showposts = 6;
-			$showposts = apply_filters( 'largo_homepage_topstories_post_count', $showposts );
+			$posts_per_page = 6;
+			$posts_per_page = apply_filters( 'largo_homepage_topstories_post_count', $posts_per_page );
 			$substories = largo_get_featured_posts( array(
 				'tax_query' => array(
 					array(
@@ -57,7 +57,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 						'terms' 	=> 'homepage-featured'
 					)
 				),
-				'showposts'		=> $showposts,
+				'posts_per_page'		=> $posts_per_page,
 				'post__not_in' 	=> $shown_ids
 			) );
 			if ( $substories->have_posts() ) :

--- a/inc/featured-content.php
+++ b/inc/featured-content.php
@@ -10,7 +10,7 @@
  */
 function largo_get_featured_posts( $args = array() ) {
     $defaults = array(
-        'showposts' => 3,
+        'posts_per_page' => 3,
         'offset' 	=> 0,
         'orderby' 	=> 'date',
         'order' 	=> 'DESC',

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -158,7 +158,7 @@ function largo_get_recent_posts_for_term( $term, $max = 5, $min = 1 ) {
     global $post;
 
     $query_args = array(
-        'showposts' 			=> $max,
+        'posts_per_page' 			=> $max,
         'orderby' 				=> 'date',
         'order' 				=> 'DESC',
         'ignore_sticky_posts' 	=> 1,
@@ -185,7 +185,7 @@ function largo_get_recent_posts_for_term( $term, $max = 5, $min = 1 ) {
 			$post_ids = preg_split( '#\s*,\s*#', get_post_meta( $post->ID, 'largo_custom_related_posts', true ) );
 			$query_args[ 'post__in' ] = $post_ids;
 			$query_args[ 'orderby' ] = 'post__in';
-			$query_args['showposts'] = count($post_ids);
+			$query_args['posts_per_page'] = count($post_ids);
 		}
 
     $query_args = apply_filters( 'largo_get_recent_posts_for_term_query_args', $query_args, $term, $max, $min, $post );
@@ -440,7 +440,7 @@ function largo_filter_get_recent_posts_for_term_query_args( $query_args, $term, 
     if ( $term->term_id == -90 ) {
         $posts = preg_split( '#\s*,\s*#', get_post_meta( $post->ID, 'largo_custom_related_posts', true ) );
         $query_args = array(
-            'showposts'             => $max,
+            'posts_per_page'        => $max,
             'orderby'               => 'post__in',
             'order'                 => 'ASC',
             'ignore_sticky_posts'   => 1,

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -55,8 +55,8 @@ class largo_recent_posts_widget extends WP_Widget {
 		$excerpt = isset( $instance['excerpt_display'] ) ? $instance['excerpt_display'] : 'num_sentences';
 
 		$query_args = array (
-			'post__not_in' 	=> get_option( 'sticky_posts' ),
-			'showposts' 	=> $instance['num_posts'],
+			'post__not_in' 	 => get_option( 'sticky_posts' ),
+			'posts_per_page' => $instance['num_posts'],
 			'post_status'	=> 'publish'
 		);
 


### PR DESCRIPTION
`posts_per_page` was introduced in WP 2.1, replacing/deprecating the `showposts` parameter

There was a bug where `posts_per_page` worked on WP_query but not in get_posts(), but that was fixed in WP 3.1

For more information, see:
https://codex.wordpress.org/Class_Reference/WP_Query#Pagination_Parameters
http://stackoverflow.com/a/3335128
http://core.trac.wordpress.org/ticket/15150