### PR TITLE
Make $post_id protected, not private

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -12,7 +12,7 @@
 class Largo_Byline {
 
 	/** @var int The ID of the post this byline is for */
-	private $post_id;
+	protected $post_id;
 
 	/** @var bool Whether or not the byline should include the date */
 	private $exclude_date;


### PR DESCRIPTION
## Changes

Makes the property `$post_id` of `Largo_Byline` protected, not private, so that when `Largo_CoAuthors_Byline` extends `Largo_Byline` and uses  `Largo_Byline`'s methods `__construct` and `populate_vars`, `Largo_CoAuthors_Byline` will be able to read the variable that it tries to set.

Otherwise, anything in `Largo_CoAuthors_Byline` that uses `$this->post_id` gets a big fat `null`, and usually tries to work based off of the current post in The Loop.

This is only a bug when calling `largo_byline` with a post ID specified.