### PR TITLE
Fix spare '()' introduced by #1319

### DIFF
--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -65,7 +65,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				while ( $substories->have_posts() ) : $substories->the_post(); $shown_ids[] = get_the_ID();
 					if ( $count <= 3 ) : ?>
 						<div <?php post_class( 'story' ); ?> >
-							<?php if ( largo_has_categories_or_tags() && $tags === 'top' () ) {
+							<?php if ( largo_has_categories_or_tags() && $tags === 'top' ) {
 								largo_maybe_top_term();
 							} ?>
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>


### PR DESCRIPTION
## Changes

- removes a `()`

## Why

Because otherwise, any site using the "Top Stories" homepage template will have this problem:

```
Parse error: syntax error, unexpected '(' in /srv/www/citylimits/htdocs/wp-content/themes/Largo/homepages/templates/top-stories.php on line 68
```

I checked in Largo for any other cases of `' () '` in the theme's PHP files, and found these: 

```
./inc/nav-menus.php:	function largo_donate_button () {
./inc/post-metaboxes.php:function largo_layout_meta_box_display () {
./lib/options-framework/options-framework.php:function optionsframework_rolescheck () {
./lib/options-framework/options-medialibrary-uploader.php:function optionsframework_mlu_init () {
./lib/options-framework/options-medialibrary-uploader.php:function optionsframework_mlu_css () {
./lib/options-framework/options-medialibrary-uploader.php:function optionsframework_mlu_js () {
./lib/options-framework/options-medialibrary-uploader.php:function optionsframework_mlu_insidepopup () {
./lib/options-framework/options-medialibrary-uploader.php:function optionsframework_mlu_js_popup () {
./lib/options-framework/options-medialibrary-uploader.php:		$( 'h3.media-title' ).each ( function () {
./lib/options-framework/options-medialibrary-uploader.php:		$( '.savesend a.del-link' ).click ( function () {
blk@oyster:~/inn/vms/vagrant-local/www/citylimits/htdocs/wp-content/themes/Largo$ gs

```

But those all look okay. And none of the other files touched by #1319 had this problem in the current develop branch.