### PR TITLE
Import the var_log function from Old Largo

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -37,3 +37,15 @@ function largo_pingback_header() {
 	}
 }
 add_action( 'wp_head', 'largo_pingback_header' );
+
+/**
+ * Send anything to the error log in a human-readable format
+ *
+ * @param 	mixed $stuff the stuff to be sent to the error log.
+ * @since 	0.4
+ */
+if (!  function_exists( 'var_log' ) ) {
+	function var_log( $stuff ) {
+		error_log( var_export( $stuff, true ) );
+	}
+}


### PR DESCRIPTION
`var_log` has been in Largo since 0.4 as a debugging aid; while it's not necessary for any functionality it's nice to not have to write `error_log(var_export( $thing, true));` every time. I'd like to keep it in.