### PR TITLE
Gallery updates

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -59,7 +59,7 @@ if ( ! defined( 'INN_MEMBER' ) )
  */
 if ( ! defined( 'LARGO_DEBUG' ) )
 	define( 'LARGO_DEBUG', FALSE );
-	
+
 /**
  * Image size constants, almost 100% that you won't need to change these
  */
@@ -419,7 +419,7 @@ if ( ! function_exists( 'largo_setup' ) ) {
 
 		// Add support for localization (this is a work in progress)
 		load_theme_textdomain('largo', get_template_directory() . '/lang');
-		
+
 		//Add support for <title> tags
 		add_theme_support( 'title-tag' );
 
@@ -453,24 +453,22 @@ if ( ! function_exists( 'of_set_option' ) ) {
 }
 
 /**
-/* Gallery Default Settings
-/* Adds a '0' option for gallery columns
-*/
+ * Gallery Default Settings
+ * Adds a '0' option for gallery columns
+ */
 add_action( 'wp_enqueue_media', 'gallery_zero_columns' );
-function gallery_zero_columns(){
+function gallery_zero_columns() {
 	$columns_src = get_template_directory_uri() . '/lib/navis-slideshows/js/navis-columns.js';
-	wp_enqueue_script('navis-columns', $columns_src, array('jquery'), '1.0', true);
+	wp_enqueue_script( 'navis-columns', $columns_src, array( 'jquery' ), '1.0', true );
 }
 /**
-/* Gallery Default Settings
-/* @param Array $settings
-/* @return Array $settings
+ * Gallery Default Settings
+ * @param Array $settings
+ * @return Array $settings
 */
 function theme_gallery_defaults( $settings ) {
 	// Sets default column setting to 0
-    $settings['galleryDefaults']['columns'] = 0;
-    return $settings;
+	$settings['galleryDefaults']['columns'] = 0;
+	return $settings;
 }
 add_filter( 'media_view_settings', 'theme_gallery_defaults' );
-
-

--- a/functions.php
+++ b/functions.php
@@ -451,3 +451,26 @@ if ( ! function_exists( 'of_set_option' ) ) {
 		return false;
 	}
 }
+
+/**
+/* Gallery Default Settings
+/* Adds a '0' option for gallery columns
+*/
+add_action( 'wp_enqueue_media', 'gallery_zero_columns' );
+function gallery_zero_columns(){
+	$columns_src = get_template_directory_uri() . '/lib/navis-slideshows/js/navis-columns.js';
+	wp_enqueue_script('navis-columns', $columns_src, array('jquery'), '1.0', true);
+}
+/**
+/* Gallery Default Settings
+/* @param Array $settings
+/* @return Array $settings
+*/
+function theme_gallery_defaults( $settings ) {
+	// Sets default column setting to 0
+    $settings['galleryDefaults']['columns'] = 0;
+    return $settings;
+}
+add_filter( 'media_view_settings', 'theme_gallery_defaults' );
+
+

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -82,20 +82,20 @@ if ( ! function_exists( 'largo_gallery_enqueue' ) ) {
 	/**
 	 * Enqueue Largo gallery CSS & JS
 	 *
-	 * @since 0.5.5
+	 * @since 0.5.5.3
 	 */
 	function largo_gallery_enqueue() {
 		$slick_css = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.css';
-		wp_enqueue_style('navis-slick', $slick_css, array(), '1.0');
+		wp_enqueue_style( 'navis-slick', $slick_css, array(), '1.0' );
 
 		$slides_src = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.min.js';
-		wp_enqueue_script('jquery-slick', $slides_src, array('jquery'), '3.0', true);
+		wp_enqueue_script( 'jquery-slick', $slides_src, array( 'jquery' ), '3.0', true );
 
 		$slides_css = get_template_directory_uri() . '/lib/navis-slideshows/css/slides.css';
-		wp_enqueue_style('navis-slides', $slides_css, array(), '1.0');
+		wp_enqueue_style( 'navis-slides', $slides_css, array(), '1.0' );
 
 		$show_src = get_template_directory_uri() . '/lib/navis-slideshows/js/navis-slideshows.js';
-		wp_enqueue_script('navis-slideshows', $show_src, array('jquery-slick'), '0.1', true);
+		wp_enqueue_script( 'navis-slideshows', $show_src, array( 'jquery-slick' ), '0.1', true );
 	}
 	add_action( 'wp_enqueue_scripts', 'largo_gallery_enqueue' );
 }

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -78,6 +78,28 @@ if ( ! function_exists( 'largo_enqueue_js' ) ) {
 }
 add_action( 'wp_enqueue_scripts', 'largo_enqueue_js' );
 
+if ( ! function_exists( 'largo_gallery_enqueue' ) ) {
+	/**
+	 * Enqueue Largo gallery CSS & JS
+	 *
+	 * @since 0.5.5
+	 */
+	function largo_gallery_enqueue() {
+		$slick_css = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.css';
+		wp_enqueue_style('navis-slick', $slick_css, array(), '1.0');
+
+		$slides_src = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.min.js';
+		wp_enqueue_script('jquery-slick', $slides_src, array('jquery'), '3.0', true);
+
+		$slides_css = get_template_directory_uri() . '/lib/navis-slideshows/css/slides.css';
+		wp_enqueue_style('navis-slides', $slides_css, array(), '1.0');
+
+		$show_src = get_template_directory_uri() . '/lib/navis-slideshows/js/navis-slideshows.js';
+		wp_enqueue_script('navis-slideshows', $show_src, array('jquery-slick'), '0.1', true);
+	}
+	add_action( 'wp_enqueue_scripts', 'largo_gallery_enqueue' );
+}
+
 if ( ! function_exists( 'largo_enqueue_child_theme_css' ) ) {
 	/**
 	 * Enqueue Largo child theme CSS

--- a/lib/navis-slideshows/css/slides.css
+++ b/lib/navis-slideshows/css/slides.css
@@ -22,7 +22,7 @@
 .navis-slideshow p {
     margin: 10px 0;
     line-height: 1.5;
-    padding: 10px;
+    padding: 0;
     font-size: 12px;
 }
 
@@ -36,11 +36,30 @@
 }
 
 .navis-slideshow h6.credit {
-    position:absolute;
-    left: 17%;
+    position:relative;
+    left:0;
     padding: .5em 0;
-    text-align:right;
-    display:none;
+    margin-bottom:-1em;
+    display: block;
+    text-align: left;
+    font-size: 11px;
+}
+
+.hero .navis-slideshow h6.credit {
+    left:17.023%;
+    color:#666;
+}
+
+.hero .navis-slideshow.navis-full h6.credit,
+.navis-slideshow.navis-full h6.credit {
+    position:absolute;
+    display: block;
+    bottom: 0;
+    margin-bottom: 0;
+    left: 17.023%;
+    text-align: left;
+    padding-left:0;
+    z-index: 4;
 }
 
 .navis-slideshow h6.permalink {
@@ -236,8 +255,7 @@ body.single-format-standard .navis-slideshow a.slick-next {
 
 /**** FULL SIZE ***/
 .navis-slideshow.navis-full {
-    margin-top: 0;
-    margin-bottom: 0;
+    margin:0;
     padding: 4px 0 0;
     position: fixed;
     top: 0;
@@ -325,12 +343,39 @@ body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
     background-color: rgba(0,0,0,.7);
     color: #ccc;
     padding: 1em 17.023%!important;
+    padding-bottom: 32px!important;
     bottom: 0;
     position: absolute;
     border: none;
-    text-align: center;
+    text-align: left;
 }
 
+body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
+    position:absolute;
+    display: block;
+    bottom: 0;
+    margin-bottom: 0;
+    left: 17.023%;
+    text-align: left;
+    padding-left:0;
+    z-index: 4;
+    background-color:transparent;
+}
+
+/**** SINGLE LIGHTBOX ***/
+.navis-single.navis-full img {
+    max-height: 100vh;
+    top: 50%;
+    position: absolute;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    -moz-transform: translate(-50%, -50%);
+    -ms-transform: translate(-50%, -50%);
+    -o-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+}
+
+/**** IMAGE GRID ***/
 .largo-img-grid {
     display: -ms-flexbox;
     display: -webkit-flex;
@@ -340,6 +385,14 @@ body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
     flex-wrap:wrap;
     justify-content:space-between;
 }
+.largo-img-grid>div>div {
+    min-height:300px;
+    background-size: cover;
+    background-position: center center;
+}
+.largo-img-grid.one-up>div{
+    width:100%;
+}
 .largo-img-grid.two-up>div{
     width:49%;
 }
@@ -348,11 +401,6 @@ body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
 }
 .largo-img-grid.four-up>div{
     width:24%;
-}
-.largo-img-grid>div>div {
-    min-height:300px;
-    background-size: cover;
-    background-position: center center;
 }
 .largo-img-grid img {
     display:none;
@@ -368,10 +416,17 @@ body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
     -webkit-justify-content: space-between;
     justify-content: space-between;
 }
