### PR TITLE
Put all theme file requires into an array

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -154,7 +154,6 @@ $requires = array(
 	'/inc/customizer/customizer.php', // Customizer additions
 	'/inc/jetpack.php', // Jetpack compatibility file
 	'/inc/settings.php', // Additional site settings
-	// widgets
 	'/inc/widgets/author-bio.php',
 	'/inc/widgets/site-description.php',
 );

--- a/functions.php
+++ b/functions.php
@@ -145,37 +145,19 @@ function largo_scripts() {
 add_action( 'wp_enqueue_scripts', 'largo_scripts' );
 
 /**
- * Implement the Custom Header feature.
+ * Require_once all Largo files
  */
-require get_template_directory() . '/inc/custom-header.php';
-
-/**
- * Custom template tags for this theme.
- */
-require get_template_directory() . '/inc/template-tags.php';
-
-/**
- * Custom functions that act independently of the theme templates.
- */
-require get_template_directory() . '/inc/extras.php';
-
-/**
- * Customizer additions.
- */
-require get_template_directory() . '/inc/customizer/customizer.php';
-
-/**
- * Load Jetpack compatibility file.
- */
-require get_template_directory() . '/inc/jetpack.php';
-
-/**
- * Load additional site settings.
- */
-require get_template_directory() . '/inc/settings.php';
-
-/**
- * Widgets
- */
-require get_template_directory() . '/inc/widgets/author-bio.php';
-require get_template_directory() . '/inc/widgets/site-description.php';
+$requires = array(
+	'/inc/custom-header.php', // Custom Header feature
+	'/inc/template-tags.php', // Custom template tags for this theme
+	'/inc/extras.php', // Custom functions that act independently of the theme templates
+	'/inc/customizer/customizer.php', // Customizer additions
+	'/inc/jetpack.php', // Jetpack compatibility file
+	'/inc/settings.php', // Additional site settings
+	// widgets
+	'/inc/widgets/author-bio.php',
+	'/inc/widgets/site-description.php',
+);
+foreach ( $requires as $require_once ) {
+	require_once( get_template_directory() . $require_once );
+}


### PR DESCRIPTION
## Changes

- individual `require` statements are now wrapped into one
- `require` replaced with `require_once`

## Why

- to simply the process of adding new files to be included in the future
- switch from require to require_once because we shouldn't load these files again if a child theme has loaded them for whatever reason.