### PR TITLE
Temporarily empty out $wp_query->posts in the homepage bottom widget area

### DIFF
--- a/partials/home-bottom-widget-area.php
+++ b/partials/home-bottom-widget-area.php
@@ -4,9 +4,19 @@
  *
  * @package Largo
  */
-global $layout; ?>
+global $layout, $wp_query;
+
+// Because this template displays no posts, and because some widgets (Largo Recent Posts) will draw from $wp_query->posts to supplement $shown_ids, we're going to temporarily zero that out.
+// @see https://github.com/INN/Largo/pull/1150
+// @see commit 4443b3047b8e64856978b0b378c2f8a3ba9ebc7c
+$preserve = $wp_query->posts;
+$wp_query->posts = array();
+?>
 <div id="homepage-bottom" class="clearfix">
 <?php if ( ! dynamic_sidebar( 'homepage-bottom' ) ) : ?>
 	<p><?php _e('Please add widgets to this content area in the WordPress admin area under appearance > widgets.', 'largo'); ?></p>
 <?php endif; ?>
 </div>
+<?php
+
+$wp_query->posts = $preserve;


### PR DESCRIPTION
## Changes

- in the Homepage Bottom Widget Area homepage bottom partial, temporarily empty `$wp_query->posts`
- add comments explaining why we do this
- reference a commit and pull request that explains that a little more, because otherwise we'll be scratching our heads when we debug this the next time.

## Why

Because the first recent posts widget in homepage bottom widget area skips 10 posts when "do not duplicate" is enabled.

From Asana:

> Ben: In largo-dev/inc/widgets/largo-recent-posts.php, line 63-69, if the checkbox to ignore shown posts is checked, the widget not only ignores $shown_ids but adds the posts from the main query on the page to the list of ids to be ignored in the query. It doesn't add those posts to $shown_ids, but just joins them to the array of post ids to be ignored.

> Adam: i would want to look first at why we did that in the first place. It seems like probably not a thing we'd want to do...unless it is? for some unknown reason.

> Ben: Largo commit 4443b304 has the reason: Adding the main river of posts to $shown_ids messes up the LMP button that gets rendered at the end of the river. So grabbing the posts from `$wp_query->posts` fixes that.
> Homepage bottom widget area, partials/home-bottom-widget-area.php, would be the place to nix the global `$wp_query->posts` array and then put it back, if we wanted to do that.

> Adam: yeah i guess that's what we'd need to do (until we blow up LMP or figure out a better way to handle that)

This PR doesn't have a corresponding issue because of the Dyn DNS DDOS of 2016-10-21. 😞 