### PR TITLE
Remove PHP short tags

### DIFF
--- a/search.php
+++ b/search.php
@@ -13,7 +13,7 @@ get_header();
 			?>
 		</h1>
 
-		<?
+		<?php
 			/**
 			 * Fires before the Google Custom Search container
 			 *
@@ -67,7 +67,7 @@ get_header();
 			<?php } ?>
 		</div>
 
-		<?
+		<?php
 			/**
 			 * Fires after the Google Custom Search container
 			 *


### PR DESCRIPTION
Fixes https://github.com/INN/largo/issues/1459

I searched the repo for other cases of short tags and didn't find any:

`$ egrep -ir '<\?$' *`

 Theme Check output agrees.