### PR TITLE
Make sure that both Guest Author and WP User avatar types have the same classes

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -104,13 +104,17 @@ class Largo_Byline {
 			$author_email = get_the_author_meta( 'email', $this->author_id );
 			if ( $this->author->type == 'guest-author' && get_the_post_thumbnail( $this->author->ID ) ) {
 				$output = get_the_post_thumbnail( $this->author->ID, array( 32,32 ) );
-				$output = str_replace( 'attachment-32x32 wp-post-image', 'avatar avatar-32 photo', $output );
+				$output = str_replace( 'attachment-32x32', 'avatar avatar-32 photo', $output );
+				$output = str_replace( 'wp-post-image', '', $output );
 			} else if ( largo_has_avatar( $author_email ) ) {
 				$output = get_avatar(
 					$author_email,
 					32,
 					'',
-					get_the_author_meta( 'display_name', $this->author_id )
+					get_the_author_meta( 'display_name', $this->author_id ),
+					array(
+						'class' => 'avatar avatar-32 photo',
+					)
 				);
 			}
 			$output .= ' '; // to reduce run-together bylines


### PR DESCRIPTION
## Changes

- Makes sure that bylines for guest authors have the same classes as other avatars.

## Why

On http://chicagoreporter.com/police-face-choice-of-handcuffs-or-helping-hand-for-mentally-ill/

<img width="610" alt="screen shot 2016-11-10 at 3 45 52 pm" src="https://cloud.githubusercontent.com/assets/1754187/20193672/0b2797ee-a75d-11e6-952d-0c7b505cf01c.png">

With this fix:

<img width="672" alt="screen shot 2016-11-10 at 3 45 44 pm" src="https://cloud.githubusercontent.com/assets/1754187/20193674/11e58442-a75d-11e6-9b9b-d2d9151b6e4e.png">
