### PR TITLE
Remove screen_icon() from Options Framework options page

### DIFF
--- a/lib/options-framework/options-framework.php
+++ b/lib/options-framework/options-framework.php
@@ -229,7 +229,6 @@ function optionsframework_page() {
 	settings_errors(); ?>
 
 	<div id="optionsframework-wrap" class="wrap">
-    <?php screen_icon( 'themes' ); ?>
     <h2 class="nav-tab-wrapper">
         <?php echo optionsframework_tabs(); ?>
     </h2>


### PR DESCRIPTION
`screen_icon()` and `get_screen_icon()` are deprecated since WordPress 4.8.

`screen_icon()` triggers a `_deprecated_function()` call and calls `get_screen_icon()`, which outputs an HTML comment: https://developer.wordpress.org/reference/functions/get_screen_icon/

Fixes https://github.com/INN/largo/issues/1523 for https://github.com/INN/largo/issues/844