### PR TITLE
Fix top term displaying twice on single-post pages

### DIFF
--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -10,9 +10,12 @@
 
 	<header>
 
-		<?php if ( largo_top_term() ) : ?> 
-			<h5 class="top-tag"><?php largo_top_term() ?></h5>
-		<?php endif; ?>
+		<?php
+			$top_term = largo_top_term( array( 'echo' => False ) );
+			if ( $top_term ) {
+		?>
+			<h5 class="top-tag"><?php echo $top_term; ?></h5>
+		<?php } ?>
 
 		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>


### PR DESCRIPTION
## Changes

- When checking to see if `largo_top_term()` returns anything, pass the argument ` array( 'echo' => False ) `: https://github.com/INN/Largo/blob/09367b17e4d49578dbcc22d9c0829d3668a1e3f5/inc/related-content.php#L313
- Capture the output of the checking call and echo that instead of calling `largo_top_term` a second time

## Questions

Should we wrap this functionality up into a template tag, call it `largo_maybe_top_term`, and replace most uses of `largo_top_term` in templates with `largo_maybe_top_term`?