### PR TITLE
Update functions cleanup for inc/updates.php

### DIFF
--- a/inc/update.php
+++ b/inc/update.php
@@ -533,18 +533,18 @@ function largo_update_custom_less_variables() {
 function largo_check_deprecated_widgets() {
 
 	$deprecated = array(
-		'largo-footer-featured' => 'largo_deprecated_footer_widget',
-		'largo-sidebar-featured' => 'largo_deprecated_sidebar_widget'
 	);
 
-	$widgets = get_option( 'sidebars_widgets ');
-	foreach ( $widgets as $region => $widgets ) {
-		if ( $region != 'wp_inactive_widgets' && $region != 'array_version' && is_array( $widgets ) ) {
-			foreach ( $widgets as $widget_instance ) {
-				foreach ( $deprecated as $widget_name => $callback ) {
-					if ( strpos( $widget_instance, $widget_name ) === 0) {
-						add_action( 'admin_notices', $callback );
-						unset( $deprecated[$widget_name] ); //no need to flag the same widget multiple times
+	if ( !empty( $deprecated) ) {
+		$widgets = get_option( 'sidebars_widgets ');
+		foreach ( $widgets as $region => $widgets ) {
+			if ( $region != 'wp_inactive_widgets' && $region != 'array_version' && is_array( $widgets ) ) {
+				foreach ( $widgets as $widget_instance ) {
+					foreach ( $deprecated as $widget_name => $callback ) {
+						if ( strpos( $widget_instance, $widget_name ) === 0) {
+							add_action( 'admin_notices', $callback );
+							unset( $deprecated[$widget_name] ); //no need to flag the same widget multiple times
+						}
 					}
 				}
 			}
@@ -552,22 +552,6 @@ function largo_check_deprecated_widgets() {
 	}
 }
 
-/**
- * Admin notices of older widgets
- */
-function largo_deprecated_footer_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __( 'You are using the <strong>Largo Footer Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
-
-function largo_deprecated_sidebar_widget() { ?>
-	<div class="update-nag"><p>
-	<?php printf( __( 'You are using the <strong>Largo Sidebar Featured Posts</strong> widget, which is deprecated and will be removed from future versions of Largo. Please <a href="%s">change your widget settings</a> to use its replacement, <strong>Largo Featured Posts</strong>.', 'largo' ), admin_url( 'widgets.php' ) ); ?>
-	</p></div>
-	<?php
-}
 
 /**
  * Replace deprecated widgets with new widgets

--- a/inc/update.php
+++ b/inc/update.php
@@ -532,6 +532,17 @@ function largo_update_custom_less_variables() {
  */
 function largo_check_deprecated_widgets() {
 
+	/*
+	 * The format of this array is:
+	 * array(
+	 *     'widget-css-class' => 'admin_notice_function',
+	 *     'largo-footer-featured' => 'largo_deprecated_footer_widget',
+	 * )
+	 *
+	 * In the above example, the presence of 'widget-css-class' will cause 'admin_notice_function' to be hooked on 'admin_notices'.
+	 * The function 'admin_notice_function' should output a div.update-nag.
+	 * An example of such a function is largo_deprecated_footer_widget, which can be found in inc/update.php in Largo v0.5.4
+	 */
 	$deprecated = array(
 	);
 

--- a/inc/update.php
+++ b/inc/update.php
@@ -47,7 +47,6 @@ function largo_perform_update() {
 		// Always run
 		largo_update_custom_less_variables();
 		largo_replace_deprecated_widgets();
-		largo_check_deprecated_widgets();
 
 		// Set version.
 		of_set_option( 'largo_version', largo_version() );
@@ -526,43 +525,6 @@ function largo_update_custom_less_variables() {
 		Largo_Custom_Less_Variables::update_custom_values($escaped);
 	}
 }
-
-/**
- * Checks for use of deprecated widgets and posts an alert
- */
-function largo_check_deprecated_widgets() {
-
-	/*
-	 * The format of this array is:
-	 * array(
-	 *     'widget-css-class' => 'admin_notice_function',
-	 *     'largo-footer-featured' => 'largo_deprecated_footer_widget',
-	 * )
-	 *
-	 * In the above example, the presence of 'widget-css-class' will cause 'admin_notice_function' to be hooked on 'admin_notices'.
-	 * The function 'admin_notice_function' should output a div.update-nag.
-	 * An example of such a function is largo_deprecated_footer_widget, which can be found in inc/update.php in Largo v0.5.4
-	 */
-	$deprecated = array(
-	);
-
-	if ( !empty( $deprecated) ) {
-		$widgets = get_option( 'sidebars_widgets ');
-		foreach ( $widgets as $region => $widgets ) {
-			if ( $region != 'wp_inactive_widgets' && $region != 'array_version' && is_array( $widgets ) ) {
-				foreach ( $widgets as $widget_instance ) {
-					foreach ( $deprecated as $widget_name => $callback ) {
-						if ( strpos( $widget_instance, $widget_name ) === 0) {
-							add_action( 'admin_notices', $callback );
-							unset( $deprecated[$widget_name] ); //no need to flag the same widget multiple times
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
 
 /**
  * Replace deprecated widgets with new widgets

--- a/inc/update.php
+++ b/inc/update.php
@@ -38,8 +38,11 @@ function largo_perform_update() {
 			largo_enable_series_if_landing_page();
 		}
 
-		// Repeatable, should be run when updating to 0.4+
-		largo_remove_topstory_prominence_term();
+		// Run when updating from pre-0.5
+		if ( version_compare( $previous_options['largo_version'], '0.5' ) < 0 ) {
+			// Repeatable, should be run when updating to 0.4+
+			largo_remove_topstory_prominence_term();
+		}
 
 		// Always run
 		largo_update_custom_less_variables();

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -241,6 +241,7 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		// Create the deprecated widgets
 		update_option('sidebars_widgets', array(
 			'article-bottom' => array (
+				// this should be instances of the widget that you want to check gets updated
 				0 => 'largo-footer-featured-2',
 				1 => 'largo-sidebar-featured-2',
 			), // largo_instantiate_widget uses article-bottom for all its widgets
@@ -249,13 +250,11 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		largo_check_deprecated_widgets();
 
 		// Test that the requisite deprecated widgets actions have been added to the admin_notices hook
-		$return = has_action('admin_notices', 'largo_deprecated_footer_widget');
-		$this->assertTrue(isset($return));
-		unset($return);
-
-		$return = has_action('admin_notices', 'largo_deprecated_sidebar_widget');
-		$this->assertTrue(isset($return));
-		unset($return);
+		# Demo test, since in 0.5.5 and following all deprecated widgets have had their files removed.
+		#
+		#$return = has_action('admin_notices', 'largo_deprecated_sidebar_widget');
+		#$this->assertTrue(isset($return));
+		#unset($return);
 
 		// Cleanup
 		of_reset_options();
@@ -263,19 +262,15 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		update_option('sidebars_widgets', $widgets_backup);
 	}
 
-	function test_largo_deprecated_footer_widget() {
-		// prints a nag
-		// uses __
-		$this->expectOutputRegex('/[.*]+/'); // This is excessively greedy, it expects any output at all
-		largo_deprecated_footer_widget();
-	}
-
-	function test_largo_deprecated_sidebar_widget() {
-		// prints a nag
-		// uses __
-		$this->expectOutputRegex('/[.*]+/'); // This is excessively greedy, it expects any output at all
-		largo_deprecated_sidebar_widget();
-	}
+	# This is what a test function for a callback for a deprecated widget should look like
+	# Please do not remove this, as we may write deprecated widget test functions in the future.
+	#
+	#function test_largo_deprecated_sidebar_widget() {
+	#	// prints a nag
+	#	// uses __()
+	#	$this->expectOutputRegex('/[.*]+/'); // This is excessively greedy, it expects any output at all
+	#	largo_deprecated_sidebar_widget();
+	#}
 
 	function test_largo_transition_nav_menus() {
 		// Test the function's ability to create the Main Navigation nav menu

--- a/tests/inc/test-update.php
+++ b/tests/inc/test-update.php
@@ -234,34 +234,6 @@ class UpdateTestFunctions extends WP_UnitTestCase {
 		update_option('sidebars_widgets', $widgets_backup);
 	}
 
-	function test_largo_check_deprecated_widgets() {
-		// Backup sidebar widgets
-		$widgets_backup = get_option('sidebars_widgets');
-
-		// Create the deprecated widgets
-		update_option('sidebars_widgets', array(
-			'article-bottom' => array (
-				// this should be instances of the widget that you want to check gets updated
-				0 => 'largo-footer-featured-2',
-				1 => 'largo-sidebar-featured-2',
-			), // largo_instantiate_widget uses article-bottom for all its widgets
-		));
-
-		largo_check_deprecated_widgets();
-
-		// Test that the requisite deprecated widgets actions have been added to the admin_notices hook
-		# Demo test, since in 0.5.5 and following all deprecated widgets have had their files removed.
-		#
-		#$return = has_action('admin_notices', 'largo_deprecated_sidebar_widget');
-		#$this->assertTrue(isset($return));
-		#unset($return);
-
-		// Cleanup
-		of_reset_options();
-		delete_option('sidebars_widgets');
-		update_option('sidebars_widgets', $widgets_backup);
-	}
-
 	# This is what a test function for a callback for a deprecated widget should look like
 	# Please do not remove this, as we may write deprecated widget test functions in the future.
 	#


### PR DESCRIPTION
## Changes

- Move `largo_remove_topstory_prominence_term` inside a <0.5 block in inc/updates.php
- Remove deprecated widget callbacks from `largo_check_deprecated_widgets` as the widgets it checks for and notifies the reader of are no longer included in Largo, and as such will be automatically removed by WordPress.
- Comment out tests for `largo_check_deprecated_widgets` so that we can still test the function without testing any callbacks.