### PR TITLE
Update Travis CI config, fix broken tests, update README, and diverse minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,3 @@ before_script:
     - cd "$WP_CORE_DIR/src/wp-content/themes/$SLUG"
 
 script: phpunit
-
-notifications:
-    hipchat:
-        rooms:
-            secure: mrJDwl2LYmWGY6gKUEsSnbGp3mQ8UhVQkb9oBmRSDx9T/hCSDx4Q2KDLo0OqCFIwDB5BevP16vDDWVmsg8Ldwk+Hh0YAmdUqBAXe21+17ojqSIAdQg6LgLrEFEBNVBlPu89xonRMnsai34RDCoRt5c9OLuWgGVMAcTojpQvPiII=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,60 @@ sudo: false
 language: php
 
 # PHP version used in first build configuration.
-# 5.3 matches the version of php installed in the INN/deploy-tools virtualbox
-# 5.5 matches http://phpinfo.wpengine.com/
-php:
-    - "5.3"
-    - "5.5"
+# We only support PHP-supported versions of PHP.
+# https://secure.php.net/supported-versions.php
+# php:
+#     - "5.6"
+#     - "7.0"
+#     - "7.1"
+#     - "7.2"
 
 # WordPress version used in first build configuration.
-env:
-    - WP_VERSION=master
-    - WP_VERSION=4.6
-    - WP_VERSION=4.5
-    - WP_VERSION=4.4
-    - WP_VERSION=4.3
-    - WP_VERSION=4.2
-    - WP_VERSION=4.1
+# env:
+#     - WP_VERSION=master
+#     - WP_VERSION=4.9
+#     - WP_VERSION=4.8
+#     - WP_VERSION=4.7
+#     - WP_VERSION=4.6
+#     - WP_VERSION=4.5
 
-# Only test the unittests branch for now
+# For a breakdown of why these versions were chosen, see https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094
+# This list should be rechecked periodically.
+matrix:
+    include:
+      # PHPunit 5
+      - php: 5.6
+        env: WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 5.6
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
+      - php: 7.0
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.0
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 6
+      - php: 7.1
+        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # PHPUnit 7 support will come with https://core.trac.wordpress.org/ticket/43218
+      # - php: 7.2
+      #   env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # - php: 7.2
+      #   env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+
+
+# Only test the main development branches for now
 branches:
     only:
-        - develop
-        - master
+        - 0.5
+        - 0.5-dev
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -28,3 +28,27 @@ if ( ! function_exists( 'largo_hero_with_caption' ) ) {
 		largo_featured_image_hero($post_id);
 	}
 }