+.largo-img-grid.one-up>div>div {
+    min-height:500px;
+}
 .largo-img-grid p.wp-caption-text {
     font-size:12px!important;
     font-style:italic;
     margin-bottom:2em;
+}
+.largo-img-grid .credit {
+    font-size: 11px;
+    margin: 6px 0 0 0;
 }
 
 @media screen and (max-width:767px) {
@@ -411,5 +466,84 @@ body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
     body.normal.single-post .hero .navis-slideshow p.wp-caption-text {
         background-color:transparent;
         padding: 1em 1em 0 1em!important;
+    }
+    .navis-slideshow.slick-initialized .slick-slide {
+        min-height: 25vh;
+    }
+    .navis-slideshow h6.credit {
+        left:0;
+    }
+    .hero .navis-slideshow h6.credit {
+        left:0;
+        padding-left:1em;
+    }
+    .largo-img-grid>div>div {
+        min-height: 200px;
+        background-size: contain;
+        background-position: bottom left;
+        background-repeat: no-repeat;
+    }
+
+    .largo-img-grid.one-up>div>div {
+        min-height: 400px;
+    }
+    .largo-img-grid.three-up>div>div {
+        min-height: 150px;
+    }
+    .largo-img-grid.four-up>div {
+        width:49%;
+    }
+    .largo-img-grid.four-up>div>div {
+        min-height: 170px;
+    }
+}
+
+@media (max-width: 680px) {
+    .largo-img-grid.one-up>div>div {
+        min-height: 350px;
+    }
+    .largo-img-grid.three-up>div>div {
+        min-height: 120px;
+    }
+    .largo-img-grid.four-up>div>div {
+        min-height: 140px;
+    }
+}
+
+@media (max-width: 520px) {
+    .largo-img-grid>div>div {
+        min-height: 160px;
+    }
+    .largo-img-grid.one-up>div>div {
+        min-height: 300px;
+    }
+    .largo-img-grid.three-up>div>div {
+        min-height: 100px;
+    }
+    .largo-img-grid.four-up>div>div {
+        min-height: 120px;
+    }
+}
+
+@media (max-width: 480px) {
+    .largo-img-grid.one-up>div>div,
+    .largo-img-grid.two-up>div>div,
+    .largo-img-grid.three-up>div>div,
+    .largo-img-grid.four-up>div>div {
+        min-height: 230px;
+    }
+    .largo-img-grid.two-up>div,
+    .largo-img-grid.three-up>div,
+    .largo-img-grid.four-up>div {
+        width:100%;
+    }
+}
+
+@media (max-width: 350px) {
+    .largo-img-grid>div>div {
+        min-height: 120px;
+    }
+    .largo-img-grid.one-up>div>div {
+        min-height: 200px;
     }
 }

