### PR TITLE
Implement largo_maybe_top_term

### DIFF
--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -65,9 +65,9 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				while ( $substories->have_posts() ) : $substories->the_post(); $shown_ids[] = get_the_ID();
 					if ( $count <= 3 ) : ?>
 						<div <?php post_class( 'story' ); ?> >
-							<?php if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?>
-								<h5 class="top-tag"><?php largo_top_term(); ?></h5>
-							<?php endif; ?>
+							<?php if ( largo_has_categories_or_tags() && $tags === 'top' () ) {
+								largo_maybe_top_term();
+							} ?>
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
 							<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail(); ?></a>
 							<?php largo_excerpt( $post, 3 ); ?>

--- a/homepages/zones/zones.php
+++ b/homepages/zones/zones.php
@@ -27,9 +27,7 @@ function homepage_big_story_headline($moreLink=false) {
 	ob_start();
 ?>
 	<article>
-		<?php if ( largo_top_term( array( 'post'=> $bigStoryPost->ID ) ) ) : ?>
-			<h5 class="top-tag"><?php largo_top_term( array( 'post'=> $bigStoryPost->ID ) ); ?></h5>
-		<?php endif; ?>
+		<?php largo_maybe_top_term( array( 'post'=> $bigStoryPost->ID ) ); ?>
 		<h2><a href="<?php echo get_permalink($bigStoryPost->ID); ?>"><?php echo $bigStoryPost->post_title; ?></a></h2>
 		<h5 class="byline"><?php largo_byline(true, true, $bigStoryPost); ?></h5>
 		<section>

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -342,3 +342,20 @@ if ( ! function_exists( 'largo_comment' ) ) {
 		endswitch;
 	}
 }
+
+/**
+ * If largo_top_term() would output a term, wrap that in an h5.top-term and output it to the page.
+ *
+ * Takes the same argument array as largo_top_term(), and passes that argument array to
+ * largo_top_term() with 'echo' => False. largo_maybe_top_term() handles the echo decision.
+ *
+ * @since 0.5.5
+ * @param Array $args the same argument array that would be passed to largo_top_term()
+ */
+function largo_maybe_top_term( $args = array() ) {
+	$args = array_merge( $args, array( 'echo' => False ) );
+	$top_term = largo_top_term( $args );
+	if ( $top_term ) { ?>
+		<h5 class="top-tag"><?php echo $top_term; ?></h5>
+	<?php }
+}

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -350,11 +350,13 @@ if ( ! function_exists( 'largo_comment' ) ) {
  * largo_top_term() with 'echo' => False. largo_maybe_top_term() handles the echo decision.
  *
  * @since 0.5.5
+ * @uses largo_top_term
  * @param Array $args the same argument array that would be passed to largo_top_term()
  */
 function largo_maybe_top_term( $args = array() ) {
 	$args = array_merge( $args, array( 'echo' => False ) );
 	$top_term = largo_top_term( $args );
+
 	if ( $top_term ) { ?>
 		<h5 class="top-tag"><?php echo $top_term; ?></h5>
 	<?php }

--- a/partials/content-roundup.php
+++ b/partials/content-roundup.php
@@ -20,9 +20,7 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 	?>
 		<div class="<?php echo $entry_classes; ?>">
 
-		<?php if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?> 
-			<h5 class="top-tag"><?php largo_top_term( $args = array( 'echo' => FALSE ) ); ?></h5>
-		<?php endif; ?>
+		<?php largo_maybe_top_term(); ?>
 
 		<h2 class="entry-title">
 			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>

--- a/partials/content-series.php
+++ b/partials/content-series.php
@@ -11,9 +11,9 @@ $tags = of_get_option ('tag_display');
 
 	<header>
 
- 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) : ?>
-			<h5 class="top-tag"><?php largo_top_term() ?></h5>
-		<?php endif ?>
+ 		<?php if ( isset($opt['show']['tags']) && $opt['show']['tags'] && largo_has_categories_or_tags() && $tags === 'top' ) {
+			largo_maybe_top_term();
+		} ?>
 
  		<h2 class="entry-title">
  			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -10,12 +10,7 @@
 
 	<header>
 
-		<?php
-			$top_term = largo_top_term( array( 'echo' => False ) );
-			if ( $top_term ) {
-		?>
-			<h5 class="top-tag"><?php echo $top_term; ?></h5>
-		<?php } ?>
+		<?php largo_maybe_top_term(); ?>
 
 		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>

--- a/partials/content.php
+++ b/partials/content.php
@@ -36,9 +36,9 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 		if ( $featured ) $entry_classes .= ' span10 with-hero';
 		echo '<div class="' . $entry_classes . '">';
 
-		if ( largo_has_categories_or_tags() && $tags === 'top' && largo_top_term() ) { ?>
-			<h5 class="top-tag"><?php largo_top_term( $args = array( 'echo' => FALSE ) ) ?></h5>
-		<?php }
+		if ( largo_has_categories_or_tags() && $tags === 'top' ) {
+			largo_maybe_top_term();
+		}
 
 		if ( !$featured ) {
 			echo '<div class="has-thumbnail '.$hero_class.'"><a href="' . get_permalink() . '">' . get_the_post_thumbnail() . '</a></div>';

--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -1,10 +1,9 @@
 <?php
 
 // The top term
-$top_term_args = array('echo' => false);
-if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() && largo_top_term( $top_term_args ) ) { ?>
-	<h5 class="top-tag"><?php echo largo_top_term( $top_term_args ); ?></h5>
-<?php }
+if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) {
+	largo_maybe_top_term();
+}
 
 // the thumbnail image (if we're using one)
 if ($thumb == 'small') {

--- a/tests/inc/test-post-tags.php
+++ b/tests/inc/test-post-tags.php
@@ -274,4 +274,11 @@ EOT;
 		largo_floating_social_button_js();
 	}
 
+	function test_largo_maybe_top_term() {
+		$this->markTestIncomplete('Test largo_maybe_top_term not implemented because test_largo_top_term not implemented');
+		// This should cover:
+		// every case when largo_top_term would and would not return a link, this checks that the liink is returned
+		// every time when there is output, make sure there's <h5 class="top-tag"> and </h5> in the output
+	}
+
 }


### PR DESCRIPTION
## Changes

- Adds function `largo_maybe_top_term( $args )`, which outputs `largo_top_term( $args )` wrapped in an `h5.top-tag` if `largo_top_term( $args )` would return a link. If no link is returned, then it does not output the `h5.top-term`. `$args` are the same for each function.
- Adds a blank test for the function, so that we know what needs to be tested in it when we eventually write a test for it.

## Why

- to reduce the number of conditionals in templates, and to finish fixing #1316 by using #1318.
- to reduce number of database queries by halving the number of times we call `largo_top_term`