### PR TITLE
Show no update nag upon initial activation of Largo

### DIFF
--- a/inc/update.php
+++ b/inc/update.php
@@ -15,7 +15,6 @@
  * @link https://github.com/INN/Largo/issues/690
  */
 function largo_activation_maybe_setup() {
-	var_log( "Should setup be done?" );
 	if ( of_get_option( 'largo_version', false ) ) {
 		return false;
 	}
@@ -41,11 +40,6 @@ function largo_activation_maybe_setup() {
 	// this must run before any other function that makes use of of_set_option()
 	largo_set_new_option_defaults();
 
-	var_log( "if this returns false it is because there is no get_option( 'optionsframework' )" );
-	var_log( of_set_option( 'largo_version', largo_version() ) );
-
-	var_log( get_option( 'optionsframework' ) );
-	var_log( largo_version() );
 	return true;
 }
 add_action( 'after_switch_theme', 'largo_activation_maybe_setup' );
@@ -121,8 +115,6 @@ function largo_need_updates() {
 	// try to figure out which versions of the options are stored. Implemented in 0.3
 	if ( of_get_option( 'largo_version' ) ) {
 		$compare = version_compare( largo_version(), of_get_option( 'largo_version' ) );
-		var_log( largo_version() );
-		var_log( of_get_option( 'largo_version' ) );
 		if ( $compare == 1 ) {
 			return true;
 		} else {

--- a/inc/update.php
+++ b/inc/update.php
@@ -8,6 +8,29 @@
  * ------------------------------------------------------ */
 
 /**
+ * For initial activations of Largo, where no largo was previously installed
+ *
+ * @since 0.5.5
+ * @return Bool false if the initial setup functions were not run, true if they were.
+ * @link https://github.com/INN/Largo/issues/690
+ */
+function largo_activation_maybe_setup() {
+	var_log( "Should setup be done?" );
+	if ( of_get_option( 'largo_version' ) ) {
+		var_log( "No.");
+		return false;
+	}
+		var_log( "Yes.");
+
+	// this must run before any other function that makes use of of_set_option()
+	largo_set_new_option_defaults();
+	of_set_option( 'largo_version', largo_version() );
+
+	return true;
+}
+add_action( 'after_switch_theme', 'largo_activation_maybe_setup' );
+
+/**
  * Performs various update functions and set a new verion number.
  *
  * This acts as a main() for applying database updates when the update ajax is

--- a/inc/update.php
+++ b/inc/update.php
@@ -40,6 +40,14 @@ function largo_activation_maybe_setup() {
 	// this must run before any other function that makes use of of_set_option()
 	largo_set_new_option_defaults();
 
+	of_set_option( 'largo_version', largo_version() );
+
+	// Prevent the update nag from displaying on the first page load
+	remove_action( 'admin_notices', 'largo_update_admin_notice', 10 );
+
+	// Prevent the theme options menu from getting hijacked with the update nag
+	remove_action( 'admin_menu', 'largo_block_theme_options_for_update', 10 );
+
 	return true;
 }
 add_action( 'after_switch_theme', 'largo_activation_maybe_setup' );
@@ -115,6 +123,7 @@ function largo_need_updates() {
 	// try to figure out which versions of the options are stored. Implemented in 0.3
 	if ( of_get_option( 'largo_version' ) ) {
 		$compare = version_compare( largo_version(), of_get_option( 'largo_version' ) );
+
 		if ( $compare == 1 ) {
 			return true;
 		} else {

--- a/lib/options-framework/options-framework.php
+++ b/lib/options-framework/options-framework.php
@@ -396,6 +396,8 @@ if ( ! function_exists( 'of_get_option' ) ) {
 		$config = get_option( 'optionsframework' );
 
 		if ( ! isset( $config['id'] ) ) {
+			var_log( "It looks like you are calling of_get_option on a site that has not initialized the options framework. Running `get_option( 'optionsframework' )` returns the following value, which does not have an index 'id' or is not an array:");
+			var_log( $config );
 			return $default;
 		}
 

--- a/options.php
+++ b/options.php
@@ -589,9 +589,12 @@ function optionsframework_options() {
 		'class' => 'hidden');
 
 
-	$screen = get_current_screen();
-	if ( is_object( $screen ) && $screen->base == 'widgets' ) {
-		return $widget_options;
+	// this is wrapped in a function_exists because optionsframework_options is called during after_switch_theme, which is not yet an admin screen, so the function is not defined
+	if ( function_exists( 'get_current_screen' ) ) {
+		$screen = get_current_screen();
+		if ( is_object( $screen ) && $screen->base == 'widgets' ) {
+			return $widget_options;
+		}
 	}
 
 


### PR DESCRIPTION
## Changes

- Create new hook on `after_switch_theme`, the activation hook, that:
    - doesn't run if there is already saved theme options for any version of Largo
    - requires the default Largo options from `options.php`, which are otherwise not included in the theme outside of the options framework pages
    - runs the options framework initiation function
    - sets the defaults using Largo's function to do so
    - sets the version number to the current version
    - removes the update nag from its enqueued action, for the single page load where `after_switch_theme` runs, because at page generation time apparently the Largo version is not set in the database even though it is set during this function that appears to run before everything else on the page. (I checked with subsequent page reloads, and with some var_logging, and the variable is set on page reload but not yet on page load. :slightly_frowning_face: )
    - removes the theme options menu link hijacker from the menus, for the single page load where `after_switch_theme` runs, for the same reason
- if `of_get_option` is called in a situation where the database doesn't contain all the information it needs to work properly, it complains to the debug log.

## Why

#690