### PR TITLE
In Largo_Byline::avatar(), swap the test around to do the coauthors byline first

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -98,16 +98,16 @@ class Largo_Byline {
 			$output = '';
 		} else {
 			$author_email = get_the_author_meta( 'email', $this->author_id );
-			if ( largo_has_avatar( $author_email ) ) {
+			if ( $this->author->type == 'guest-author' && get_the_post_thumbnail( $this->author->ID ) ) {
+				$output = get_the_post_thumbnail( $this->author->ID, array( 32,32 ) );
+				$output = str_replace( 'attachment-32x32 wp-post-image', 'avatar avatar-32 photo', $output );
+			} else if ( largo_has_avatar( $author_email ) ) {
 				$output = get_avatar(
 					$author_email,
 					32,
 					'',
 					get_the_author_meta( 'display_name', $this->author_id )
 				);
-			} elseif ( $this->author->type == 'guest-author' && get_the_post_thumbnail( $this->author->ID ) ) {
-				$output = get_the_post_thumbnail( $this->author->ID, array( 32,32 ) );
-				$output = str_replace( 'attachment-32x32 wp-post-image', 'avatar avatar-32 photo', $output );
 			}
 			$output .= ' '; // to reduce run-together bylines
 		}


### PR DESCRIPTION
## changes

- inverts a test to see first if it's a coauthor that has an image before falling back to a different test for the author.

## why

this fixes the behavior described in http://support.largoproject.org/helpdesk/tickets/300

> For example, on Curtis Black's latest column, a picture of Asraa is showing up in the byline of the posy. The proper image is showing up at the bottom.

The user that created the post was being shown instead of the set guest author