### PR TITLE
suppress filters that cause errors

### DIFF
--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -76,6 +76,9 @@ class largo_recent_posts_widget extends WP_Widget {
 			);
 		}
 
+		$query_args['no_found_rows'] = 1;
+		$query_args['suppress_filters'] = 1;
+
 		echo '<ul>';
 
 		$my_query = new WP_Query( $query_args );


### PR DESCRIPTION
I'm really on the fence about including this, but it's causing some _weird_ errors clashing with the link roundups plugin that don't appear to be fixable in the link roundups plugin.