### PR TITLE
Copy the fix for "WP_Admin_Bar::add_node was called incorrectly" into 0.5-dev

### DIFF
--- a/inc/dashboard.php
+++ b/inc/dashboard.php
@@ -120,53 +120,53 @@ if ( INN_MEMBER === TRUE ) {
  * Largo Dashboard / Admin Bar Menu
  * -- Priority 15 Places between WordPress Logo and My Sites
  * -- To move menu to end of items use something like priority 999
- */ 
+ */
 
 add_action( 'admin_bar_menu', 'largo_dash_admin_menu', 15 );
 function largo_dash_admin_menu( $wp_admin_bar ) {
 
 	// Add Top Level Text Node for Dropdown
-	$args = array( 'id' => 'largo_admin_mega', 'title' => 'Largo' ); 
+	$args = array( 'id' => 'largo_admin_mega', 'title' => 'Largo' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Main Website
-	$args = array( 'id' => 'website', 'title' => 'Main Website', 'href' => 'http://largoproject.org/', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'website', 'title' => 'Main Website', 'href' => 'http://largoproject.org/', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Documentation
-	$args = array( 'id' => 'largo_docs', 'title' => 'Documentation', 'href' => 'http://largo.readthedocs.io/', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'largo_docs', 'title' => 'Documentation', 'href' => 'http://largo.readthedocs.io/', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Knowledge Base
-	$args = array( 'id' => 'knowledge_base', 'title' => 'Knowledge Base', 'href' => 'http://support.largoproject.org/support/solutions', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'knowledge_base', 'title' => 'Knowledge Base', 'href' => 'http://support.largoproject.org/support/solutions', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Member Help Desk
-	$args = array( 'id' => 'support', 'title' => 'Help Desk', 'href' => 'http://support.largoproject.org', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'support', 'title' => 'Help Desk', 'href' => 'http://support.largoproject.org', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Member Forums
-	$args = array( 'id' => 'user_forums', 'title' => 'Community Forums', 'href' => 'http://support.largoproject.org/support/discussions', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'user_forums', 'title' => 'Community Forums', 'href' => 'http://support.largoproject.org/support/discussions', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Largo on GitHub
-	$args = array( 'id' => 'github', 'title' => 'Largo on GitHub', 'href' => 'https://github.com/inn/largo', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'github', 'title' => 'Largo on GitHub', 'href' => 'https://github.com/inn/largo', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Largo on Twitter
-	$args = array( 'id' => 'twitter', 'title' => '@LargoProject on Twitter', 'href' => 'https://twitter.com/largoproject', 'parent' => 'largo_admin_mega'); 
+	$args = array( 'id' => 'twitter', 'title' => '@LargoProject on Twitter', 'href' => 'https://twitter.com/largoproject', 'parent' => 'largo_admin_mega');
 	$wp_admin_bar->add_node( $args );
-	
+
 	// INN Nerds
-	$args = array(' id' => 'inn_nerds', 'title' => 'INN Nerds', 'href' => 'http://nerds.inn.org', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'inn_nerds', 'title' => 'INN Nerds', 'href' => 'http://nerds.inn.org', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
-	// About INN	
-	$args = array( 'id' => 'about_inn', 'title' => 'About INN', 'href' => 'http://inn.org', 'parent' => 'largo_admin_mega' ); 
+
+	// About INN
+	$args = array( 'id' => 'about_inn', 'title' => 'About INN', 'href' => 'http://inn.org', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
-	
+
 	// Donate
-	$args = array( 'id' => 'donate_inn', 'title' => 'Donate', 'href' => 'https://inn.org/donate', 'parent' => 'largo_admin_mega' ); 
+	$args = array( 'id' => 'donate_inn', 'title' => 'Donate', 'href' => 'https://inn.org/donate', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 }


### PR DESCRIPTION
## Changes

This closes #1349 in the 0.5 branch. It fixes a spacing error.

## Why

Because seeing this in the console log for every single page load makes debugging annoying:

> 2018/07/31 11:18:49 [error] 33695#0: *39 FastCGI sent in stderr: "PHP message: PHP Notice:  WP_Admin_Bar::add_node was called <strong>incorrectly</strong>. The menu ID should not be empty. Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.3.0.) in /Users/blk/sites/largo/wp-includes/functions.php on line 4161" while reading upstream, client: 127.0.0.1, server: , request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/Users/blk/.valet/valet.sock:", host: "largo.test"

And because RC's commit 6e8587a141d637e01300cb0de44c6c91db5496a3 wasn't in the present Largo.