### PR TITLE
Copy https://github.com/INN/largo/pull/1469 into 0.5-dev

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 
 ## [Unreleased](https://github.com/INN/largo/compare/0.5...0.5-dev)
 
+Thanks to Mike Schinkel for his work on [pull request 1469](https://github.com/INN/largo/pull/1469) at WordCamp for Publishers 2017's Contributor Day.
+
+### New Features
 - Adds Gutenberg support, with
 	- editor styles
 	- support for the `.alignwide` and `.alignfull` CSS classes and their use in blocks
@@ -19,6 +22,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 ### Removed
 - Removes the default inclusion of Google Analytics with INN's Largo Project IDs. [PR #1502](https://github.com/INN/largo/pull/1502) as part of [issue #1495](https://github.com/INN/largo/issues/1495), and by request.
 - Removes the INN Member RSS widget, because the RSS feed it draws from is no longer supported or maintained by INN. Because the RSS feed was occasionally empty, the widget would result in 500 errors. [RP #1535](https://github.com/INN/largo/pulls/1535) for [issue #1511](https://github.com/INN/largo/issues/1511) and [#893](https://github.com/INN/largo/issues/893).
+- Removes lingering traces of the Largo Featured Widget. [PR #1563](https://github.com/INN/largo/pull/1563) and [#1469](https://github.com/INN/largo/pull/1469), from Github user [mikeschinkel](https://github.com/mikeschinkel).
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.

--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ Thanks to Mike Schinkel for his work on [pull request 1469](https://github.com/I
 ### Removed
 - Removes the default inclusion of Google Analytics with INN's Largo Project IDs. [PR #1502](https://github.com/INN/largo/pull/1502) as part of [issue #1495](https://github.com/INN/largo/issues/1495), and by request.
 - Removes the INN Member RSS widget, because the RSS feed it draws from is no longer supported or maintained by INN. Because the RSS feed was occasionally empty, the widget would result in 500 errors. [RP #1535](https://github.com/INN/largo/pulls/1535) for [issue #1511](https://github.com/INN/largo/issues/1511) and [#893](https://github.com/INN/largo/issues/893).
-- Removes lingering traces of the Largo Featured Widget. [PR #1563](https://github.com/INN/largo/pull/1563) and [#1469](https://github.com/INN/largo/pull/1469), from Github user [mikeschinkel](https://github.com/mikeschinkel).
+- Removes lingering traces of the Largo Featured Widget. [PR #1563](https://github.com/INN/largo/pull/1563) and [#1469](https://github.com/INN/largo/pull/1469) for [issue 1467](https://github.com/INN/largo/issues/1467), from Github user [mikeschinkel](https://github.com/mikeschinkel).
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.

--- a/inc/widgets/largo-about.php
+++ b/inc/widgets/largo-about.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * About this site
+ * "About this site" widget.
  */
 
 /**
@@ -50,13 +50,13 @@ class largo_about_widget extends WP_Widget {
 		if ( of_get_option( 'site_blurb' ) ) {
 			echo '<p>' . of_get_option( 'site_blurb' ) . '</p>';
 		} else {
-		    $link_title = __( 'The Largo Theme Options page', 'largo' );
-		    $options_url = site_url( '/wp-admin/themes.php?page=options-framework' );
+			$link_title = __( 'The Largo Theme Options page', 'largo' );
+			$options_url = site_url( '/wp-admin/themes.php?page=options-framework' );
 			$message = sprintf(
 				__( '%sYou have not set a description for your site.%s Add a site description by visiting %sthe Largo Theme Options page%s.', 'largo' ),
-                '<strong>','</strong>',
-                "<a href=\"{$options_url}\" title=\"{$link_title}\">", '</a>'
-            );
+				'<strong>','</strong>',
+				"<a href=\"{$options_url}\" title=\"{$link_title}\">", '</a>'
+			);
 			echo "<p class=\"error\">{$message}</p>";
 		}
 
@@ -94,7 +94,7 @@ class largo_about_widget extends WP_Widget {
 
 	/**
 	 * Returns defaults for an instance, or ensures an instance has a title
-     *
+	 *
 	 * @param array $instance     The widget instance info
 	 * @return array
 	 */

--- a/inc/widgets/largo-about.php
+++ b/inc/widgets/largo-about.php
@@ -2,49 +2,100 @@
 /*
  * About this site
  */
+
+/**
+ * Class largo_about_widget
+ */
 class largo_about_widget extends WP_Widget {
 
+	/**
+	 * largo_about_widget constructor.
+	 */
 	function __construct() {
 		$widget_ops = array(
-			'classname' 	=> 'largo-about',
-			'description'	=> __('Show the site description from your theme options page', 'largo')
+			'classname'   => 'largo-about',
+			'description' => __( 'Show the site description from your theme options page', 'largo' )
 		);
-		parent::__construct( 'largo-about-widget', __('Largo About Site', 'largo'), $widget_ops);
+		parent::__construct( 'largo-about-widget', __( 'Largo About Site', 'largo' ), $widget_ops );
 	}
 
+	/**
+	 * Echos output for the widget
+	 *
+	 * @param array $args
+	 * @param array $instance
+	 */
 	function widget( $args, $instance ) {
-		extract( $args );
 
-		$title = apply_filters('widget_title', empty( $instance['title'] ) ? sprintf( __( 'About %s', 'largo' ), get_bloginfo('name') ) : $instance['title'], $instance, $this->id_base);
+		$args = wp_parse_args( $args, array(
+			'before_widget' => '',
+			'before_title'  => '',
+			'after_title'   => '',
+			'after_widget'  => '',
+		));
 
-		echo $before_widget;
-		if ( $title )
-			echo $before_title . $title . $after_title; ?>
+		/*
+		 * Set default title
+		 */
+		$instance = $this->_instance_defaults( $instance );
 
-			<?php if ( of_get_option( 'site_blurb' ) ) : ?>
-                <p><?php echo of_get_option( 'site_blurb' ); ?></p>
-			<?php else: ?>
-    			<p class="error"><strong><?php _e('You have not set a description for your site.</strong> Add a site description by visiting the Largo Theme Options page.', 'largo'); ?></p>
-        	<?php endif; // end about site ?>
+		echo $args[ 'before_widget' ];
 
-		<?php
-		echo $after_widget;
+		$title = apply_filters( 'widget_title', $instance[ 'title' ], $instance, $this->id_base );
+
+		if ( $title ) {
+			echo "{$args[ 'before_title' ]}{$title}{$args[ 'after_title' ]}";
+		}
+
+		if ( of_get_option( 'site_blurb' ) ) {
+			echo '<p>' . of_get_option( 'site_blurb' ) . '</p>';
+		} else {
+			echo '<p class="error"><strong>';
+			_e( 'You have not set a description for your site.</strong> Add a site description by visiting the Largo Theme Options page.', 'largo' );
+			echo '</p>';
+		}
+
+		echo $args[ 'after_widget' ];
 	}
 
-	function update( $new_instance, $old_instance ) {
-		$instance = $old_instance;
-		$instance['title'] = sanitize_text_field( $new_instance['title'] );
+	/**
+	 * @param array $new_instance The new widget instance
+	 * @param array $instance     The old Widget instance
+	 *
+	 * @return array
+	 */
+	function update( $new_instance, $instance ) {
+		$new_instance = $this->_instance_defaults( $new_instance );
+		$instance[ 'title' ] = sanitize_text_field( $new_instance[ 'title' ] );
 		return $instance;
 	}
 
+	/**
+	 * Display form to allow updating title
+	 * @param array $instance
+	 * @return string Default return is 'noform'.
+	 */
 	function form( $instance ) {
-		$defaults = array( 'title' => sprintf( __( 'About %s', 'largo' ), get_bloginfo('name') ) );
-		$instance = wp_parse_args( (array) $instance, $defaults );
+		$instance = wp_parse_args( (array) $instance, $this->_instance_defaults( $instance ) );
+		$title_field_id = $this->get_field_id( 'title' );
+		$title_field_name = $this->get_field_name( 'title' );
 		?>
-		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title', 'largo' ); ?>:</label>
-			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" style="width:90%;" />
-		</p>
-	<?php
+        <p>
+            <label for="<?php echo esc_attr( $title_field_id ); ?>"><?php _e( 'Title', 'largo' ); ?>:</label>
+            <input id="<?php echo esc_attr( $title_field_id ); ?>" name="<?php echo esc_attr( $title_field_name ); ?>" value="<?php echo esc_attr( $instance[ 'title' ] ); ?>" style="width:90%;" />
+        </p>
+		<?php
+	}
+
+	/**
+	 * Returns defaults for an instance, or ensures an instance has a title
+     *
+	 * @param array $instance     The widget instance info
+	 * @return array
+	 */
+	private function _instance_defaults( $instance = array() ) {
+		return wp_parse_args( $instance, array(
+			'title' => sprintf( __( 'About %s', 'largo' ), get_bloginfo( 'name' ) ),
+		));
 	}
 }

--- a/inc/widgets/largo-about.php
+++ b/inc/widgets/largo-about.php
@@ -50,9 +50,14 @@ class largo_about_widget extends WP_Widget {
 		if ( of_get_option( 'site_blurb' ) ) {
 			echo '<p>' . of_get_option( 'site_blurb' ) . '</p>';
 		} else {
-			echo '<p class="error"><strong>';
-			_e( 'You have not set a description for your site.</strong> Add a site description by visiting the Largo Theme Options page.', 'largo' );
-			echo '</p>';
+		    $link_title = __( 'The Largo Theme Options page', 'largo' );
+		    $options_url = site_url( '/wp-admin/themes.php?page=options-framework' );
+			$message = sprintf(
+				__( '%sYou have not set a description for your site.%s Add a site description by visiting %sthe Largo Theme Options page%s.', 'largo' ),
+                '<strong>','</strong>',
+                "<a href=\"{$options_url}\" title=\"{$link_title}\">", '</a>'
+            );
+			echo "<p class=\"error\">{$message}</p>";
 		}
 
 		echo $args[ 'after_widget' ];

--- a/partials/footer-widget-3col-default.php
+++ b/partials/footer-widget-3col-default.php
@@ -5,18 +5,7 @@
 </div>
 
 <div class="span6 widget-area" role="complementary">
-	<?php if ( ! dynamic_sidebar( 'footer-2' ) ) {
-		the_widget( 'largo_featured_widget', array(
-				'term' => 'footer-featured',
-				'title' => __('In Case You Missed It', 'largo'),
-				'widget_class' => 'default',
-				'num_posts' => 2,
-				'num_sentences' => 2,
-				'thumb' => 'before'
-			)
-		);
-	}
-	?>
+	<?php dynamic_sidebar( 'footer-2' ); ?>
 </div>
 
 <div class="span3 widget-area" role="complementary">

--- a/partials/footer-widget-3col-equal.php
+++ b/partials/footer-widget-3col-equal.php
@@ -5,18 +5,7 @@
 </div>
 
 <div class="span4 widget-area" role="complementary">
-	<?php if ( ! dynamic_sidebar( 'footer-2' ) ) {
-		the_widget( 'largo_featured_widget', array(
-				'term' => 'footer-featured',
-				'title' => __('In Case You Missed It', 'largo'),
-				'widget_class' => 'default',
-				'num_posts' => 2,
-				'num_sentences' => 2,
-				'thumb' => 'before'
-			)
-		);
-	}
-	?>
+	<?php dynamic_sidebar( 'footer-2' ); ?>
 </div>
 
 <div class="span4 widget-area" role="complementary">

--- a/partials/footer-widget-4col.php
+++ b/partials/footer-widget-4col.php
@@ -5,18 +5,7 @@
 </div>
 
 <div class="span3 widget-area" role="complementary">
-	<?php if ( ! dynamic_sidebar( 'footer-2' ) ) {
-		the_widget( 'largo_featured_widget', array(
-				'term' => 'footer-featured',
-				'title' => __('In Case You Missed It', 'largo'),
-				'widget_class' => 'default',
-				'num_posts' => 2,
-				'num_sentences' => 2,
-				'thumb' => 'before'
-			)
-		);
-	}
-	?>
+	<?php dynamic_sidebar( 'footer-2' ); ?>
 </div>
 
 <div class="span3 widget-area" role="complementary">

--- a/partials/sidebar-fallback.php
+++ b/partials/sidebar-fallback.php
@@ -23,12 +23,3 @@ if (of_get_option('donate_link')) {
 		)
 	);
 }
-
-the_widget( 'largo_featured_widget', array(
-		'term' => 'sidebar-featured',
-		'title' => __('We Recommend', 'largo'),
-		'widget_class' => 'default',
-		'num_posts' => 5,
-		'num_sentences' => 2
-	)
-);


### PR DESCRIPTION
## Changes

- Restructures the largo_about_widget to:
    - "ensure no undeclared errors" and add comments
    - create private initialization function for $instance for DRY
    - add esc_attr() in several places
    - make the code a little more readable.
- Removes `largo_featured_widget` instances as fallback content in sidebars.

This PR is substantially @mikeschinkel's work. 

## Why

- because Largo Featured Widget is no more
- because the about widget was throwing a lot of errors
- closes https://github.com/INN/largo/issues/1467