### PR TITLE
Add WordPress 5.0 to travis list, remove 4.5 from PHP 5.6 and 4.8 from PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
     include:
       # PHPunit 5
       - php: 5.6
-        env: WP_VERSION=4.5 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 5.6
         env: WP_VERSION=4.6 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       - php: 5.6
         env: WP_VERSION=4.7 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
@@ -47,14 +45,14 @@ matrix:
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       # PHPUnit 6
       - php: 7.1
-        env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      - php: 7.1
         env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      - php: 7.1
+        env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
       # PHPUnit 7 support will come with https://core.trac.wordpress.org/ticket/43218
       # - php: 7.2
-      #   env: WP_VERSION=4.8 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
-      # - php: 7.2
       #   env: WP_VERSION=4.9 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
+      # - php: 7.2
+      #   env: WP_VERSION=5.0 WP_TESTS_DIR=/tmp/wordpress/tests/phpunit WP_CORE_DIR=/tmp/wordpress
 
 
 # Only test the main development branches for now


### PR DESCRIPTION
## Why

Partially addressing #1534's directive in tagging Largo 0.6 to make sure that this works with Gutenberg and WordPress 5.0

## Todo

Should not be merged before tests finish running.
