### PR TITLE
Add the actions largo_lmp_before_posts and largo_lmp_after_posts to enable wrapping the Load More Posts return with other HTML.

### DIFF
--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -118,15 +118,19 @@ if ( !function_exists( 'largo_load_more_posts' ) ) {
 
 		if ( $query->have_posts() ) {
 			// Choose the correct partial to load here
-			$partial = largo_load_more_posts_choose_partial($query);
+			$partial = largo_load_more_posts_choose_partial( $query );
+
+			do_action( 'largo_lmp_before_posts' );
 
 			// Render all the posts
 			while ( $query->have_posts() ) : $query->the_post();
 				// Use largo_get_partial_by_post_type here as well as in the search archive,
 				// to ensure that LMP posts will be using the partial set by the child theme for that post type.
-				$post_type_partial = largo_get_partial_by_post_type($partial, get_post_type(), $partial);
+				$post_type_partial = largo_get_partial_by_post_type( $partial, get_post_type(), $partial );
 				get_template_part( 'partials/content', $post_type_partial );
 			endwhile;
+
+			do_action( 'largo_lmp_after_posts' );
 		}
 		wp_die();
 	}


### PR DESCRIPTION
Resolves https://github.com/INN/largo/issues/929

So we can do things like adding a wrapper div for custom styling:

```php
add_action( 'largo_lmp_before_posts', function() {
	echo '<div class="wrapper">';
} );
add_action( 'largo_lmp_before_posts', function() {
	echo '</div>';
} );
```

or outputting a widget area, for ads while you scroll.

```php
add_action( 'largo_lmp_before_posts', function() {
	dynamic_sidebar( 'custom-lmp-ad-sidebar' );
} );
```