### PR TITLE
Add warning output if WP_DEBUG || LARGO_DEBUG about the third parameter of largo_byline being required

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.
+- A future version of Largo will require the third parameter of `largo_byline()` to be specified in all calls. [PR #1561](https://github.com/INN/largo/pull/1561) for [issue #1517](https://github.com/INN/largo/issues/1517) adds code that, in testing environments with `WP_DEBUG` or `LARGO_DEBUG` set to `true`, will result in server log messages. This is necessary to prevent mismatches between the Loop's global `$post` and the desired byline output. The third parameter of `largo_byline()` may be a `WP_Post` instance or a post ID. Example call: `largo_byline( null, null, get_the_ID() );`.
 
 ## [Largo 0.5.5.4](https://github.com/INN/largo/releases/tag/v0.5.5.4)
 

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -28,7 +28,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 		?>
 				<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'large' ); ?></a>
 				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-				<h5 class="byline"><?php largo_byline(); ?></h5>
+				<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 				<?php largo_excerpt( $post, 4 ); ?>
 				<?php if ( largo_post_in_series() ):
 					$feature = largo_get_the_main_feature();

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -131,6 +131,10 @@ if ( ! function_exists( 'largo_byline' ) ) {
 				$post_id = $post;
 		} else {
 			$post_id = get_the_ID();
+
+			if ( WP_DEBUG || LARGO_DEBUG ) {
+				_doing_it_wrong( 'largo_byline', 'largo_byline must be called with a post or post ID specified as the third argument. For more information, see https://github.com/INN/largo/issues/1517 .', '0.6' );
+			}
 		}
 
 		// Set us up the options

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -57,7 +57,7 @@ class largo_related_posts_widget extends WP_Widget {
 
 				<?php if ( isset( $instance['show_byline'] ) && $instance['show_byline'] ) { ?>
 					<h5 class="byline">
-						<span class="by-author"><?php largo_byline( true, false ); ?></span>
+						<span class="by-author"><?php largo_byline( true, false, get_the_ID() ); ?></span>
 					</h5>
 				<?php } ?>
 

--- a/partials/archive-category-primary-feature.php
+++ b/partials/archive-category-primary-feature.php
@@ -15,7 +15,7 @@
 					rel="bookmark"><?php echo $featured_post->post_title; ?></a>
 			</h2>
 
-			<h5 class="byline"><?php largo_byline(true, false, $featured_post); ?></h5>
+			<h5 class="byline"><?php largo_byline( true, false, $featured_post ); ?></h5>
 		</header>
 
 		<div class="entry-content">

--- a/partials/content-roundup.php
+++ b/partials/content-roundup.php
@@ -25,7 +25,7 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 		<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
 	</h2>
 
-	<h5 class="byline visuallyhidden"><?php largo_byline(); ?></h5>
+	<h5 class="byline visuallyhidden"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 
 	<?php the_content(); ?>
 

--- a/partials/content-single-classic.php
+++ b/partials/content-single-classic.php
@@ -14,7 +14,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) )
 			echo '<h2 class="subtitle">' . $subtitle . '</h2>';
 		?>
-		<h5 class="byline"><?php largo_byline(); ?></h5>
+		<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 
 		<?php
 			if ( !of_get_option( 'single_social_icons' ) == false ) {

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -16,7 +16,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
 			<h2 class="subtitle"><?php echo $subtitle ?></h2>
 		<?php endif; ?>
-		<h5 class="byline"><?php largo_byline(); ?></h5>
+		<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 
 		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
 			largo_post_social_links();

--- a/partials/content.php
+++ b/partials/content.php
@@ -72,7 +72,7 @@ if ( $featured ) {
 
 		<?php
 			if ( $show_byline ) { ?>
-				<h5 class="byline"><?php largo_byline(); ?></h5>
+				<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 			<?php }
 		?>
 

--- a/partials/sticky-posts.php
+++ b/partials/sticky-posts.php
@@ -14,8 +14,8 @@ $query = new WP_Query( $args );
 
 if ( $query->have_posts() ) {
 	while ( $query->have_posts() ) {
-	   	$query->the_post();
-	   	$shown_ids[] = get_the_ID();
+		$query->the_post();
+		$shown_ids[] = get_the_ID();
 
 		if ( $sticky && $sticky[0] && ! is_paged() ) { ?>
 
@@ -50,7 +50,7 @@ if ( $query->have_posts() ) {
 						<?php } ?>
 
 						<h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-						<h5 class="byline"><?php largo_byline(); ?></h5>
+						<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
 
 						<div class="entry-content">
 						<?php
@@ -71,11 +71,12 @@ if ( $query->have_posts() ) {
 									?>
 								</ul>
 								<?php
-								if ( count( $feature_posts ) == 3 )
-											printf( '<p class="sticky-all"><a href="%1$s">%2$s &raquo;</a></p>',
-												esc_url( get_term_link( $feature ) ),
-												__( 'Full Coverage', 'largo' )
-											);
+									if ( count( $feature_posts ) == 3 ) {
+										printf( '<p class="sticky-all"><a href="%1$s">%2$s &raquo;</a></p>',
+											esc_url( get_term_link( $feature ) ),
+											__( 'Full Coverage', 'largo' )
+										);
+									}
 								?>
 							</div>
 						<?php } // feature_posts ?>

--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -36,7 +36,7 @@ if ($thumb == 'small') {
 
 <?php // byline on posts
 if ( isset( $instance['show_byline'] ) && $instance['show_byline'] == true) { ?>
-	<span class="byline"><?php echo largo_byline( false, $instance['hide_byline_date'] ); ?></span>
+	<span class="byline"><?php echo largo_byline( false, $instance['hide_byline_date'], get_the_ID() ); ?></span>
 <?php }
 
 // the excerpt

--- a/series-landing.php
+++ b/series-landing.php
@@ -45,7 +45,7 @@ $content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 
 		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<?php
 		if ( $opt['show_series_byline'] )
-			echo '<h5 class="byline">' . largo_byline( false ) . '</h5>';
+			echo '<h5 class="byline">' . largo_byline( false, null, get_the_ID() ) . '</h5>';
 		if ( $opt['show_sharebar'] )
 			largo_post_social_links();
 		?>


### PR DESCRIPTION
## Changes

- Using WordPress' private function _doing_it_wrong, complain if largo_byline() is called without specifying a post or post ID.
- fix a number of partials and templates that were not in compliance with the new regime.
- provides changelog update and advice

## Why

Because when you call largo_byline() without a post specified, sometimes the global `$post` and the post you're displaying stuff for don't match. This causes problems.

The first part of https://github.com/INN/largo/issues/1517: the plan to eventually deprecate calling largo_byline without specifiying a post.