### PR TITLE
Use more-precise conditional for current_user_can in largo byline class

### DIFF
--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -181,7 +181,7 @@ class Largo_Byline {
 	 */
 	function edit_link() {
 		// Add the edit link if the current user can edit the post
-		if ( current_user_can( 'edit_published_posts' ) ) {
+		if ( current_user_can( 'edit_post', $this->post_id ) ) {
 			echo ' <span class="edit-link"><a href="' . get_edit_post_link( $this->post_id ) . '">' . __( 'Edit This Post', 'largo' ) . '</a></span>';
 		}
 	}


### PR DESCRIPTION
For the odd case where someone might have the 'edit_published_posts' capability, but not the capability to edit the current post, because of plugins or something.

Fixes https://github.com/INN/largo/issues/1543