### PR TITLE
Make the $author_id property of Largo_Byline and extending classes public

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -102,9 +102,6 @@ class Largo_Byline {
 			$output = '';
 		} else {
 			$author_email = get_the_author_meta( 'email', $this->author_id );
-			var_log( $this->author->ID );
-			var_log( $this->author_id );
-			var_log( $author_email );
 			if ( $this->author->type == 'guest-author' && get_the_post_thumbnail( $this->author->ID ) ) {
 				$output = get_the_post_thumbnail( $this->author->ID, array( 32,32 ) );
 				$output = str_replace( 'attachment-32x32 wp-post-image', 'avatar avatar-32 photo', $output );

--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -23,8 +23,12 @@ class Largo_Byline {
 	 */
 	private $custom;
 
-	/** @var int The ID of the author for this post */
-	private $author_id;
+	/**
+	 * Temporary variable used for the author ID;
+	 * This must be public, because Largo_CoAuthors_Byline's methods incorporate methods from Largo_Byline, and parent classes cannot see private or protected members of extending classes.
+	 * @var int The ID of the author for this post
+	 */
+	public $author_id;
 
 	/**
 	 * @var string The HTML ouput of this class
@@ -98,6 +102,9 @@ class Largo_Byline {
 			$output = '';
 		} else {
 			$author_email = get_the_author_meta( 'email', $this->author_id );
+			var_log( $this->author->ID );
+			var_log( $this->author_id );
+			var_log( $author_email );
 			if ( $this->author->type == 'guest-author' && get_the_post_thumbnail( $this->author->ID ) ) {
 				$output = get_the_post_thumbnail( $this->author->ID, array( 32,32 ) );
 				$output = str_replace( 'attachment-32x32 wp-post-image', 'avatar avatar-32 photo', $output );
@@ -211,9 +218,10 @@ class Largo_CoAuthors_Byline extends Largo_Byline {
 
 	/**
 	 * Temporary variable used for the author ID;
+	 * This must be public, because Largo_CoAuthors_Byline's methods incorporate methods from Largo_Byline, and parent classes cannot see private or protected members of extending classes.
 	 * @see $this->generate_byline();
 	 */
-	private $author_id;
+	public $author_id;
 
 	/**
 	 * Differs from Largo_Byline in following ways:


### PR DESCRIPTION
## Changes

- Makes the `$author_id` property of the `Largo_Byline` class and its extenders public, because for `Largo_Byline->avatar()` to work, it needs to be able to read the `Largo_CoAuthors_Byline->author_id`, and extended classes can't read the private or protected variables of their extending classes.

This fixes the behavior documented in http://support.largoproject.org/helpdesk/tickets/300 where posts were showing author avatars based on the ID of the post's database author, not the ID of coauthors or normal wordpress users.

https://github.com/INN/Largo/pull/1374 assumed that it was just bad logic; this looked at the variables and found that one was `''` and therefore the author email address being fetched by [get_the_author_meta](https://developer.wordpress.org/reference/functions/get_the_author_meta/) was coming back as the post's database author, not the appropriate coauthors-defined author. 