### PR TITLE
Fix Largo_Related

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -539,14 +539,19 @@ class Largo_Related {
 				$args = array(
 					'post_type' => 'post',
 					'posts_per_page' => $this->number,
-					'taxonomy' => 'series',
-					'term' => $term->slug,
 					'orderby' => 'date',
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
 						'after' => $this->post->post_date,
 					),
+					'tax_query' => array(
+						array(
+							'taxonomy' => 'series',
+							'term' => $term->slug,
+							'field' => 'slug'
+						)
+					)
 				);
 
 				// see if there's a post that has the sort order info for this series
@@ -616,7 +621,7 @@ class Largo_Related {
 
 		//we've gone back and forth through all the post's series, now let's try traditional taxonomies	
 		$taxonomies = array();
-		foreach ( array( 'categories', 'tags' ) as $_taxonomy ) {
+		foreach ( array( 'category', 'post_tag' ) as $_taxonomy ) {
 			$_terms = get_object_term_cache( $this->post_id, $_taxonomy );
 
 			if ( false === $_terms ) {
@@ -638,14 +643,19 @@ class Largo_Related {
 				$args = array(
 					'post_type' => 'post',
 					'posts_per_page' => $this->number,
-					'taxonomy' => $term->taxonomy,
-					'term' => $term->slug,
 					'orderby' => 'date',
 					'order' => 'DESC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
 						'after' => $this->post->post_date,
 					),
+					'tax_query' => array(
+						array(
+							'taxonomy' => $term->taxonomy,
+							'terms' => $term->slug,
+							'field' => 'slug',
+						)
+					)
 				);
 
 				// run the query
@@ -673,7 +683,7 @@ class Largo_Related {
 						break;
 					}
 				}
-			}
+			} // foreach
 		}
 	}
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -539,19 +539,14 @@ class Largo_Related {
 				$args = array(
 					'post_type' => 'post',
 					'posts_per_page' => $this->number,
+					'taxonomy' => 'series',
+					'term' => $term->slug,
 					'orderby' => 'date',
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
 					'date_query' => array(
 						'after' => $this->post->post_date,
 					),
-					'tax_query' => array(
-						array(
-							'taxonomy' => 'series',
-							'term' => $term->slug,
-							'field' => 'slug'
-						)
-					)
 				);
 
 				// see if there's a post that has the sort order info for this series

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -223,7 +223,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series_id,
+				'series' => $this->series->slug,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'ASC');
@@ -263,7 +263,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series_id,
+				'series' => $this->series->slug,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'DESC');
@@ -311,7 +311,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series_id,
+				'series' => $this->series->slug,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'custom');
@@ -342,7 +342,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series_id,
+				'series' => $this->series->slug,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'featured, DESC');
@@ -362,8 +362,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 		// create a post that is featured in this taxonomy. It shall be the first.
 		$feat = $this->factory->post->create(array(
+			'series' => $this->series->slug,
 			'tax_input' => array(
-				'series' => $this->series_id,
 				'prominence' => 'taxonomy-featured'
 			)
 		));
@@ -381,7 +381,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series_id,
+				'series' => $this->series->slug,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'featured, ASC');
@@ -409,8 +409,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			)
 		);
 		$feat = $this->factory->post->create(array(
+			'series' => $this->series->slug,
 			'tax_input' => array(
-				'series' => $this->series_id,
 				'prominence' => 'taxonomy-featured'
 			)
 		));

--- a/tests/inc/test-related-content.php
+++ b/tests/inc/test-related-content.php
@@ -223,7 +223,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series->slug,
+				'series' => $this->series_id,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'ASC');
@@ -263,7 +263,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series->slug,
+				'series' => $this->series_id,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'DESC');
@@ -311,7 +311,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series->slug,
+				'series' => $this->series_id,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'custom');
@@ -342,7 +342,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series->slug,
+				'series' => $this->series_id,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'featured, DESC');
@@ -362,8 +362,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		));
 		// create a post that is featured in this taxonomy. It shall be the first.
 		$feat = $this->factory->post->create(array(
-			'series' => $this->series->slug,
 			'tax_input' => array(
+				'series' => $this->series_id,
 				'prominence' => 'taxonomy-featured'
 			)
 		));
@@ -381,7 +381,7 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 		$landing = $this->factory->post->create(array(
 			'post_type' => 'cftl-tax-landing',
 			'tax_input' => array(
-				'series' => $this->series->slug,
+				'series' => $this->series_id,
 			),
 		));
 		update_post_meta($landing, 'has_order', 'featured, ASC');
@@ -409,8 +409,8 @@ class LargoRelatedTestFunctions extends WP_UnitTestCase {
 			)
 		);
 		$feat = $this->factory->post->create(array(
-			'series' => $this->series->slug,
 			'tax_input' => array(
+				'series' => $this->series_id,
 				'prominence' => 'taxonomy-featured'
 			)
 		));


### PR DESCRIPTION
## Changes

- replace the old direct `'taxonomy'` and `'term'` query vars with a `'tax_query'` array, so we're using the modern style instead of the style deprecated in WordPress 3.1: https://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters (#1335)
- replace bad term slugs (the true cause of the issue)
    - 'categories' becomes 'category'
    - 'tags' becomes 'post_tag'

This probably would have been caught by https://github.com/INN/Largo/issues/884 if we had tests. 

I'll make a note of this PR on https://github.com/INN/Largo/pull/1274, which removes this widget and puts it in a plugin.