+
+/**
+ * Deprecated function to check whether a Facebook user/page was followable.
+ *
+ * This function used to use the Facebook Follow button's HTML markup
+ * https://developers.facebook.com/docs/archive/docs/plugins/follow-button/
+ * to determine whether a page or user could be followed. The button was
+ * deprecated by Facebook on February 5, 2018, and as a result, this function
+ * stopped working.
+ *
+ * There are no plans to provide similar functionality in the future, because
+ * the relevant Facebook Graph API calls require Facebook API tokens,
+ * and it seems excessive to require theme users to get one just for this check.
+ *
+ * @param   string  $username a valid Facebook username or page name. They're generally indistinguishable, except pages get to use '-'
+ * @return  bool    False
+ */
+function largo_fb_user_is_followable( $username = '' ) {
+	if ( WP_DEBUG || LARGO_DEBUG ) {
+		error_log( 'largo_db_user_is_followable is deprecated and should not be used.' );
+	}
+	return false;
+}
+

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -28,29 +28,6 @@ function largo_fb_url_to_username( $url )  {
 }
 
 /**
- * Checks to see if a given Facebook username or ID has following enabled by
- * checking the iframe of that user's "Follow" button for <table>.
- * Usernames that can be followed have <tables>.
- * Users that can't be followed don't.
- * Users that don't exist don't.
- *
- * @param   string  $username a valid Facebook username or page name. They're generally indistinguishable, except pages get to use '-'
- * @uses    wp_remote_get
- * @return  bool    The user specified by the username or ID can be followed
- */
-function largo_fb_user_is_followable( $username ) {
-	// syntax for this iframe taken from https://developers.facebook.com/docs/plugins/follow-button/
-	$get = wp_remote_get( 'https://www.facebook.com/plugins/follow.php?href=https%3A%2F%2Fwww.facebook.com%2F' . $username . '&amp;width&amp;height=80&amp;colorscheme=light&amp;layout=button&amp;show_faces=true' );
-	if ( ! is_wp_error( $get ) ) {
-		$response = $get['body'];
-		if ( strpos( $response, 'table' ) !== false ) {
-			return true; // can follow
-		}
-		return false; // cannot follow
-	}
-}
-
-/**
  * Cleans a Facebook url to the bare username or id when the user is edited
  *
  * Edits $_POST directly because there's no other way to save the corrected username
@@ -84,7 +61,6 @@ function clean_user_fb_username( $user_id ) {
  * Checks that the Facebook URL submitted is valid and the user is followable and causes an error if not
  *
  * @uses  largo_fb_url_to_username
- * @uses  largo_fb_user_is_followable
  * @param   $errors the error object
  * @param   bool    $update whether this is a user update
  * @param   object  $user a WP_User object
@@ -99,9 +75,6 @@ function validate_fb_username( $errors, $update, $user ) {
 			if ( preg_match( '/[^a-zA-Z0-9\.\-]/', $fb_user ) ) {
 				// it's not a valid Facebook username, because it uses an invalid character
 				$errors->add( 'fb_username', '<b>' . $fb_suspect . '</b> ' . __( 'is an invalid Facebook username.', 'largo' ) . '</p>' . '<p>' . __('Facebook usernames only use the uppercase and lowercase alphabet letters (a-z A-Z), the Arabic numbers (0-9), periods (.) and dashes (-)', 'largo' ) );
- 			}
- 			if ( ! largo_fb_user_is_followable( $fb_user ) ) {
- 				$errors->add( 'fb_username',' <b>' . $fb_suspect . '</b> ' . __( 'does not allow followers on Facebook.', 'largo' ) . '</p>' . '<p>' . __('<a href="https://www.facebook.com/help/201148673283205#How-can-I-let-people-follow-me?">Follow these instructions</a> to allow others to follow you.', 'largo' ) );
  			}
  		}
 	}

--- a/inc/post-social.php
+++ b/inc/post-social.php
@@ -32,7 +32,7 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 
 		$values = get_post_custom( $post->ID );
 
-		if ( $utilities['facebook'] === '1' ) {
+		if ( isset( $utilities['facebook'] ) && '1' === $utilities['facebook'] ) {
 			$fb_share = '<span class="facebook"><a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u=%1$s"><i class="icon-facebook"></i><span class="hidden-phone">%2$s</span></a></span>';
 			$output .= sprintf(
 				$fb_share,
@@ -41,7 +41,7 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 			);
 		}
 
-		if ( $utilities['twitter'] === '1' ) {
+		if ( isset( $utilities['twitter'] ) && '1' === $utilities['twitter'] ) {
 			$twitter_share = '<span class="twitter"><a target="_blank" href="https://twitter.com/intent/tweet?text=%1$s&url=%2$s%3$s"><i class="icon-twitter"></i><span class="hidden-phone">%4$s</span></a></span>';
 
 			// By default, don't set a via.
@@ -86,8 +86,8 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 				__( 'Tweet', 'largo' )
 			);
 		}
-		
-		if ( $utilities['email'] === '1' ) {
+
+		if ( isset( $utilities['email'] ) && '1' === $utilities['email'] ) {
 			$output .= sprintf(
 				'<span data-service="email" class="email share-button"><a href="mailto:?subject=%2$s&body=%3$s%0D%0A%4$s" target="_blank"><i class="icon-mail"></i> <span class="hidden-phone">%1$s</span></a></span>',
 				esc_attr( __( 'Email', 'largo' ) ),
@@ -97,8 +97,7 @@ if ( ! function_exists( 'largo_post_social_links' ) ) {
 			);
 		}
 
-		
-		if ( $utilities['print'] === '1' ) {
+		if ( isset( $utilities['print'] ) && '1' === $utilities['print'] ) {
 			$output .= '<span class="print"><a href="#" onclick="window.print()" title="' . esc_attr( __( 'Print this article', 'largo' ) ) . '" rel="nofollow"><i class="icon-print"></i><span class="hidden-phone">' . esc_attr( __( 'Print', 'largo' ) ) . '</span></a></span>';
 		}
 

--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -207,7 +207,10 @@ function largo_remove_hero( $content ) {
 	$post_img_id = $matches[1];
 
 	if ( $featured_img_id === $post_img_id ) {
-		return str_replace( $matches[0], '', $content );
+		$minus_image = str_replace( $matches[0], '', $content );
+		// remove leading <p></p> tag, even if it contains HTML attributes,
+		// but not if it's not empty
+		return preg_replace( '/^<p[^>]?><\/p>/m', '', $minus_image, 1 );
 	}
 
 	return $content;

--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -195,8 +195,7 @@ function largo_remove_hero( $content ) {
 	// Creates the array:
 	// 		$matches[0] = <img src="..." class="..." id="..." />
 	//		$matches[1] = image id from class="wp-image-[id]"
-	//		$matches[2] = value of src.
-	$pattern = '/<img\s+[^>]*class="[^"]*?wp-image-(\d+)[^"]*?"\s+[^>]*src="([^"]*)"[^>]*>/';
+	$pattern = '/<img\s+[^>]*class="[^"]*?wp-image-(\d+)[^"]*?"\s+[^>]*[^>]*>/';
 	$has_img = preg_match( $pattern, $p[0], $matches );
 
 	// 3: if there's no image, there's nothing to worry about.

--- a/inc/post-templates.php
+++ b/inc/post-templates.php
@@ -210,7 +210,7 @@ function largo_remove_hero( $content ) {
 		$minus_image = str_replace( $matches[0], '', $content );
 		// remove leading <p></p> tag, even if it contains HTML attributes,
 		// but not if it's not empty
-		return preg_replace( '/^<p[^>]?><\/p>/m', '', $minus_image, 1 );
+		return trim( preg_replace( '/^<p[^>]?><\/p>/m', '', $minus_image, 1 ) );
 	}
 
 	return $content;

--- a/lib/options-framework/options-sanitize.php
+++ b/lib/options-framework/options-sanitize.php
@@ -38,10 +38,19 @@ function of_sanitize_checkbox( $input ) {
 }
 add_filter( 'of_sanitize_checkbox', 'of_sanitize_checkbox' );
 
-/* Multicheck */
-
+/**
+ * Multicheck sanitization function for the options framework
+ *
+ * This sanitizes the submitted option for a multiple-checkbox input
+ * based on the argument $option
+ *
+ * @since 0.1
+ * @param Array $input An array of options as descriped in the Options Framework.
+ * @param Array $option An array of valid checkbox values for the input
+ * @return Array sanitized options
+ */
 function of_sanitize_multicheck( $input, $option ) {
-	$output = '';
+	$output = array();
 	if ( is_array( $input ) ) {
 		foreach( $option['options'] as $key => $value ) {
 			$output[$key] = "0";

--- a/readme.md
+++ b/readme.md
@@ -56,13 +56,12 @@ If you're still not sure where to start, that's totally fine! [Just shoot us an 
 
 Built and maintained by the [Institute for Nonprofit News](http://inn.org) product and technology team ([@INNNerds](http://twitter.com/INNNerds)):
 
--  **[Adam Schweigert](https://github.com/aschweigert)** ([@aschweig](http://twitter.com/aschweig)), Senior Director of Product and Technology
--  **[RC Lations](https://github.com/rclations)** ([@rclations](https://twitter.com/rclations)), Lead Developer
--  **[Julia Smith](https://github.com/julia67)** ([@julia67](https://twitter.com/julia67)), Lead Designer
--  **[Ben Keith](https://github.com/benlk)** ([@benlkeith](http://twitter.com/benlkeith)), News Apps Developer
--  **[Gabriel Hongsdusit](https://github.com/gabehong)** ([@ghongsdusit](https://twitter.com/ghongsdusit)), Design Apprentice
+- **[Kay Lima](https://github.com/kaylima)**, Acting Director
+- **[Ben Keith](https://github.com/benlk)** ([@benlkeith](http://twitter.com/benlkeith)), Lead Developer
+- **[Tyler Machado](https://github.com/tylermachado)** ([@tylermachado](https://twitter.com/tylermachado)), Front-End Developer
+- **Paola Baradello**, Account Director
 
-Special thanks to everyone who has contributed to the project, including: [rnagle](https://github.com/rnagle), [kaeti](https://github.com/kaeti), [jackbrighton](http://github.com/jackbrighton), [danielbachhuber](http://github.com/danielbachhuber), [willhaynes](http://github.com/willhaynes), [drywall](http://github.com/drywall), [nacin](http://github.com/nacin), [meredithinn](http://github.com/meredithinn), [tothebeat](http://github.com/tothebeat), [lindamood](http://github.com/lindamood), [mospaw](http://github.com/mospaw), [DrewAPicture](http://github.com/drewapicture), [nipoez](http://github.com/nipoez), [palewire](http://github.com/palewire), [GaryJones](http://github.com/garyjones), [seamusleahy](http://github.com/seamusleahy), [joshuarrrr](http://github.com/joshuarrrr), [yayannabelle](https://github.com/yayannabelle), [jmusal](https://github.com/jmusal), [ntwb](https://github.com/ntwb) and [MsPseudolus](https://github.com/MsPseudolus).
+Special thanks to everyone who has contributed to the project, including: [rnagle](https://github.com/rnagle), [kaeti](https://github.com/kaeti), [jackbrighton](http://github.com/jackbrighton), [danielbachhuber](http://github.com/danielbachhuber), [willhaynes](http://github.com/willhaynes), [drywall](http://github.com/drywall), [nacin](http://github.com/nacin), [meredithinn](http://github.com/meredithinn), [tothebeat](http://github.com/tothebeat), [lindamood](http://github.com/lindamood), [mospaw](http://github.com/mospaw), [DrewAPicture](http://github.com/drewapicture), [nipoez](http://github.com/nipoez), [palewire](http://github.com/palewire), [GaryJones](http://github.com/garyjones), [seamusleahy](http://github.com/seamusleahy), [joshuarrrr](http://github.com/joshuarrrr), [yayannabelle](https://github.com/yayannabelle), [jmusal](https://github.com/jmusal), [ntwb](https://github.com/ntwb), [MsPseudolus](https://github.com/MsPseudolus), [@gabehong](https://github.com/gabehong), [@julia67](https://github.com/julia67), [@rclations](https://github.com/rclations), [@aschweigert Schweigert](https://github.com/aschweigert) and the whole news nerd and WordPress communities.
 
 This project builds on a number of great open source projects, including:
 

--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,11 @@ The project extends work done by [NPR's Project Argo](http://argoproject.org/).
 
 **Support** is available [via our helpdesk system](http://support.largoproject.org/) or by emailing [support@largoproject.org](mailto:support@largoproject.org).
 
-**Current version:** v0.5.5.2
+**Current version:** v0.5.5.4
 
-**Minimum supported PHP version:** 5.3
+**Minimum PHP version:** We only support the [currently-maintained versions of PHP](https://secure.php.net/supported-versions.php).
 
-**Minimum supported WordPress version:** 4.1, though we usually recommend using the current version of WordPress
+**Minimum supported WordPress version:** We recommend using [the current version of WordPress](https://wordpress.org/download/releases/). To see what versions of WordPress automated tests are run against, check out [the Travis CI configuration file](./.travis.yml).
 
 ## Setup
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Follow the [setup instructions in the documentation](http://largo.readthedocs.io
 
 ## Contributing
 
-We welcome contributions to any of open source projects. 
+We welcome contributions to any of our open source projects.
 
 If you're not sure where to start, [review the open issues on github](https://github.com/INN/Largo/issues) (you might be particularly interested in the issues labelled [help wanted](https://github.com/INN/Largo/labels/help%20wanted) or [good for beginners](https://github.com/INN/Largo/issues?q=label%3A%22good+for+beginners%22)) and then see [our contributing guidelines](/contributing.md) to get started.
 

--- a/tests/inc/test-helpers.php
+++ b/tests/inc/test-helpers.php
@@ -67,34 +67,13 @@ class HelpersTestFunctions extends WP_UnitTestCase {
 
 	function test_largo_fb_user_is_followable() {
 		/**
-		 * With no input, there should be no <table> in the resulting iframe
+		 * The function has been changed to always return false.
 		 */
-		$result = largo_fb_user_is_followable("");
-		$this->assertFalse($result, "The Facebook follow button iframe HTML structure has changed and largo_fb_url_to_username no longer operates predictably. Please fix.");
-		unset($result);
-
-		/**
-		 * With Mark Zuckerberg, we hope that he will remain followable.
-		 */
-		$result = largo_fb_user_is_followable("zuck");
-		$this->assertTrue($result, "Either Mark Zuckerberg is no longer followable, or the Facebook follow button iframe HTML structure has changed and largo_fb_url_to_username no longer operates predictably. Please log into Facebook and check that https://www.facebook.com/zuck has a 'Follow' button.");
-		unset($result);
-
-		/**
-		 * With a user that does not exist, we hope that the user will continue to not exist
-		 */
-		$result = largo_fb_user_is_followable("fb8c57ff40dda4b6898ae049d8298584");
-		$this->assertFalse($result, "Either https://www.facebook.com/fb8c57ff40dda4b6898ae049d8298584 is user that exists and allows follows, or the Facebook follow button iframe HTML structure has changed and largo_fb_url_to_username no longer operates predictably.");
-		unset($result);
-
-		/**
-		 * With an invalid username, this should return false
-		 */
-		$result = largo_fb_user_is_followable("%22Aardvarks+lurk%2C+OK%3F%22");
-		$this->assertFalse($result, "Either https://www.facebook.com/%22Aardvarks+lurk%2C+OK%3F%22 is user that exists and allows follows (not at all likely), or the Facebook follow button iframe HTML structure has changed and largo_fb_url_to_username no longer operates predictably.");
+		$result = largo_fb_user_is_followable( 'zuck' );
+		$this->assertFalse($result, "largo_fb_user_is_followable doesn't work, so it shouldn't be returning anything other than False. What changed?");
 		unset($result);
 	}
-	
+
 	function test_clean_user_fb_username() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -53,32 +53,49 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
 		$attachment_url = $attachment_url[0];
 
+		// create our post and set it up.
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, '_thumbnail_id', $attachment_id );
+		$this->go_to( '/?p=' . $post_id );
+
+		// with a post set up like so, remove the thing
 		$c1 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-
 		$c1final = '<h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$final1 = largo_remove_hero( $c1 );
+		$this->assertEquals( $c1final, $final1, "C1" );
 
+		// with a post set up like so, remove the thing
+		// @todo: how is this setup different that the above setup?
 		$c2 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-
 		$c2final = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-
-		$post_id = $this->factory->post->create();
-
-		add_post_meta( $post_id, '_thumbnail_id', $attachment_id );
-
-		$this->go_to( '/?p=$post_id' );
-
-		$final1 = largo_remove_hero( $c1 );
 		$final2 = largo_remove_hero( $c2 );
-		$this->assertEquals( $c1final, $final1, "C1" );
 		$this->assertEquals( $c2final, $final2, "C2" );
 
+		// test for https://github.com/INN/largo/pull/1503#issuecomment-407901229
+		// if the opening paragraph tag contains a matching image and other stuff,
+		// remove the matching image but nothing else
+		$c3 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" />foo</p>
+<h2>Headings</h2>
+<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$c3final = '<p>foo</p>
+<h2>Headings</h2>
+<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$final3 = largo_remove_hero( $c3 );
+		$this->assertEquals( $c3final, $final3, "C3" );
+
+		// don't remove the image if it doesn't match the attachment URL
+		$c4 = '<p><img src="https://upload.wikimedia.org/wikipedia/commons/4/4a/Dr._James_Naismith.jpg" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
+<h2>Headings</h2>
+<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$final4 = largo_remove_hero( $c4 );
+		$this->assertEquals( $c4, $final4, "C4" );
 	}
 
 	function _make_attachment( $upload, $parent_post_id = 0 ) {

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -76,8 +76,8 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 
 		$final1 = largo_remove_hero( $c1 );
 		$final2 = largo_remove_hero( $c2 );
-		$this->assertEquals( $c1final, $final1 );
-		$this->assertEquals( $c2final, $final2 );
+		$this->assertEquals( $c1final, $final1, "C1" );
+		$this->assertEquals( $c2final, $final2, "C2" );
 
 	}
 

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -23,6 +23,37 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete( 'This test has not yet been implemented.' );
 	}
 
+	// returns unchanged when:
+	//     global $post is not set
+	function test_largo_remove_hero_C0() {
+		//     the current $post does not have a featured media thumbnail
+		//     of_get_option('single_template') is not normal or classic
+		//     the first paragraph of the post contents doesn't have an image
+		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
+		//
+		// Otherwise, the first paragraph is removed from the post contents
+
+		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
+		$contents = file_get_contents( $filename );
+
+		$upload = wp_upload_bits( basename( $filename ), null, $contents );
+
+		print_r( $upload['error'] );
+		$this->assertTrue( empty( $upload['error'] ) );
+
+		$attachment_id = $this->_make_attachment( $upload );
+
+		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
+		$attachment_url = $attachment_url[0];
+
+		// with a post set up like so, remove the thing
+		$c0 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
+<h2>Headings</h2>
+<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$final1 = largo_remove_hero( $c0 );
+		$this->assertEquals( $c0, $final0, "C0" );
+	}
+
 	function test_largo_remove_hero_C1() {
 		// returns unchanged when:
 		//     global $post is not set
@@ -30,7 +61,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		//     of_get_option('single_template') is not normal or classic
 		//     the first paragraph of the post contents doesn't have an image
 		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
-		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
 		//
 		// Otherwise, the first paragraph is removed from the post contents
 
@@ -69,7 +99,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		//     of_get_option('single_template') is not normal or classic
 		//     the first paragraph of the post contents doesn't have an image
 		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
-		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
 		//
 		// Otherwise, the first paragraph is removed from the post contents
 
@@ -92,12 +121,13 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$this->go_to( '/?p=' . $post_id );
 
 		// with a post set up like so, remove the thing
-		// @todo: how is this setup different that the above setup?
+		// where C1 has the CSS class .size-large, C2 has the CSS class .size-medium.
+		// That distinction made a difference before pull request #1400 removed the relevant check:
+		// https://github.com/INN/largo/pull/1400/files#diff-751911f6a0ebcc05da47094668329397L234
 		$c2 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-		$c2final = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-medium wp-image-' . $attachment_id . '" /></p>
-<h2>Headings</h2>
+		$c2final = '<h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 		$final2 = largo_remove_hero( $c2 );
 		$this->assertEquals( $c2final, $final2, "C2" );
@@ -110,7 +140,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		//     of_get_option('single_template') is not normal or classic
 		//     the first paragraph of the post contents doesn't have an image
 		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
-		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
 		//
 		// Otherwise, the first paragraph is removed from the post contents
 
@@ -152,7 +181,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		//     of_get_option('single_template') is not normal or classic
 		//     the first paragraph of the post contents doesn't have an image
 		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
-		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
 		//
 		// Otherwise, the first paragraph is removed from the post contents
 
@@ -176,6 +204,41 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 		$final4 = largo_remove_hero( $c4 );
 		$this->assertEquals( $c4, $final4, "C4" );
+	}
+
+	// returns unchanged when:
+	//     the current $post does not have a featured media thumbnail
+	function test_largo_remove_hero_C5() {
+		// returns unchanged when:
+		//     of_get_option('single_template') is not normal or classic
+		//     the first paragraph of the post contents doesn't have an image
+		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
+		//
+		// Otherwise, the first paragraph is removed from the post contents
+
+		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
+		$contents = file_get_contents( $filename );
+
+		$upload = wp_upload_bits( basename( $filename ), null, $contents );
+
+		print_r( $upload['error'] );
+		$this->assertTrue( empty( $upload['error'] ) );
+
+		$attachment_id = $this->_make_attachment( $upload );
+
+		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
+		$attachment_url = $attachment_url[0];
+
+		// create our post and set it up.
+		$post_id = $this->factory->post->create();
+		$this->go_to( '/?p=' . $post_id );
+
+		// with a post set up like so, remove the thing
+		$c5 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
+<h2>Headings</h2>
+<p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
+		$final1 = largo_remove_hero( $c5 );
+		$this->assertEquals( $c5, $final1, "C5" );
 	}
 
 	function _make_attachment( $upload, $parent_post_id = 0 ) {

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -1,6 +1,7 @@
 <?php
 
 class PostTemplatesTestFunctions extends WP_UnitTestCase {
+	private $ids = array();
 
 	function setUp() {
 		parent::setUp();
@@ -22,7 +23,7 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete( 'This test has not yet been implemented.' );
 	}
 
-	function test_largo_remove_hero() {
+	function test_largo_remove_hero_C1() {
 		// returns unchanged when:
 		//     global $post is not set
 		//     the current $post does not have a featured media thumbnail
@@ -32,13 +33,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
 		//
 		// Otherwise, the first paragraph is removed from the post contents
-
-		$this->markTestIncomplete( 'This test has not yet been implemented.' );
-	}
-
-	private $ids = array();
-
-	function test_insert_image_no_thumb() {
 
 		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
 		$contents = file_get_contents( $filename );
@@ -66,6 +60,36 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 		$final1 = largo_remove_hero( $c1 );
 		$this->assertEquals( $c1final, $final1, "C1" );
+	}
+
+	function test_largo_remove_hero_C2() {
+		// returns unchanged when:
+		//     global $post is not set
+		//     the current $post does not have a featured media thumbnail
+		//     of_get_option('single_template') is not normal or classic
+		//     the first paragraph of the post contents doesn't have an image
+		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
+		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
+		//
+		// Otherwise, the first paragraph is removed from the post contents
+
+		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
+		$contents = file_get_contents( $filename );
+
+		$upload = wp_upload_bits( basename( $filename ), null, $contents );
+
+		print_r( $upload['error'] );
+		$this->assertTrue( empty( $upload['error'] ) );
+
+		$attachment_id = $this->_make_attachment( $upload );
+
+		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
+		$attachment_url = $attachment_url[0];
+
+		// create our post and set it up.
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, '_thumbnail_id', $attachment_id );
+		$this->go_to( '/?p=' . $post_id );
 
 		// with a post set up like so, remove the thing
 		// @todo: how is this setup different that the above setup?
@@ -77,7 +101,36 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 		$final2 = largo_remove_hero( $c2 );
 		$this->assertEquals( $c2final, $final2, "C2" );
+	}
 
+	function test_largo_remove_hero_C3() {
+		// returns unchanged when:
+		//     global $post is not set
+		//     the current $post does not have a featured media thumbnail
+		//     of_get_option('single_template') is not normal or classic
+		//     the first paragraph of the post contents doesn't have an image
+		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
+		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
+		//
+		// Otherwise, the first paragraph is removed from the post contents
+
+		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
+		$contents = file_get_contents( $filename );
+
+		$upload = wp_upload_bits( basename( $filename ), null, $contents );
+
+		print_r( $upload['error'] );
+		$this->assertTrue( empty( $upload['error'] ) );
+
+		$attachment_id = $this->_make_attachment( $upload );
+
+		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
+		$attachment_url = $attachment_url[0];
+
+		// create our post and set it up.
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, '_thumbnail_id', $attachment_id );
+		$this->go_to( '/?p=' . $post_id );
 		// test for https://github.com/INN/largo/pull/1503#issuecomment-407901229
 		// if the opening paragraph tag contains a matching image and other stuff,
 		// remove the matching image but nothing else
@@ -89,6 +142,33 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
 		$final3 = largo_remove_hero( $c3 );
 		$this->assertEquals( $c3final, $final3, "C3" );
+
+	}
+
+	function test_largo_remove_hero_C4() {
+		// returns unchanged when:
+		//     global $post is not set
+		//     the current $post does not have a featured media thumbnail
+		//     of_get_option('single_template') is not normal or classic
+		//     the first paragraph of the post contents doesn't have an image
+		//     the image in the first paragraph has a different src and attachment id than the post's featured media thumbnail
+		//     the image in the first paragraph has the same src, or has a different src but the same id, and the image's classes include 'size-small' or 'size-medium'
+		//
+		// Otherwise, the first paragraph is removed from the post contents
+
+		$filename = ( dirname(__FILE__) .'/../mock/img/cat.jpg' );
+		$contents = file_get_contents( $filename );
+
+		$upload = wp_upload_bits( basename( $filename ), null, $contents );
+
+		print_r( $upload['error'] );
+		$this->assertTrue( empty( $upload['error'] ) );
+
+		$attachment_id = $this->_make_attachment( $upload );
+
+		$attachment_url = wp_get_attachment_image_src( $attachment_id, 'large' );
+		$attachment_url = $attachment_url[0];
+
 
 		// don't remove the image if it doesn't match the attachment URL
 		$c4 = '<p><img src="https://upload.wikimedia.org/wikipedia/commons/4/4a/Dr._James_Naismith.jpg" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
@@ -123,7 +203,6 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
 
 		return $this->ids[] = $id;
-
 	}
 
 	function test_largo_get_partial_by_post_type() {

--- a/tests/inc/test-post-templates.php
+++ b/tests/inc/test-post-templates.php
@@ -50,7 +50,7 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$c0 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-		$final1 = largo_remove_hero( $c0 );
+		$final0 = largo_remove_hero( $c0 );
 		$this->assertEquals( $c0, $final0, "C0" );
 	}
 
@@ -237,8 +237,8 @@ class PostTemplatesTestFunctions extends WP_UnitTestCase {
 		$c5 = '<p><img src="' . $attachment_url . '" alt="1559758083_cef4ef63d2_o" width="771" height="475" class="alignnone size-large wp-image-' . $attachment_id . '" /></p>
 <h2>Headings</h2>
 <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui.</p>';
-		$final1 = largo_remove_hero( $c5 );
-		$this->assertEquals( $c5, $final1, "C5" );
+		$final5 = largo_remove_hero( $c5 );
+		$this->assertEquals( $c5, $final5, "C5" );
 	}
 
 	function _make_attachment( $upload, $parent_post_id = 0 ) {


### PR DESCRIPTION
## Changes

- Implements the matrix-based Travis CI config originally written for NPR's Story API plugin, as the research conducted [in that issue's comments](https://github.com/INN/WP-DS-NPR-API/issues/12#issuecomment-374730094) is still valid regarding which versions of PHP and PHPunit are supported by WordPress.
    - We can support PHP 7.2 in tests once https://core.trac.wordpress.org/ticket/43218 is merged; this is likely to happen with WordPress 5.0
    - Drops support for PHP 5.3 and 5.5, gaining support for PHP 5.6
    - Gains support for PHP 5.6, 7.0, 7.1
- Removes a portion of the Travis CI config that would have messaged our Hipchat room; we stopped using Hipchat a while ago.
- Changes PHP support to whatever versions of PHP are currently receiving updates 
- Changes WordPress support to a recommendation to use the most-recent version, with a pointer to `.travis.yml` to read the list of PHP versions we test against.
- As collateral damage of updating the supported PHP/Wordpress versions:
    - Updates the staff list in README.md
    - Updates the version number of the current Largo release in README.md
- Adds checks in `largo_post_social_links()` to make sure that the array keys it's trying to access exist before accessing them.
- Changes `of_sanitize_multicheck()` to initialize a variable accessed as an array with an array instead of an empty string.
- Changes largo_remove_hero() to fix https://github.com/INN/largo/issues/1404:
    - adjusts the regular expression pattern to no longer require the `src=""` attribute, as it's not needed
    - [`trim()](https://secure.php.net/manual/en/function.trim.php)s the post content to remove empty leading newlines after removing an empty first paragraph tag caused by removing the duplicate hero image.
    - updates tests and test documentation for this function, and adds tests for a couple more conditions.

## Why

Two-part:
- so that the README in 0.5-dev and, eventually, 0.5, are up to date with current versions of Largo and INN Labs
- so that we can have tests for all stuff in the post-0.5.5.4 development work, including https://github.com/INN/largo/pull/1501