### PR TITLE
Use correct arguments on example function for largo_lmp_template_partial

### DIFF
--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -124,7 +124,7 @@ filter: **largo_lmp_template_partial**
 
     When building your own filter, you must set the fourth parameter of add_filter to 2: ::
 
-        function your_filter_name( $partial, $post_type, $context ) {
+        function your_filter_name( $partial, $post_type ) {
             // things
             return $partials;
         }

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -197,7 +197,7 @@ if (!function_exists('largo_load_more_posts_choose_partial')) {
 		 *
 		 * When building your own filter, you must set the fourth parameter of add_filter to 2:
 		 *
-		 *     function your_filter_name($partial, $post_type, $context) {
+		 *     function your_filter_name($partial, $post_type) {
 		 *         // things
 		 *         return $partials;
 		 *     }


### PR DESCRIPTION
## Changes

- Removes a unused argument from the reference implementation of a filter function on this filter.

Here's a live implementation of this filter: https://bitbucket.org/projectlargo/theme-chicago-reporter/src/f31772191ab00f4c6443eb9c2b57d56d0c1727ad/inc/taxonomies.php?at=master&fileviewer=file-view-default#taxonomies.php-158