### PR TITLE
Remove the modified date

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -179,12 +179,10 @@ class Largo_Byline {
 	 */
 	function edited_date() {
 		echo sprintf(
-			' <time class="entry-date updated dtstamp" datetime="%1$s"><span class="last-modified">%2$s %3$s %4$s %5$s</span></time> ',
+			' <time class="entry-date updated dtstamp" datetime="%1$s"><span class="last-modified">%2$s %3$s</span></time> ',
 			esc_attr( get_the_modified_date( 'c', $this->post_id ) ),
 			__( 'Updated', 'largo' ),
-			largo_modified_time( false, $this->post_id ),
-			__( 'at', 'largo' ),
-			get_the_modified_date( 'g:i a' )
+			largo_modified_time( false, $this->post_id )
 		);
 	}
 

--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -173,7 +173,7 @@ class Largo_Byline {
 	}
 
 	/**
-	 * Display the last-edited date for this post, only to admin users
+	 * Display the last-edited date for this post
 	 *
 	 * @todo: should this be displayed under different conditions?
 	 */


### PR DESCRIPTION
## Changes

For https://app.asana.com/0/131668199203736/193381343837860: 

- removes the 'at 12:30 PM' text from the byline of edited posts