--- a/lib/navis-slideshows/css/slides.css
+++ b/lib/navis-slideshows/css/slides.css
@@ -8,6 +8,7 @@
     margin-top: 0;
     margin-bottom: 20px;
     padding: 4px 0 0 0;
+    text-align: left;
 }
 
 .navis-slideshow .slick-list {
@@ -23,6 +24,7 @@
     font-weight: normal;
     font-style: normal;
     font-size: 12px;
+    margin-bottom:0;
 }
 
 .navis-slideshow .wp-caption-text {
@@ -39,6 +41,7 @@
 
 body.normal.single-post .hero .navis-slideshow .wp-caption-text {
     padding:1em 17.0213%!important;
+    margin:0;
 }
 
 .slide-permalink:hover {
@@ -359,6 +362,9 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
 }
 
 @media screen and (max-width:767px) {
+    .hero .navis-slideshow {
+        margin-bottom: 0;
+    }
     .navis-slideshow {
         background-color: transparent;
     }
@@ -394,7 +400,7 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
     }
     body.normal.single-post .hero .navis-slideshow p.wp-caption-text {
         background-color:transparent;
-        padding: 1em 1em 0 1em!important;
+        padding:0!important;
     }
     .navis-slideshow.slick-initialized .slick-slide {
         min-height: 25vh;

--- a/lib/navis-slideshows/css/slides.css
+++ b/lib/navis-slideshows/css/slides.css
@@ -1,6 +1,5 @@
 .navis-slideshow {
     background-color: #fff;
-    font-family: sans-serif;
     font-size: 11px;
     color: #666;
     position: relative;
@@ -19,61 +18,11 @@
     display: block;
 }
 
-.navis-slideshow p {
-    margin: 10px 0;
-    line-height: 1.5;
-    padding: 0;
-    font-size: 12px;
-}
-
-.navis-slideshow h6 {
-    margin: 0 0 -10px;
-    font-weight: normal;
-    font-size: 11px;
-    font-style: italic;
-    color: #666;
-    z-index:2;
-}
-
-.navis-slideshow h6.credit {
-    position:relative;
-    left:0;
-    padding: .5em 0;
-    margin-bottom:-1em;
-    display: block;
-    text-align: left;
-    font-size: 11px;
-}
-
-.hero .navis-slideshow h6.credit {
-    left:17.023%;
-    color:#666;
-}
-
-.hero .navis-slideshow.navis-full h6.credit,
-.navis-slideshow.navis-full h6.credit {
-    position:absolute;
-    display: block;
-    bottom: 0;
-    margin-bottom: 0;
-    left: 17.023%;
-    text-align: left;
-    padding-left:0;
-    z-index: 4;
-}
-
-.navis-slideshow h6.permalink {
-    position:absolute;
-    left: 2%;
-    text-align: left;
-    padding-left: 16px;
-}
-
-.slide-permalink {
+.navis-slideshow .slide-permalink,
+.largo-img-grid .slide-permalink {
     font-weight: normal;
     font-style: normal;
-    outline: none;
-    display:none;
+    font-size: 12px;
 }
 
 .navis-slideshow .wp-caption-text {
@@ -82,14 +31,9 @@
     color: #000;
     background-color: #fff;
     width: 100%;
-    padding:1em 0!important;
+    padding:0;
     margin:0;
-    //margin: 0 2%!important;
-    // padding: .75em 1em 1.5em!important;
-    // border: 4px solid #000;
-    // border-bottom:none;
     position: relative;
-    font-size:12px!important;
     font-style:italic;
 }
 
@@ -244,18 +188,16 @@ body.single-format-standard .navis-slideshow a.slick-next {
     margin:0 auto;
     max-height: 80vh;
     position: relative;
-    //margin-bottom: -1.5em;
 }
 
 .navis-slideshow.slick-initialized .slick-slide {
     position:relative;
-    //background-color: #000;
     min-height: 50vh;
 }
 
 /**** FULL SIZE ***/
 .navis-slideshow.navis-full {
-    margin:0;
+    margin:0!important;
     padding: 4px 0 0;
     position: fixed;
     top: 0;
@@ -265,6 +207,9 @@ body.single-format-standard .navis-slideshow a.slick-next {
     z-index: 999999;
     overflow:visible;
     background-color: #000;
+}
+.navis-slideshow.navis-full .permalink {
+    display: none;
 }
 .navis-slideshow.navis-full .slick-list {
     top:0;
@@ -308,8 +253,9 @@ body.single-format-standard .navis-slideshow a.slick-next {
     position: absolute;
     top: 10px;
     right: 14px;
-    color: white;
     z-index: 99999;
+    color: white;
+    font-family: sans-serif;
     font-size: 2.5em;
 }
 
@@ -334,16 +280,13 @@ body.single-format-standard .navis-slideshow a.slick-next {
             transform: translate(-50%, -50%);
 }
 
-.navis-slideshow.navis-full h6 {
-    padding: 10px 16px;
-}
-
 .navis-slideshow.navis-full .wp-caption-text,
 body.normal.single-post .hero .navis-slideshow.navis-full p.wp-caption-text {
     background-color: rgba(0,0,0,.7);
     color: #ccc;
     padding: 1em 17.023%!important;
     padding-bottom: 32px!important;
+    margin:0!important;
     bottom: 0;
     position: absolute;
     border: none;
@@ -354,10 +297,10 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
     position:absolute;
     display: block;
     bottom: 0;
-    margin-bottom: 0;
+    margin: 0;
     left: 17.023%;
     text-align: left;
-    padding-left:0;
+    padding:.75em 0 .5em 0;
     z-index: 4;
     background-color:transparent;
 }
@@ -383,7 +326,10 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
     -ms-flex-wrap:wrap;
     -webkit-flex-wrap:wrap;
     flex-wrap:wrap;
-    justify-content:space-between;
+    -ms-justify-content: space-between;
+    -webkit-justify-content: space-between;
+    justify-content: space-between;
+    margin-bottom:1em;
 }
 .largo-img-grid>div>div {
     min-height:300px;
@@ -402,31 +348,14 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
 .largo-img-grid.four-up>div{
     width:24%;
 }
-.largo-img-grid img {
-    display:none;
-}
-.largo-img-grid {
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-    -ms-flex-wrap:wrap;
-    -webkit-flex-wrap:wrap;
-    flex-wrap:wrap;
-    -ms-justify-content: space-between;
-    -webkit-justify-content: space-between;
-    justify-content: space-between;
-}
 .largo-img-grid.one-up>div>div {
     min-height:500px;
 }
-.largo-img-grid p.wp-caption-text {
-    font-size:12px!important;
-    font-style:italic;
-    margin-bottom:2em;
+.largo-img-grid img {
+    display:none;
 }
-.largo-img-grid .credit {
-    font-size: 11px;
-    margin: 6px 0 0 0;
+.largo-img-grid p.permalink {
+    margin-bottom: 0;
 }
 
 @media screen and (max-width:767px) {
@@ -469,13 +398,6 @@ body.normal.single-post .navis-slideshow.navis-full p.wp-media-credit {
     }
     .navis-slideshow.slick-initialized .slick-slide {
         min-height: 25vh;
-    }
-    .navis-slideshow h6.credit {
-        left:0;
-    }
-    .hero .navis-slideshow h6.credit {
-        left:0;
-        padding-left:1em;
     }
     .largo-img-grid>div>div {
         min-height: 200px;

--- a/lib/navis-slideshows/js/navis-columns.js
+++ b/lib/navis-slideshows/js/navis-columns.js
@@ -1,0 +1,27 @@
+(function() {
+	if(wp.media.view.Settings.Gallery){
+		wp.media.view.Settings.Gallery = wp.media.view.Settings.extend({
+			className: "collection-settings gallery-settings",
+			template: wp.media.template("gallery-settings"),
+			render:	function() {
+				wp.media.View.prototype.render.apply( this, arguments );
+				// Append an option for 0 (zero) columns if not already present
+				var $s = this.$('select.columns');
+				if(!$s.find('option[value="0"]').length){
+					$s.prepend('<option value="0">0</option>');
+				}
+				// Set default to the new 0 column
+				$s.val(0);
+				// Remove too-large column values
+				$s.find('option')[9].remove();
+				$s.find('option')[8].remove();
+				$s.find('option')[7].remove();
+				$s.find('option')[6].remove();
+				$s.find('option')[5].remove();
+				// Select the correct values.
+				_( this.model.attributes ).chain().keys().each( this.update, this );
+				return this;
+			}
+		});
+	}
+})(jQuery);

--- a/lib/navis-slideshows/js/navis-slideshows.js
+++ b/lib/navis-slideshows/js/navis-slideshows.js
@@ -111,9 +111,8 @@
 
     function closeSingle(gallery, attrs){
         $('.navis-before').remove(); // Removes close (X) button
-        $('.navis-single').removeClass('navis-full navis-slideshow navis-single'); // Removes navis classes
 
-        if (attrs){
+        if (gallery.hasClass('navis-single') && attrs){
             var img = gallery.find('img');
             // Reset attributes
             img.attr('sizes', attrs[0]);
@@ -121,6 +120,8 @@
             img.attr('height', attrs[2]);
             gallery.attr('style', attrs[3]);
         }
+
+        $('.navis-single').removeClass('navis-full navis-slideshow navis-single'); // Removes navis classes
     }
 
     function closeFull($slider){

--- a/lib/navis-slideshows/js/navis-slideshows.js
+++ b/lib/navis-slideshows/js/navis-slideshows.js
@@ -1,5 +1,6 @@
 (function() {
     var $ = jQuery;
+    var attrs = [];
 
     function createSlider($gallery, slide_num){
 
@@ -115,10 +116,10 @@
         if (attrs){
             var img = gallery.find('img');
             // Reset attributes
-            img.attr('sizes', attrs.sizes);
-            img.attr('width', attrs.width);
-            img.attr('height', attrs.height);
-            gallery.attr('style', attrs.style);
+            img.attr('sizes', attrs[0]);
+            img.attr('width', attrs[1]);
+            img.attr('height', attrs[2]);
+            gallery.attr('style', attrs[3]);
         }
     }
 
@@ -153,7 +154,7 @@
         $slider.find('.slick-slide').unbind('click');
 
         // Return images to original sizes
-        closeSingle();
+        closeSingle($slider, attrs);
     }
 
     $(document).ready(function() {
@@ -179,8 +180,9 @@
                         var sizes = img.attr('sizes'),
                             width = img.attr('width'),
                             height = img.attr('height'),
-                            style = gallery.attr('style'),
-                            attrs = [sizes, width, height, style];
+                            style = gallery.attr('style');
+
+                        attrs = [sizes, width, height, style];
 
                         // Adjust styles so images can expand to full width
                         gallery.css('max-width','100%');

--- a/lib/navis-slideshows/js/navis-slideshows.js
+++ b/lib/navis-slideshows/js/navis-slideshows.js
@@ -14,29 +14,36 @@
                 initialSlide: slide_num
             };
 
-        
-        
-
+        // Make the slider
         $gallery.slick(slick_opts);
 
-        //distinguish between click or drag (drag >100ms)
+        // Focus on the slider to allow user to use arrow keys right away
+        $gallery.find('.slick-list').focus();
+
+        // If the slider is full size, allow the user to click to advance
+        if ($gallery.hasClass('navis-full')){
+            $gallery.find('.slick-slide').click(function(){
+                $('.slick-next').trigger('click');
+            });
+        }
+
+        // Distinguish between click or drag (drag >100ms)
         var valid_click = true;
         var delay = 100;
 
-        //this function sets the flag to false
+        // Sets the flag to false
         var drag = function(){
             valid_click = false;
         }
 
-        //var $target = $('.navis-slideshow img');
         var $target = $($gallery.find('img'));
 
-        //mousedown, a global variable is set to the timeout function
+        // mousedown, a global variable is set to the timeout function
         $target.mousedown( function(){
             cancel_click = setTimeout( drag, delay );
         })
 
-        //mouseup, the timeout for drag is cancelled
+        // mouseup, the timeout for drag is cancelled
         $target.mouseup( function(e){
             clearTimeout( cancel_click );
 
@@ -51,18 +58,19 @@
 
     function createGallery($gallery, slide_num){
 
-        
+        // Prep each image in the gallery 
+        // When the parent is clicked, create a slider
         $gallery.find('img').each(function(){
             var $this = $(this);
             var src = $this.data('lazy');
             var $parent = $this.parent();
-            //$this.attr('src', src);
+
             $parent.prepend('<div style="background-image:url(' + src + ');"></div>');
-            //$parent.css({'width': '33%', 'float': 'left'});
             $parent.click(function(){
                 var $this = $(this);
                 if ($this.closest('.largo-img-grid').length > 0){
                     $gallery.addClass('navis-slideshow').removeClass('largo-img-grid').addClass('navis-full');
+                    // The parent index lets the slider know which image to show first
                     createSlider($gallery, $parent.index());
                     addCloseX($gallery);
                 }
@@ -80,6 +88,7 @@
         });
     }
 
+    // Full-width function for small slideshows
     function expandSlider($slider){
         var full = 'navis-full';
 
@@ -89,39 +98,115 @@
 
             addCloseX($slider);
         }
+
+        // Without the timeout, the full-width slider will advance beyond the first slide... 
+        // ...because it thinks the click to expand is also the click to advance.
+        setTimeout(function(){
+            $slider.find('.slick-slide').click(function(){
+                $('.slick-next').trigger('click');
+            });
+        },1000);
     };
 
-    function closeFull($slider){
-        $('.navis-before').remove();
-        $('.navis-full').removeClass('navis-full');
-        $slider.slick('setPosition');
+    function closeSingle(gallery, attrs){
+        $('.navis-before').remove(); // Removes close (X) button
+        $('.navis-single').removeClass('navis-full navis-slideshow navis-single'); // Removes navis classes
 
-        if (!$slider.hasClass('one-up')){
-            $slider.slick('unslick');
-            $slider.removeClass('navis-slideshow').addClass('largo-img-grid');
-            var $parent = $slider.find('>div');
-            //$parent.css({'width': '33%', 'float': 'left'});
-            $parent.click(function(){
-                var $this = $(this);
-                if ($this.closest('.largo-img-grid').length > 0){
-                    $slider.addClass('navis-slideshow').removeClass('largo-img-grid').addClass('navis-full');
-                    createSlider($slider, $this.index());
-                    addCloseX($slider);
-                }
-                
-            });
+        if (attrs){
+            var img = gallery.find('img');
+            // Reset attributes
+            img.attr('sizes', attrs.sizes);
+            img.attr('width', attrs.width);
+            img.attr('height', attrs.height);
+            gallery.attr('style', attrs.style);
         }
     }
 
+    function closeFull($slider){
+        $('.navis-before').remove(); // Removes close (X) button
+        $('.navis-full').removeClass('navis-full');
+
+        // Check if the slider belongs to a single image or a gallery/slideshow/grid (true is for gallery)
+        if($slider.hasClass('slick-slider')){
+            $slider.slick('setPosition');
+
+            // Check if the slider belongs to a gallery or a grid (true is for grid)
+            if (!$slider.hasClass('none-up')){
+                $slider.slick('unslick');
+                $slider.removeClass('navis-slideshow').addClass('largo-img-grid');
+
+
+                // Reconfigure grid view
+                var $parent = $slider.find('>div');
+                $parent.click(function(){
+                    var $this = $(this);
+                    if ($this.closest('.largo-img-grid').length > 0){
+                        $slider.addClass('navis-slideshow').removeClass('largo-img-grid').addClass('navis-full');
+                        createSlider($slider, $this.index());
+                        addCloseX($slider);
+                    }
+                    
+                });
+            }
+        }
+        // Unbind the click event so that small slideshows don't break
+        $slider.find('.slick-slide').unbind('click');
+
+        // Return images to original sizes
+        closeSingle();
+    }
+
     $(document).ready(function() {
+        // For single images, loop through each image on the page
+        $('article.post img').each(function() {
+
+            // If this is not already a slideshow
+            var img = $(this);
+            if ( img[0].hasAttribute('src') ){
+
+                // When an image is clicked, add classes to the parent element to open the lightbox view
+                img.click(function(){
+                    var gallery = img.parent();
+
+                    // If the image isn't linked
+                    if (gallery[0].localName !== "a"){
+                        gallery.addClass('navis-slideshow navis-single navis-full');
+
+                        // Add the close (X) button
+                        gallery.prepend('<span class=\"navis-before\">X</span>');
+
+                        // Save original attribute values
+                        var sizes = img.attr('sizes'),
+                            width = img.attr('width'),
+                            height = img.attr('height'),
+                            style = gallery.attr('style'),
+                            attrs = [sizes, width, height, style];
+
+                        // Adjust styles so images can expand to full width
+                        gallery.css('max-width','100%');
+                        img.removeAttr('width height sizes');
+
+                        // Close the lightbox when the close (X) button is clicked
+                        $('.navis-single .navis-before').click(function(){
+                            closeSingle(gallery, attrs);
+                        });
+                    }
+                });
+
+            }
+        });
+
+        // For each gallery, convert to a grid if necessary
         $('.navis-slideshow').each(function() {
             var $gallery = $(this);
             var slide_num = 0;
 
-            if ($gallery.hasClass('one-up')){
+            // 'none-up' is the slideshow setting (0 columns)
+            if ($gallery.hasClass('none-up')){
                 var post_id = $gallery.attr('id'),
                 post_id_clean = post_id.replace('slides-', '');
 
+                // Check for permalink
                 if (window.location.hash) {
                     var search = new RegExp(post_id_clean, 'g');
 
@@ -133,8 +218,10 @@
                             slide_num = slideNum - 1;
                     }
                 }
+                // Create a slider for the gallery
                 createSlider($gallery, slide_num);
             } else {
+                // If this gallery should have a grid layout, add the largo grid class
                 $gallery.removeClass('navis-slideshow').addClass('largo-img-grid');
                 createGallery($gallery, slide_num);
             }

--- a/lib/navis-slideshows/navis-slideshows.php
+++ b/lib/navis-slideshows/navis-slideshows.php
@@ -62,7 +62,7 @@ class Navis_Slideshows {
 			'itemtag' => 'dl',
 			'icontag' => 'dt',
 			'captiontag' => 'dd',
-			'columns'  => 1,
+			'columns'  => 0,
 			'size' => 'thumbnail',
 			'link' => 'file',
 			'ids' => ''

--- a/lib/navis-slideshows/navis-slideshows.php
+++ b/lib/navis-slideshows/navis-slideshows.php
@@ -138,7 +138,7 @@ class Navis_Slideshows {
 			}
 
 			$column_label = $columns . '-up';
-		} 
+		}
 
 		if ( empty( $attachments ) )
 			return '';

--- a/lib/navis-slideshows/navis-slideshows.php
+++ b/lib/navis-slideshows/navis-slideshows.php
@@ -179,12 +179,13 @@ class Navis_Slideshows {
 			$output .= '<img data-lazy="' . esc_url( $img_url ) . '" />';
 
 			if (!empty($credit))
-				$output .= '<h6 class="credit">' . wp_kses_post( $credit ) . '</h6>';
+				$output .= '<p class="wp-media-credit">' . wp_kses_post( $credit ) . '</p>';
 
-			$slide_link = get_permalink($post) . '#' . $post_html_id . '/' . $count;
-			$output .= '<h6 class="permalink"><a href="' . $slide_link . '" class="slide-permalink"><i class="icon-link"></i> ' . esc_attr( __( 'permalink', 'largo' ) ) . '</a></h6>';
 			if (!empty($caption))
 				$output .= '<p class="wp-caption-text">' . wp_kses_post( $caption ) . '</p>';
+
+			$slide_link = get_permalink($post) . '#' . $post_html_id . '/' . $count;
+			$output .= '<p class="permalink"><a href="' . $slide_link . '" class="slide-permalink"><i class="icon-link"></i> ' . esc_attr( __( 'permalink', 'largo' ) ) . '</a></p>';
 
 			$output .= '</div>';
 		}

--- a/lib/navis-slideshows/navis-slideshows.php
+++ b/lib/navis-slideshows/navis-slideshows.php
@@ -28,7 +28,8 @@ class Navis_Slideshows {
 	public $slideshows = 0;
 
 	function __construct() {
-		add_action( 'init', array( &$this, 'add_slideshow_header' ) );
+
+		/* All CSS & JS enqueues have been moved to largo/inc/enqueue.php */
 
 		add_filter(
 			'post_gallery', array( &$this, 'handle_slideshow' ), 10, 2
@@ -42,14 +43,6 @@ class Navis_Slideshows {
 		add_shortcode('gallery', array(&$this, 'handle_slideshow'), 10, 2);
 	}
 
-	function add_slideshow_header() {
-		$slides_css = get_template_directory_uri() . '/lib/navis-slideshows/css/slides.css';
-		wp_enqueue_style('navis-slides', $slides_css, array(), '1.0');
-
-		$slick_css = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.css';
-		wp_enqueue_style('navis-slick', $slick_css, array(), '1.0');
-	}
-
 	/**
 	 *
 	 * @uses global $post WP Post object
@@ -61,14 +54,6 @@ class Navis_Slideshows {
 		global $post;
 
 		$this->slideshows += 1;
-
-		// jQuery slides plugin, available at http://slidesjs.com/
-		$slides_src = get_template_directory_uri() . '/lib/navis-slideshows/vendor/slick/slick.min.js';
-		wp_enqueue_script('jquery-slick', $slides_src, array('jquery'), '3.0', true);
-
-		// our custom js
-		$show_src = get_template_directory_uri() . '/lib/navis-slideshows/js/navis-slideshows.js';
-		wp_enqueue_script('navis-slideshows', $show_src, array('jquery-slick'), '0.1', true);
 
 		$attr = shortcode_atts( array(
 			'order' => 'ASC',
@@ -128,9 +113,11 @@ class Navis_Slideshows {
 			}
 		}
 
-		$column_label = 'one-up';
+		$column_label = 'none-up';
 		if ( !empty( $columns ) ) {
-			if ($columns == '1') {
+			if ($columns == '0') {
+				$columns = 'none';
+			} else if ($columns == '1') {
 				$columns = 'one';
 			} else if ($columns == '2') {
 				$columns = 'two';
@@ -148,7 +135,7 @@ class Navis_Slideshows {
 				$columns = 'eight';
 			} else if ($columns == '9') {
 				$columns = 'nine';
-			} 
+			}
 
 			$column_label = $columns . '-up';
 		} 


### PR DESCRIPTION
## Changes:
* Modified the media view settings to ajust the number of column options from 1-9 to 0-4. Zero (0) will create a slideshow, the others (1-4) will create a grid layout.
    * Added lib/navis-slideshows/js/navis-columns.js to adjust the column numbers.
    * Added `theme_gallery_defaults` filter and `gallery_zero_columns` action to functions.php.
* Moved gallery enqueques from lib/navis-slideshows/navis-slideshows.php to inc/enqueue.php to allow single images to use the lightbox functionality.
* In lib/navis-slideshows/navis-slideshows.php:
    * Removed enqueues and functions referencing them.
    * Changed `one-up` to `none-up` and `$columns == '1'` to `$columns == '0'` to use the new zero-column option to create the sliders.
    * Changed `h6` tags to `p.wp-media-credit` or `p.permalink` to take advantage of largo default styles.
    * Moved permalink output after caption output. 
* In lib/navis-slideshows/js/navis-slideshows.js: 
  * Changed `one-up` classes to `none-up` to use the new zero-column option.
  * Added single-image lightbox functionality, notably the `$('article.post img').each(function() {}` loop in doc ready.
  * Click event binding/unbinding to `.slick-slide` class to allow image click progression through slides.
* In lib/navis-slideshows/css/slides.css:
  * Removed all `h6` styles.
  * Removed misplaced `display:none` on media credits.
  * Rewrote media queries for grid layouts 1-4: `.largo-img-grid.one-up>div>div, .largo-img-grid.two-up>div>div, .largo-img-grid.three-up>div>div, .largo-img-grid.four-up>div>div` etc.
  * Removed all unnecessary font styles.
* In total, these changes affected the following files:      
    * functions.php
    * inc/enqueue.php 
    * lib/navis-slideshows/
        * navis-slideshows.php
    * lib/navis-slideshows/css/
        * slides.css
    * lib/navis-slideshows/js/
        * navis-columns.js
        * navis-slideshows.js

     
## Features
This update encompasses two main enhancements: adding the lightbox view to single images, and making the gallery/grid-view setup more user-friendly and consistent. New features:

* Grid views auto focus on lightbox slideshows (so users can arrow through)
* All galleries have image-click slideshow advancing
* One-up grids display as a vertical list of photos down the page
* Column selection for slideshows and grid views is more straight-forward (0=slideshow, 1-4=grid, default=0)
* Three-up grid views function as expected (fixed bug with default column number)
* Single images have pop-out lightboxes
* Grid view responsive layouts work better (one-up grids are designed for horizontal photos –f vertical photos are necessary, don't use a gallery)
* Linked images function as follows: media file = opens in lightbox; attachment page = navigates to url; custom url = navigates to url; none = opens in lightbox

