### PR TITLE
updating largo analytics from classic tracking to universal

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -230,31 +230,21 @@ if ( ! function_exists( 'largo_google_analytics' ) ) {
 	function largo_google_analytics() {
 		if ( !current_user_can('edit_posts') ) : // don't track editors ?>
 			<script>
-			    var _gaq = _gaq || [];
 			<?php if ( of_get_option( 'ga_id', true ) ) : // make sure the ga_id setting is defined ?>
-				_gaq.push(['_setAccount', '<?php echo of_get_option( "ga_id" ) ?>']);
-				_gaq.push(['_trackPageview']);
+				ga( 'create', '<?php echo of_get_option( "ga_id" ) ?>', 'auto' );
+				ga( 'send', 'pageview' );
 			<?php endif; ?>
 				<?php if (defined('INN_MEMBER') && INN_MEMBER) { ?>
-				_gaq.push(
-					["inn._setAccount", "UA-17578670-2"],
-					["inn._setCustomVar", 1, "MemberName", "<?php bloginfo('name') ?>"],
-					["inn._trackPageview"]
-				);
+				ga( 'create', 'UA-17578670-2', 'auto' );
+				ga( 'send', 'pageview' );
 				<?php } ?>
-			    _gaq.push(
-					["largo._setAccount", "UA-17578670-4"],
-					["largo._setCustomVar", 1, "SiteName", "<?php bloginfo('name') ?>"],
-					["largo._setDomainName", "<?php echo parse_url( home_url(), PHP_URL_HOST ); ?>"],
-					["largo._setAllowLinker", true],
-					["largo._trackPageview"]
-				);
+				ga( 'create', 'UA-17578670-4', 'auto' );
+				ga( 'send', 'pageview' );
 
-			    (function() {
-				    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-				    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-				    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-				})();
+				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+				})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 			</script>
 	<?php endif;
 	}


### PR DESCRIPTION
This changes the existing tracking code in largo_google_analytics (ga.js) to the new Universal tracking code (analytics.js).

Any UA- codes added by users in the WP dashboard will now be tracked via Universal analytics.