### PR TITLE
Minor improvements to code quality in inc/term-sidebars.php

### DIFF
--- a/inc/term-meta.php
+++ b/inc/term-meta.php
@@ -33,7 +33,7 @@ function largo_get_term_meta_post( $taxonomy, $term_id ) {
 		'tax_query'      => array(
 			array(
 				'taxonomy'         => $taxonomy,
-				'field'            => 'id',
+				'field'            => 'term_id',
 				'terms'            => $term_id,
 				'include_children' => false
 			)

--- a/inc/term-sidebars.php
+++ b/inc/term-sidebars.php
@@ -1,23 +1,34 @@
 <?php
+/**
+ * File for Largo's Term Sidebars
+ *
+ * @package Largo
+ */
 
 /**
  * Display the fields for selecting icons for terms in the "post-type" taxonomy
  */
 class Largo_Term_Sidebars {
 
-	function __construct() {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
 		add_action( 'edit_category_form_fields', array( $this, 'display_fields' ) );
 		add_action( 'edit_tag_form_fields', array( $this, 'display_fields' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts') );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'edit_terms', array( $this, 'edit_terms' ), 10, 2 );
 		add_action( 'create_term', array( $this, 'edit_terms' ), 10, 2 );
 	}
 
 	/**
+	 * Return a list of taxonomies that term sidebars are enabled for
 	 *
+	 * @filter largo_get_sidebar_taxonomies
+	 * @return Array of taxonomy slugs
 	 */
-	function get_sidebar_taxonomies() {
-		if ( empty($this->_sidebar_taxonomies) ) {
+	public function get_sidebar_taxonomies() {
+		if ( empty( $this->_sidebar_taxonomies ) ) {
 			$this->_sidebar_taxonomies = apply_filters( 'largo_get_sidebar_taxonomies', array( 'category', 'post_tag', 'series' ) );
 		}
 		return $this->_sidebar_taxonomies;
@@ -25,27 +36,30 @@ class Largo_Term_Sidebars {
 
 	/**
 	 * Renders the form fields on the term's edit page
+	 *
+	 * @param WP_Term $term The term for which the fields should be displayed.
+	 * @return nothing
 	 */
-	function display_fields( $term ) {
-		if ( !in_array( $term->taxonomy, $this->get_sidebar_taxonomies() ) ) {
-			// abort if the term doesn't belong to the taxonomies to have icons
+	public function display_fields( $term ) {
+		if ( ! in_array( $term->taxonomy, $this->get_sidebar_taxonomies(), true ) ) {
+			// abort if the term doesn't belong to the taxonomies to have icons.
 			return;
 		}
 
-		//get the proxy post id
+		// get the proxy post id.
 		$post_id = largo_get_term_meta_post( $term->taxonomy, $term->term_id );
 		$current_value = largo_get_term_meta( $term->taxonomy, $term->term_id, 'custom_sidebar', true );
 		?>
 		<tr class="form-field">
-			<th scope="row" valign="top"><label for="custom_sidebar"><?php _e('Archive Sidebar', 'largo'); ?></label></th>
+			<th scope="row" valign="top"><label for="custom_sidebar"><?php esc_html_e( 'Archive Sidebar', 'largo' ); ?></label></th>
 			<td>
 				<select name="custom_sidebar" id="custom_sidebar" style="min-width: 300px;">
-					<?php largo_custom_sidebars_dropdown( $current_value, false, $post_id ); //get the options ?>
+					<?php largo_custom_sidebars_dropdown( $current_value, false, $post_id ); // get a list of sidebar options. ?>
 				</select>
 				<br/>
-				<p class="description"><?php _e("The sidebar to display on this term's archive page.", 'largo'); ?></p>
+				<p class="description"><?php esc_html_e( 'The sidebar to display on this term\'s archive page.', 'largo' ); ?></p>
 				<?php
-				wp_nonce_field( 'custom_sidebar-'.$term->term_id, '_custom_sidebar_nonce' );
+					wp_nonce_field( 'custom_sidebar-' . $term->term_id, '_custom_sidebar_nonce' );
 				?>
 			</td>
 		</tr>
@@ -54,15 +68,17 @@ class Largo_Term_Sidebars {
 
 	/**
 	 * Renders the form fields for the new form creation on the term listing paga
+	 *
+	 * @param string $taxonomy unused.
 	 */
-	function display_add_new_field( $taxonomy ) {
+	public function display_add_new_field( $taxonomy ) {
 		?>
 		<div class="form-field">
-			<label for="custom_sidebar"><?php _e('Archive Sidebar', 'largo'); ?></label>
+			<label for="custom_sidebar"><?php esc_html_e( 'Archive Sidebar', 'largo' ); ?></label>
 			<select name="custom_sidebar" id="custom_sidebar" style="min-width: 300px;">
-				<?php largo_custom_sidebars_dropdown( '', false, 0 ); //get the options ?>
+				<?php largo_custom_sidebars_dropdown( '', false, 0 ); // get the options. ?>
 			</select>
-			<p class="description"><?php _e('The sidebar to show on this term\'s archive.', 'largo'); ?></p>
+			<p class="description"><?php esc_html_e( 'The sidebar to show on this term\'s archive.', 'largo' ); ?></p>
 			<?php wp_nonce_field( 'custom_sidebar-new', '_custom_sidebar_nonce' ); ?>
 		</div>
 		<?php
@@ -70,16 +86,20 @@ class Largo_Term_Sidebars {
 
 	/**
 	 * Attach the Javascript and Stylesheets to the term edit page
+	 *
+	 * @param string $hook_suffix what page we're running this on.
 	 */
-	function admin_enqueue_scripts( $hook_suffix ) {
+	public function admin_enqueue_scripts( $hook_suffix ) {
+		// @todo: does this need nonce verification?
+		$taxonomy = wp_unslash( $_REQUEST['taxonomy'] );
 
-		if ( $hook_suffix == 'edit-tags.php' && !empty($_REQUEST['taxonomy']) ) {
-			if ( !in_array( $_REQUEST['taxonomy'], $this->get_sidebar_taxonomies() ) ) {
-				// abort if the term doesn't belong to the taxonomies to have icons
+		if ( 'edit-tags.php' === $hook_suffix && ! empty( $taxonomy ) ) {
+			if ( ! in_array( $taxonomy, $this->get_sidebar_taxonomies(), true ) ) {
+				// abort if the term doesn't belong to the taxonomies to have icons.
 				return;
 			}
 
-			add_action( $_REQUEST['taxonomy'].'_add_form_fields', array( $this, 'display_add_new_field' ) );
+			add_action( $taxonomy . '_add_form_fields', array( $this, 'display_add_new_field' ) );
 		}
 	}
 
@@ -87,18 +107,24 @@ class Largo_Term_Sidebars {
 	 * Save the results from the term edit page
 	 *
 	 * @filter edit_terms
+	 * @param int|string $term_id  the term ID.
+	 * @param string     $taxonomy the taxonomy of the term.
 	 */
-	function edit_terms( $term_id, $taxonomy ) {
-		if (isset($_POST['action']) && $_POST['action'] == 'add-tag')
+	public function edit_terms( $term_id, $taxonomy ) {
+		// nonce verification comes later in this function.
+		if ( isset( $_POST['action'] ) && 'add-tag' === $_POST['action'] ) {
 			$nonce_action = 'custom_sidebar-new';
-		else
+		} else {
 			$nonce_action = 'custom_sidebar-' . $term_id;
+		}
 
-		if ( isset($_POST['_custom_sidebar_nonce']) && wp_verify_nonce($_POST['_custom_sidebar_nonce'], $nonce_action ) ) {
-			if ( ! isset( $taxonomy ) ) {
-				$taxonomy = $_REQUEST['taxonomy'];
-			}
-			largo_update_term_meta( $taxonomy, $term_id, 'custom_sidebar', $_POST['custom_sidebar'] );
+		if ( isset( $_POST['_custom_sidebar_nonce'] ) && wp_verify_nonce( wp_unslash( $_POST['_custom_sidebar_nonce'] ), $nonce_action ) ) {
+			// @todo: better verification/sanitization of this
+			$sidebar = wp_unslash( $_POST['custom_sidebar'] );
+
+			// @todo: make sure that the taxonomy is one that is valid for getting sidebars
+
+			largo_update_term_meta( $taxonomy, $term_id, 'custom_sidebar', $sidebar );
 		}
 	}
 }

--- a/inc/term-sidebars.php
+++ b/inc/term-sidebars.php
@@ -9,8 +9,8 @@ class Largo_Term_Sidebars {
 		add_action( 'edit_category_form_fields', array( $this, 'display_fields' ) );
 		add_action( 'edit_tag_form_fields', array( $this, 'display_fields' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts') );
-		add_action( 'edit_terms', array( $this, 'edit_terms' ) );
-		add_action( 'create_term', array( $this, 'edit_terms' ) );
+		add_action( 'edit_terms', array( $this, 'edit_terms' ), 10, 2 );
+		add_action( 'create_term', array( $this, 'edit_terms' ), 10, 2 );
 	}
 
 	/**
@@ -85,15 +85,19 @@ class Largo_Term_Sidebars {
 
 	/**
 	 * Save the results from the term edit page
+	 *
+	 * @filter edit_terms
 	 */
-	function edit_terms( $term_id ) {
+	function edit_terms( $term_id, $taxonomy ) {
 		if (isset($_POST['action']) && $_POST['action'] == 'add-tag')
 			$nonce_action = 'custom_sidebar-new';
 		else
 			$nonce_action = 'custom_sidebar-' . $term_id;
 
 		if ( isset($_POST['_custom_sidebar_nonce']) && wp_verify_nonce($_POST['_custom_sidebar_nonce'], $nonce_action ) ) {
-			$taxonomy = $_REQUEST['taxonomy'];
+			if ( ! isset( $taxonomy ) ) {
+				$taxonomy = $_REQUEST['taxonomy'];
+			}
 			largo_update_term_meta( $taxonomy, $term_id, 'custom_sidebar', $_POST['custom_sidebar'] );
 		}
 	}


### PR DESCRIPTION
## Changes:

- adds docblocks
- adds method visibility
- sanitizes and validates some things that weren't
- adds `@todo` comments where we can do better
- cleans up code style in accordance with https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
- corrects line where we were querying for _term_meta posts by the invalid item `id` &mdash; this wasn't causing problems because the default value there is `term_id`, which was what we were querying by anyways.

## Why

- code quality
- I was in this file anyways and wanted to make sure that stuff in this file wasn't the cause of the bugs I was experiencing (https://github.com/INN/umbrella-energynewsnetwork/pull/40)