### PR TITLE
Exclude the current post from yet another area where we're creating lists of IDs

### DIFF
--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -758,8 +758,11 @@ class Largo_Related {
 		while ( $q->have_posts() ) {
 			$q->the_post();
 			// add this post if it's new
-			if ( ! in_array( $q->post->ID, $this->post_ids ) ) {	// only add it if it wasn't already there
-				$this->post_ids[] = (int) trim( $q->post->ID );
+			if (
+				! in_array( $q->post->ID, $this->post_ids ) 	// only add it if it wasn't already there
+				&& $q->post->ID != $this->post_id // do not add the id of the current post, because we do not want to ever return that
+			) {
+				$this->post_ids[] = (int) trim($q->post->ID);
 				// stop if we have enough
 				if ( $this->have_enough_posts() ) return;
 			}

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -762,7 +762,7 @@ class Largo_Related {
 				! in_array( $q->post->ID, $this->post_ids ) 	// only add it if it wasn't already there
 				&& $q->post->ID != $this->post_id // do not add the id of the current post, because we do not want to ever return that
 			) {
-				$this->post_ids[] = (int) trim($q->post->ID);
+				$this->post_ids[] = (int) trim( $q->post->ID );
 				// stop if we have enough
 				if ( $this->have_enough_posts() ) return;
 			}


### PR DESCRIPTION
## Changes

- exclude the current post's ID from the list of ids generated by `add_from_query`, the method of the class that is responsible for generating lists of IDs in multiple parts of the `Largo_Related` class.

## Why

Something in one of the two calls to `WP_Query` in [`Largo_Related->get_series_posts()`](https://github.com/INN/Largo/blob/v0.5.5.2/inc/related-content.php#L545-L604) is ignoring the `post__not_in` argument on the query, so now I'm going to just exclude the current post's post ID from ever being added to the list of IDs

This is because of HelpScout ticket 559, and is a continuation of issue #1381 and the work done in PR #1385.