### PR TITLE
Improve docs for the homepage-bottom widget area

### DIFF
--- a/inc/sidebars.php
+++ b/inc/sidebars.php
@@ -77,7 +77,7 @@ function largo_register_sidebars() {
 	if ( of_get_option('homepage_bottom') == 'widgets' ) {
 		$sidebars[] = array(
 			'name' 	=> __( 'Homepage Bottom', 'largo' ),
-			'desc' 	=> __( 'An optional widget area at the bottom of the homepage', 'largo' ),
+			'desc' 	=> __( 'An optional widget area at the bottom of the homepage, enabled when you choose the widget area homepage bottom in Theme Options > Layout', 'largo' ),
 			'id' 	=> 'homepage-bottom'
 		);
 	}


### PR DESCRIPTION
Fixes an 'obviousness' deficiency in the purpose of the Homepage Bottom widget area, where it was unclear which widget area widgets should go into when using the widget area option for Theme Options > Layout > Homepage Bottom.

Because of https://secure.helpscout.net/conversation/452777097/1398/