### PR TITLE
Post Comment Errors

### DIFF
--- a/inc/avatars.php
+++ b/inc/avatars.php
@@ -38,14 +38,15 @@ function largo_has_gravatar( $email ) {
  * @return bool true if an avatar is available for this user
  * @since 0.4
  */
-function largo_has_avatar($email) {
-	$user = get_user_by('email', $email);
-	$result = largo_get_user_avatar_id($user->ID);
-	if (!empty($result))
+function largo_has_avatar( $email ) {
+	$user = get_user_by( 'email', $email );
+	$result = largo_get_user_avatar_id( $user->ID );
+	if ( ! empty ( $result ) ) {
 		return true;
-	else {
-		if (largo_has_gravatar($email))
+	} else {
+		if ( largo_has_gravatar( $email ) ) {
 			return true;
+		}	
 	}
 	return false;
 }

--- a/inc/avatars/functions.php
+++ b/inc/avatars/functions.php
@@ -28,12 +28,17 @@ add_action( 'get_avatar', 'largo_get_avatar_filter', 1, 5 );
  * @param int $string The size of the avatar
  */
 function largo_get_avatar_src( $id_or_email, $size ) {
-	// get the user ID;
-	if ( ! is_numeric( $id_or_email ) ) {
+
+	// get the user ID
+	if ( is_numeric( $id_or_email ) ) {
+		$id = (int) $id_or_email;
+	} elseif ( is_object( $id_or_email ) ) {
+		if ( ! empty( $id_or_email->user_id ) ) {
+			$id = (int) $id_or_email->user_id;
+		}
+	} else {
 		$user = get_user_by( 'email', $id_or_email );
 		$id = $user->ID;
-	} else {
-		$id = (int) $id_or_email;
 	}
 
 	$avatar_id = largo_get_user_avatar_id( $id );


### PR DESCRIPTION
## What
On at least some post comments, a PHP error is being printed to the front end.

## Why
We're using the `get_avatar` hook, who's third parameter `$id_or_email`, is specified at `A user ID, email address, or comment object.`

We are only accommodating for a user ID or email address, and do not have code to accept a comment object.

Reference: https://codex.wordpress.org/Plugin_API/Filter_Reference/get_avatar

## The Fix
I've updated the offending function using the example from the codex page to also accept comment objects