### PR TITLE
Return support for PHP versions less than 5.5, and add 7.0 to the Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,13 @@ language: php
 php:
     - "5.3"
     - "5.5"
+    - "7.0"
 
 # WordPress version used in first build configuration.
 env:
     - WP_VERSION=master
     - WP_VERSION=4.6
     - WP_VERSION=4.5
-    - WP_VERSION=4.4
-    - WP_VERSION=4.3
-    - WP_VERSION=4.2
-    - WP_VERSION=4.1
 
 # Only test the unittests branch for now
 branches:

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -283,13 +283,13 @@ function largo_render_template( $slug, $name = null, $context = array() ) {
 /**
  * Get the current URL, including the protocol and host
  *
- * @since 0.5.5.4
+ * @since 0.5
  */
 function largo_get_current_url() {
 	$is_ssl = is_ssl();
 	$url = $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
 
-	if (!empty($is_ssl)) {
+	if ( ! empty( $is_ssl ) ) {
 		return "https://" . $url;
 	} else {
 		return "http://" . $url;

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -283,12 +283,18 @@ function largo_render_template( $slug, $name = null, $context = array() ) {
 /**
  * Get the current URL, including the protocol and host
  *
- * @since 0.5
+ * @since 0.5.5.4
  */
- function largo_get_current_url() {
- 	$url = $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
- 	return ( ! empty( is_ssl() ) ) ? 'https://' . $url : 'http://' . $url;
- }
+function largo_get_current_url() {
+	$is_ssl = is_ssl();
+	$url = $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+
+	if (!empty($is_ssl)) {
+		return "https://" . $url;
+	} else {
+		return "http://" . $url;
+	}
+}
 
 /**
  * Return the first featured image thumbnail found in a given array of WP_Posts


### PR DESCRIPTION
## Changes

- Reverts changes from #1407 to the `return` portion of `largo_get_current_url()` because of #1410, but keeps the `$url` portion because it's a nice "Don't Repeat Yourself" thing.
- Adds PHP version 7.0 to Travis (does not add 7.1)
- Removes WordPress versions 4.1, 4.2, 4.3, and 4.4. 

## Why

- `return` fix because of https://github.com/INN/Largo/pull/1407#discussion_r105945697
- add 7.0 because of https://secure.php.net/supported-versions.php
- don't add 7.1 yet because we don't want to slam travis too badly
- keep PHP 5.x because WordPress still supports down to 5.2: https://wordpress.org/about/requirements/