### PR TITLE
Document minimum PHP version for Largo

### DIFF
--- a/docs/users/download.rst
+++ b/docs/users/download.rst
@@ -6,6 +6,8 @@ Download and Install WordPress
 
 The Largo parent theme and plugins have been tested with the latest version of WordPress. Some hosting providers offer one-click installation of WordPress and that should get you the latest version. If that does not work for you, download the latest version from the `WordPress downloads <https://wordpress.org/download/>`_  page and follow their `instructions <http://codex.wordpress.org/Installing_WordPress>`_ to get it setup.
 
+Largo requires a minimum PHP version of 5.3, and has been tested thoroughly on PHP 5.5.
+
 Download and Install Largo
 --------------------------
 

--- a/docs/users/download.rst
+++ b/docs/users/download.rst
@@ -6,7 +6,7 @@ Download and Install WordPress
 
 The Largo parent theme and plugins have been tested with the latest version of WordPress. Some hosting providers offer one-click installation of WordPress and that should get you the latest version. If that does not work for you, download the latest version from the `WordPress downloads <https://wordpress.org/download/>`_  page and follow their `instructions <http://codex.wordpress.org/Installing_WordPress>`_ to get it setup.
 
-Largo requires a minimum PHP version of 5.3, and has been tested thoroughly on PHP 5.5.
+Largo requires a minimum PHP version of 5.3, and has been tested thoroughly on PHP 5.5. Contact your hosting provider if you are unsure which version of PHP your site uses.
 
 Download and Install Largo
 --------------------------

--- a/docs/users/download.rst
+++ b/docs/users/download.rst
@@ -11,7 +11,7 @@ Largo requires a minimum PHP version of 5.3, and has been tested thoroughly on P
 Download and Install Largo
 --------------------------
 
-The latest stable version of the Largo parent theme is available for download from `the project repository on github <https://github.com/INN/Largo>`_ on github. The master branch (`download link <https://github.com/INN/Largo/archive/master.zip>`_) is always the latest stable release although you may sometimes want to also keep an eye on `the develop branch <https://github.com/inn/largo/tree/develop>`_ which contains our work on the next release of Largo. Note that we do not recommend using the develop branch on a production site.
+The latest stable version of the Largo parent theme is available for download from `the project repository on github <https://github.com/INN/Largo/releases>`_ on github. The master branch (`download link <https://github.com/INN/Largo/archive/master.zip>`_) is always the latest stable release although you may sometimes want to also keep an eye on `the develop branch <https://github.com/inn/largo/tree/develop>`_ which contains our work on the next release of Largo. Note that we do not recommend using the develop branch on a production site.
 
 Once you have downloaded the Largo theme you'll need to unzip it, and will typically want to rename the resulting folder to just "largo" (github will include the name of the branch in the name of the folder, i.e. - largo-master, but to avoid potential problems with the following instructions using "largo" as the name of the folder will make your life a little easier.
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ The project extends work done by [NPR's Project Argo](http://argoproject.org/).
 
 **Minimum supported PHP version:** 5.3
 
-**Minimum supported WordPress version:** 4.1, though you should always use the current version of WordPress
+**Minimum supported WordPress version:** 4.1, though we usually recommend using the current version of WordPress
 
 ## Setup
 

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ The project extends work done by [NPR's Project Argo](http://argoproject.org/).
 
 **Current version:** v0.5.4
 
+**Minimum supported PHP version:** 5.3
+
+**Minimum supported WordPress version:** 4.1, though you should always use the current version of WordPress
+
 ## Setup
 
 Follow the [setup instructions in the documentation](http://largo.readthedocs.io/users/download.html).

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ A responsive WordPress framework designed for news publishers and developed by t
 
 We are making regular updates that may or may not always play nice with previous versions.
 
+For released versions of Largo, please see the [list of tagged releases](https://github.com/INN/Largo/releases).
+
 The `master` branch is the latest stable version and what INN is using for our sites in production (with a few minor tweaks specific to our hosting environment). Please do not submit pull requests to this branch unless they are minor hotfixes that can be directly merged.
 
 The `develop` branch contains work in progress slated for our next point release. Feel free to try it out, report issues, etc. but we DO NOT recommend using it in production. This is also typically the branch to submit pull requests to if you want to contribute to the project.


### PR DESCRIPTION
## Changes

- Notes minimum PHP version at https://largo.readthedocs.io/users/download.html
- Directs users to the tagged releases first, then to the master branch
- Notes minimum WordPress version in readme.md, but not in the user docs because the user docs kinda assume that you're going to be installing the latest version. The Version used here is 4.1 because that's the earliest version that the develop branch tests against at this time.

For #1344. This is a PR against master because it needs to affect largo.readthedocs.io, which only compiles from the master branch.
