### PR TITLE
Fix featured media display for galleries, embeds, and videos

### DIFF
--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -110,6 +110,12 @@ function largo_get_featured_hero( $post = null, $classes = '' ) {
 	$hero_class = largo_hero_class( $the_post->ID, false );
 	$classes = 'hero $hero_class $classes';
 
+	$context = array(
+		'classes' => $classes,
+		'featured_media' => $featured_media,
+		'the_post' => $the_post
+	);
+
 	if ( 'image' == $featured_media['type'] ) {
 		$thumb_meta = null;
 		if ( $thumb_id = get_post_thumbnail_id( $the_post->ID ) ) {
@@ -122,26 +128,25 @@ function largo_get_featured_hero( $post = null, $classes = '' ) {
 				'credit_url' => ( ! empty( $thumb_custom['_media_credit_url'][0] ) ) ? $thumb_custom['_media_credit_url'][0] : null,
 				'organization' => ( ! empty( $thumb_custom['_navis_media_credit_org'][0] ) ) ? $thumb_custom['_navis_media_credit_org'][0] : null
 			);
+
+			$context['thumb_meta'] = $thumb_meta;
 		}
 
 	}
 
-	$context = array(
-		'classes' => $classes,
-		'featured_media' => $featured_media,
-		'thumb_meta' => $thumb_meta,
-		'the_post' => $the_post
-	);
+	if ( 'gallery' == $featured_media['type'] ) {
+		$context['gallery_ids'] = implode(',', $featured_media['gallery']);
+	}
 
 	switch( $featured_media['type'] ) {
+		// video and embed code use the same partial;
+		// empty statement list for a case passes control to next case: https://secure.php.net/manual/en/control-structures.switch.php
 		case 'video':
-			$template_slug = 'video';
+		case 'embed-code':
+			$template_slug = 'embed';
 			break;
 		case 'image':
 			$template_slug = 'image';
-			break;
-		case 'embed-code':
-			$template_slug = 'embed';
 			break;
 		case 'gallery':
 			$template_slug = 'gallery';

--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -128,6 +128,7 @@ function largo_get_featured_hero( $post = null, $classes = '' ) {
 
 	$context = array(
 		'classes' => $classes,
+		'featured_media' => $featured_media,
 		'thumb_meta' => $thumb_meta,
 		'the_post' => $the_post
 	);

--- a/inc/update.php
+++ b/inc/update.php
@@ -862,9 +862,12 @@ function largo_update_admin_notice() {
 	}
 	if ( largo_need_updates() && ! ( isset( $_GET['page'] ) && $_GET['page'] == 'update-largo' ) ) {
 ?>
-	<div class="update-nag" style="display: block;">
-		<p>Largo has been updated! Please <a href="<?php echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply a required database update.</p>
-	</div>
+	<div class="update-nag" style="display: block;"><p>
+	<?php printf(
+		__( 'Largo has been updated! Please <a href="%s">visit the update page</a> to apply a required database update.', 'largo' ),
+		admin_url( 'index.php?page=update-largo' )
+	?>
+	</p></div>
 <?php
 	}
 }
@@ -1150,6 +1153,11 @@ add_action( 'admin_menu', 'largo_block_theme_options_for_update', 10 );
  * @since 0.5.3
  */
 function largo_block_theme_options() { ?>
-	<h3>Please <a href="<?php echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply required Largo updates before editing Theme Options.</h3>
+	<h3>
+	<?php printf(
+		__( 'Please <a href="%s">visit the update page</a> to apply required Largo updates before editing Theme Options.', 'largo' ),
+		admin_url( 'index.php?page=update-largo' )
+	); ?>
+	</h3>
 <?php
 }

--- a/inc/update.php
+++ b/inc/update.php
@@ -863,7 +863,7 @@ function largo_update_admin_notice() {
 	if ( largo_need_updates() && ! ( isset( $_GET['page'] ) && $_GET['page'] == 'update-largo' ) ) {
 ?>
 	<div class="update-nag" style="display: block;">
-		<p>Largo has been updated! Please <a href="<? echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply a required database update.</p>
+		<p>Largo has been updated! Please <a href="<?php echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply a required database update.</p>
 	</div>
 <?php
 	}
@@ -1150,6 +1150,6 @@ add_action( 'admin_menu', 'largo_block_theme_options_for_update', 10 );
  * @since 0.5.3
  */
 function largo_block_theme_options() { ?>
-	<h3>Please <a href="<? echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply required Largo updates before editing Theme Options.</h3>
+	<h3>Please <a href="<?php echo admin_url( 'index.php?page=update-largo' ); ?>">visit the update page</a> to apply required Largo updates before editing Theme Options.</h3>
 <?php
 }

--- a/partials/hero-featured-embed.php
+++ b/partials/hero-featured-embed.php
@@ -1,6 +1,6 @@
 <div class="<?php echo $classes; ?>">
 	<div class="embed-container">
-		<? echo $featured_media['embed']; ?>
+		<?php echo $featured_media['embed']; ?>
 	</div>
 	<div class="embed-details wp-caption">
 	<?php if (!empty($featured_media['credit'])) { ?>


### PR DESCRIPTION
## Changes

In `inc/featured-media.php`'s `largo_get_featured_hero()`:

- Sets video featured media to use the `embed` type of partial, `partials/hero-featured-embed.php`: #1285 changed this to `video` but didn't create a new partial to be rendered in this space.
- Passes `$featured_media` in the `$context` variable, needed for embeds and videos, which was removed in #1285's consolidation of the largo_get_featured_`X` functions
- Passes a list of gallery IDs in the `$context` variable, needed for galleries, which was removed in #1285's consolidation of the largo_get_featured_`X` functions

In `partials/hero-featured-embed.php`, converts a short-tag `<?` to the full `<?php`

In `inc/update.php`, converts a short-tag `<?` to the full `<?php`, because now was as good a time as any to search for other `<?` tags.

## Why

For #1322, because #1285 broke non-image featured media hero functions.