### PR TITLE
Featured image performance

### DIFF
--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -216,36 +216,6 @@ function largo_remove_hero( $content ) {
 }
 add_filter( 'the_content', 'largo_remove_hero', 1 );
 
-
-/**
- * Retrieves the attachment ID from the file URL
- * (or that of any thumbnail image)
- *
- * @since 0.4
- * @see https://pippinsplugins.com/retrieve-attachment-id-from-image-url/
- *
- * @return Int ID of post attachment (or false if not found)
- */
-function largo_url_to_attachmentid( $url ) {
-
-	global $wpdb;
-	$attachment = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $url ) );
-
-	if ( ! empty( $attachment ) ) {
-		return $attachment[0];
-	}
-
-	// Check if there's a size in the url and remove it.
-	$url = preg_replace( '/-\d+x\d+(?=\.(jpg|jpeg|png|gif)$)/i', '', $url );
-	$attachment = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $url ) );
-
-	if ( ! empty( $attachment ) ) {
-		return $attachment[0];
-	} else {
-		return false;
-	}
-}
-
 /**
  * Given a post type and an optional context, return the partial that should be loaded for that sort of post.
  *

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -53,18 +53,18 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
 		$attachment_url = $attachment_url[0];
 
-		$c1 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large" /></p>
+		$c1 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 
 		$c1final = '<h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 
-		$c2 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium" /></p>
+		$c2 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 
-		$c2final = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium" /></p>
+		$c2final = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 
@@ -76,7 +76,7 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 
 		$final1 = largo_remove_hero( $c1 );
 		$final2 = largo_remove_hero( $c2 );
-		$this->assertEquals( $c1final, $final1  );
+		$this->assertEquals( $c1final, $final1 );
 		$this->assertEquals( $c2final, $final2 );
 
 	}

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -36,10 +36,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete( 'This test has not yet been implemented.' );
 	}
 
-	function test_largo_url_to_attachmentid() {
-		$this->markTestIncomplete( 'This test has not yet been implemented.' );
-	}
-
 	private $ids = array();
 
 	function test_insert_image_no_thumb() {


### PR DESCRIPTION
## The Problem
We're running a filter on post body content that checks if the post starts with an image, and if that image matches the post's featured image, removes the content from the post display (to prevent duplicate displays of that featured image).

The issue is the method we're running that check. Currently, we're getting the source for the image in the post body, then running a very slow query to lookup that image's ID in the database. This type of query/logic cannot continue to exist for performance reasons.

## The solution
Every image inserted by the media editor should have a `wp-image-##` class on it, where `##` is the id of the media file. By pulling this ID out with regex, we can achieve the same effect, but avoid expensive queries.

## Potential Downsides
If the html for the image has been manipulated or inserted by hand so that it does not include the `wp-image-##` class, then this obviously won't work.