### PR TITLE
Probable fix for https://github.com/INN/Largo/issues/1381

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -550,6 +550,7 @@ class Largo_Related {
 					'orderby' => 'date',
 					'order' => 'ASC',
 					'ignore_sticky_posts' => 1,
+					'post__not_in' => array( $this->post_id ),
 					'date_query' => array(
 						'after' => $this->post->post_date,
 					),
@@ -647,6 +648,7 @@ class Largo_Related {
 					'orderby' => 'date',
 					'order' => 'DESC',
 					'ignore_sticky_posts' => 1,
+					'post__not_in' => array( $this->post_id ),
 					'date_query' => array(
 						'after' => $this->post->post_date,
 					),

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -33,6 +33,7 @@ class largo_related_posts_widget extends WP_Widget {
 		$rel_posts = new WP_Query( array(
 			'post__in' => $related->ids(),
 			'nopaging' => 1,
+			'post__not_in' => array( $post->ID ),
 			'posts_per_page' => $instance['qty'],
 			'ignore_sticky_posts' => 1
 		) );


### PR DESCRIPTION
I'm not able to duplicate the bug described in https://github.com/INN/Largo/issues/1381, but this looks like a fix: exclude the current post from the posts that get returned in any query in the Largo_Related class, which is what feeds the Largo Related Posts widget.

Please wait for tests on this one.