### PR TITLE
Removes most uses of extract()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ Thanks to Mike Schinkel for his work on [pull request 1469](https://github.com/I
 - Removes the default inclusion of Google Analytics with INN's Largo Project IDs. [PR #1502](https://github.com/INN/largo/pull/1502) as part of [issue #1495](https://github.com/INN/largo/issues/1495), and by request.
 - Removes the INN Member RSS widget, because the RSS feed it draws from is no longer supported or maintained by INN. Because the RSS feed was occasionally empty, the widget would result in 500 errors. [RP #1535](https://github.com/INN/largo/pulls/1535) for [issue #1511](https://github.com/INN/largo/issues/1511) and [#893](https://github.com/INN/largo/issues/893).
 - Removes lingering traces of the Largo Featured Widget. [PR #1563](https://github.com/INN/largo/pull/1563) and [#1469](https://github.com/INN/largo/pull/1469) for [issue 1467](https://github.com/INN/largo/issues/1467), from Github user [mikeschinkel](https://github.com/mikeschinkel).
+- Removes many uses of `extract()` in widgets and theme functions, and improves code quality in widgets.
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.

--- a/homepages/homepage-class.php
+++ b/homepages/homepage-class.php
@@ -72,6 +72,9 @@ class Homepage {
 					$vars[$zone] = call_user_func(array($this, $zone));
 			}
 		}
+
+		// this turns the list of zones into actual variables in the current scope.
+		// the $vars array here is not affected by user input.
 		extract($vars);
 		include_once $this->template;
 	}

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -30,13 +30,13 @@ add_action( 'init', 'largo_add_mce_buttons' );
  * @since 0.3
  */
 function largo_module_shortcode( $atts, $content, $code ) {
-    extract( shortcode_atts( array(
+    $atts = shortcode_atts( array(
         'align' => 'left',
         'width' => 'half',
         'type' => 'aside',
-    ), $atts ) );
+    ), $atts );
 
-    return sprintf( '<aside class="module %s %s %s">%s</aside>', $type, $align, $width, $content );
+    return sprintf( '<aside class="module %s %s %s">%s</aside>', $atts['type'], $atts['align'], $atts['width'], $atts['content'] );
 }
 add_shortcode( 'module', 'largo_module_shortcode' );
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -178,11 +178,6 @@ if ( ! function_exists( 'largo_footer_js' ) ) {
 			}(document, 'script', 'facebook-jssdk'));</script>
 		<?php }
 
-		if ( largo_twitter_widget::is_rendered() ) { ?>
-			<!--Twitter-->
-			<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-		<?php }
-
 		/*
 		 * Load Facebook Tracking Pixel if defined in Theme Options
 		 *

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -59,32 +59,31 @@ if ( ! function_exists( 'largo_custom_wp_link_pages' ) ) {
 
 		$r = wp_parse_args( $args, $defaults );
 		$r = apply_filters( 'wp_link_pages_args', $r );
-		extract( $r, EXTR_SKIP );
 
 		global $page, $numpages, $multipage, $more, $pagenow;
 
 		$output = '';
 		if ( $multipage ) {
 			//if ( 'number' == $next_or_number ) {
-				$output .= $before;
+				$output .= $r['before'];
 
 				//previous page
 				$i = $page - 1;
 				if ( $i && $more ) {
 					$output .= _wp_link_page( $i );
-					$output .= $text_before . $previouspagelink . $text_after . '</a>|';
+					$output .= $r['text_before'] . $r['previouspagelink'] . $r['text_after'] . '</a>|';
 				}
 
 				//list of page #s
 				for ( $i = 1; $i < ( $numpages + 1 ); $i = $i + 1 ) {
-					$j = str_replace( '%', $i, $pagelink );
+					$j = str_replace( '%', $i, $r['pagelink'] );
 					$output .= ' ';
 					if ( $i != $page || ( ( ! $more ) && ( $page == 1 ) ) )
 						$output .= _wp_link_page( $i );
 					else
 						$output .= '<span class="current-post-page">';
 
-					$output .= $text_before . $j . $text_after;
+					$output .= $r['text_before'] . $j . $r['text_after'];
 					if ( $i != $page || ( ( ! $more ) && ( $page == 1 ) ) )
 						$output .= '</a>';
 					else
@@ -95,15 +94,15 @@ if ( ! function_exists( 'largo_custom_wp_link_pages' ) ) {
 				$i = $page + 1;
 				if ( $i <= $numpages && $more ) {
 					$output .= '|' . _wp_link_page( $i );
-					$output .= $text_before . $nextpagelink . $text_after . '</a>';
+					$output .= $r['text_before'] . $r['nextpagelink'] . $r['text_after'] . '</a>';
 				}
 
 				$output .= '|<a href="' . add_query_arg( array( 'all' => '1'), get_permalink() ) . '" title="View all pages">View As Single Page</a>';
 
-				$output .= $after;
+				$output .= $r['after'];
 		}
 
-		if ( $echo )
+		if ( $r['echo'] )
 			echo $output;
 
 		return $output;

--- a/inc/users.php
+++ b/inc/users.php
@@ -326,11 +326,9 @@ function save_more_profile_info($user_id) {
 		'hide' => 'off'
 	));
 
-	extract($values);
-
-	update_user_meta($user_id, 'job_title', $job_title);
-	update_user_meta($user_id, 'show_email', $show_email);
-	update_user_meta($user_id, 'hide', $hide);
+	update_user_meta($user_id, 'job_title', $values['job_title']);
+	update_user_meta($user_id, 'show_email', $values['show_email']);
+	update_user_meta($user_id, 'hide', $values['hide']);
 }
 add_action('personal_options_update', 'save_more_profile_info');
 add_action('edit_user_profile_update', 'save_more_profile_info');

--- a/inc/widgets/largo-author-bio.php
+++ b/inc/widgets/largo-author-bio.php
@@ -26,13 +26,12 @@ class largo_author_widget extends WP_Widget {
 
 		global $post;
 
-		extract( $args );
-
 		$authors = array();
 		$bios = '';
 
-		if( get_post_meta( $post->ID, 'largo_byline_text' ) )
+		if( get_post_meta( $post->ID, 'largo_byline_text' ) ) {
 			$byline_text = esc_attr( get_post_meta( $post->ID, 'largo_byline_text', true ) );
+		}
 
 		$is_series_landing = ( function_exists( 'largo_is_series_landing') ) ? largo_is_series_landing( $post ) : false;
 
@@ -59,7 +58,7 @@ class largo_author_widget extends WP_Widget {
 		}
 
 		if ( is_author() || ! empty( $bios ) ) {
-			echo $before_widget;
+			echo $args['before_widget'];
 
 			foreach( $authors as $author_obj ) {
 				$context = array('author_obj' => $author_obj); ?>
@@ -70,7 +69,7 @@ class largo_author_widget extends WP_Widget {
 					</div>
 			<?php }
 
-			echo $after_widget;
+			echo $args['after_widget'];
 		}
 	}
 

--- a/inc/widgets/largo-disclaimer-widget.php
+++ b/inc/widgets/largo-disclaimer-widget.php
@@ -17,20 +17,19 @@ class largo_disclaimer_widget extends WP_Widget {
 			return;
 		}
 
-		extract( $args );
+		echo $args['before_widget'];
 
-		echo $before_widget;
 		?>
 			<?php if ( get_post_meta(get_the_ID(), 'disclaimer', true ) ): ?>
 				<?php echo get_post_meta(get_the_ID(), 'disclaimer', true ); ?>
 			<?php elseif ( of_get_option( 'default_disclaimer' ) ) : ?>
-        <?php echo of_get_option( 'default_disclaimer' ); ?>
+				<?php echo of_get_option( 'default_disclaimer' ); ?>
 			<?php else: ?>
-    			<p class="error"><strong><?php _e('You have not set a disclaimer for your site.</strong> Add a site disclaimer by visiting the Largo Theme Options page.', 'largo'); ?></p>
-      <?php endif; ?>
-
+				<p class="error"><strong><?php _e('You have not set a disclaimer for your site.</strong> Add a site disclaimer by visiting the Largo Theme Options page.', 'largo'); ?></p>
+			<?php endif; ?>
 		<?php
-		echo $after_widget;
+
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/inc/widgets/largo-donate.php
+++ b/inc/widgets/largo-donate.php
@@ -11,20 +11,22 @@ class largo_donate_widget extends WP_Widget {
 		);
 		parent::__construct( 'largo-donate-widget', __('Largo Donate Widget', 'largo'),$widget_opts);
 	}
+
 	function widget( $args, $instance ) {
-		extract( $args );
 
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Support ' . get_bloginfo('name'), 'largo') : $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
-		if ( $title )
-			echo $before_title . $title . $after_title; ?>
+		echo $args['before_widget'];
+		if ( $title ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
 
-            <p><?php echo esc_html( $instance['cta_text'] ); ?></p>
-            <a class="btn btn-primary" href="<?php echo esc_url( $instance['button_url'] ); ?>"><?php echo esc_html( $instance['button_text'] ); ?></a>
-
+		?>
+			<p><?php echo esc_html( $instance['cta_text'] ); ?></p>
+			<a class="btn btn-primary" href="<?php echo esc_url( $instance['button_url'] ); ?>"><?php echo esc_html( $instance['button_text'] ); ?></a>
 		<?php
-		echo $after_widget;
+
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/inc/widgets/largo-facebook.php
+++ b/inc/widgets/largo-facebook.php
@@ -20,9 +20,7 @@ class largo_facebook_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
-		extract( $args );
-
-		echo $before_widget;
+		echo $args['before_widget'];
 
 			$page_url = esc_url( $instance['fb_page_url'] );
 			$height = isset( $instance['widget_height'] ) ? $instance['widget_height'] : 350;
@@ -37,7 +35,7 @@ class largo_facebook_widget extends WP_Widget {
 
 		echo $output;
 
-		echo $after_widget;
+		echo $args['after_widget'];
 
 		self::$rendered = true;
 	}

--- a/inc/widgets/largo-follow.php
+++ b/inc/widgets/largo-follow.php
@@ -18,18 +18,17 @@ class largo_follow_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
-		extract( $args );
 
 		$title = apply_filters('widget_title',  $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
 		if ( is_single() && isset($id) && $id == 'article-bottom' ) {
 			// display the post social bar
 			largo_post_social_links();
 		} else {
 			// Display the widget title if one was input
-			if ( $title ) echo $before_title . $title . $after_title;
+			if ( $title ) echo $args['before_title'] . $title . $args['after_title'];
 			
 			// Display the usual buttons and whatnot
 			$networks = array(
@@ -64,7 +63,7 @@ class largo_follow_widget extends WP_Widget {
 			}
 		}
 
-		echo $after_widget;
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/inc/widgets/largo-image-widget.php
+++ b/inc/widgets/largo-image-widget.php
@@ -52,7 +52,6 @@ class largo_image_widget extends WP_Widget {
 	 * @author Modern Tribe, Inc.
 	 */
 	function widget( $args, $instance ) {
-		extract( $args );
 		$instance = wp_parse_args( (array) $instance, self::get_defaults() );
 		if ( !empty( $instance['imageurl'] ) || !empty( $instance['attachment_id'] ) ) {
 
@@ -73,22 +72,19 @@ class largo_image_widget extends WP_Widget {
 			}
 			$instance['imageurl'] = apply_filters( 'image_widget_image_url', esc_url( $instance['imageurl'] ), $args, $instance );
 
-			// Using extracted vars now
-			extract( $instance );
-
 			//output the widget
-			echo $before_widget;
+			echo $args['before_widget'];
 
-			if ( !empty( $title ) ) { echo $before_title . $title . $after_title; }
+			if ( !empty( $title ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
 
 			echo self::get_image_html( $instance, true );
 
-			if ( !empty( $description ) ) {
+			if ( !empty( $instance['description'] ) ) {
 				echo '<div class="' . $this->widget_options['classname'] . '-description" >';
-				echo wpautop( $description );
+				echo wpautop( $instance['description'] );
 				echo "</div>";
 			}
-			echo $after_widget;
+			echo $args['after_widget'];
 		}
 	}
 

--- a/inc/widgets/largo-post-series-links.php
+++ b/inc/widgets/largo-post-series-links.php
@@ -15,17 +15,16 @@ class largo_post_series_links_widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 		global $post;
-		extract( $args );
 
 		// only useful on post pages
 		if ( !is_single() || !largo_post_in_series() ) return;
 
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Related Series', 'largo') : $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
 		/* Display the widget title if one was input */
-		if ( $title ) echo $before_title . $title . $after_title;
+		if ( $title ) echo $args['before_title'] . $title . $args['after_title'];
 
 		global $post;
 		$post_terms = largo_custom_taxonomy_terms( $post->ID );		//this is the only invocation of this function anywhere in Largo
@@ -35,7 +34,7 @@ class largo_post_series_links_widget extends WP_Widget {
 			echo largo_term_to_label( $term ); //this is the only invocation of this function anywhere in Largo
 		}
 
-		echo $after_widget;
+		echo $args['after_widget'];
 	}
 
 	/**

--- a/inc/widgets/largo-prev-next-post-links.php
+++ b/inc/widgets/largo-prev-next-post-links.php
@@ -14,16 +14,15 @@ class largo_prev_next_post_links_widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 		global $post;
-		extract( $args );
 
 		// only useful on post pages
 		if ( !is_single() ) return;
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
 		largo_content_nav( 'single-post-nav-below', $instance['in_same_cat'] );
 
-		echo $after_widget;
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/inc/widgets/largo-recent-comments.php
+++ b/inc/widgets/largo-recent-comments.php
@@ -43,13 +43,11 @@ class largo_recent_comments_widget extends WP_Widget {
 			return;
 		}
 
-		extract( $args );
-		$output = '';
-
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __('Recent Comments', 'largo') : $instance['title'], $instance, $this->id_base);
 
-		if ( empty( $instance['number'] ) || ! $number = absint( $instance['number'] ) )
+		if ( empty( $instance['number'] ) || ! $number = absint( $instance['number'] ) ) {
 			$number = 5;
+		}
 
 		$comments = get_comments(apply_filters('widget_comments_args', array(
 			'number' => $number,
@@ -58,9 +56,11 @@ class largo_recent_comments_widget extends WP_Widget {
 			'type' => 'comment'
 		)));
 
-		$output .= $before_widget;
-		if ( $title )
-			$output .= $before_title . $title . $after_title;
+		// Begin widget output generation
+		$output = $args['before_widget'];
+		if ( $title ) {
+			$output .= $args['before_title'] . $title . $args['after_title'];
+		}
 
 		$output .= '<ul id="recentcomments">';
 		if ( $comments ) {
@@ -72,7 +72,7 @@ class largo_recent_comments_widget extends WP_Widget {
 			}
  		}
 		$output .= '</ul>';
-		$output .= $after_widget;
+		$output .= $args['after_widget'];
 
 		echo $output;
 		$cache[$args['widget_id']] = $output;

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -40,16 +40,14 @@ class largo_recent_posts_widget extends WP_Widget {
 		// Preserve global $post
 		$preserve = $post;
 
-		extract( $args );
-
 		$posts_term = of_get_option( 'posts_term_plural', 'Posts' );
 
 		// Add the link to the title.
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? __( 'Recent ' . $posts_term, 'largo' ) : $instance['title'], $instance, $this->id_base );
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
-		if ( $title ) echo $before_title . $title . $after_title;
+		if ( $title ) echo $args['before_title'] . $title . $args['after_title'];
 
 		$thumb = isset( $instance['thumbnail_display'] ) ? $instance['thumbnail_display'] : 'small';
 		$excerpt = isset( $instance['excerpt_display'] ) ? $instance['excerpt_display'] : 'num_sentences';
@@ -117,7 +115,7 @@ class largo_recent_posts_widget extends WP_Widget {
 		if( $instance['linkurl'] !='' ) {
 			echo '<p class="morelink"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
 		}
-		echo $after_widget;
+		echo $args['after_widget'];
 
 		// Restore global $post
 		wp_reset_postdata();

--- a/inc/widgets/largo-related-posts.php
+++ b/inc/widgets/largo-related-posts.php
@@ -16,16 +16,15 @@ class largo_related_posts_widget extends WP_Widget {
 		global $post;
 		// Preserve global $post
 		$preserve = $post;
-		extract( $args );
 
 		// only useful on post pages
 		if ( !is_single() ) return;
 
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __( 'Read Next', 'largo' ) : $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
-		if ( $title ) echo $before_title . $title . $after_title;
+		if ( ! empty( $title ) ) echo $args['before_title'] . $title . $args['after_title'];
 
 		if ( isset( $instance['qty'] ) ) {
 			$related = new Largo_Related( $instance['qty'] );
@@ -68,7 +67,7 @@ class largo_related_posts_widget extends WP_Widget {
 
 			echo "</ul>";
 		}
-		echo $after_widget;
+		echo $args['after_widget'];
 		// Restore global $post
 		wp_reset_postdata();
 		$post = $preserve;
@@ -78,7 +77,7 @@ class largo_related_posts_widget extends WP_Widget {
 		$instance = $old_instance;
 		$instance['title'] = sanitize_text_field($new_instance['title']);
 		$instance['qty'] = (int) $new_instance['qty'];
-		$instance['show_byline'] = (int) $new_instance['show_byline'];
+		$instance['show_byline'] = isset( $new_instance['show_byline'] ) ? (int) $new_instance['show_byline'] : 0 ;
 		return $instance;
 	}
 

--- a/inc/widgets/largo-series-posts.php
+++ b/inc/widgets/largo-series-posts.php
@@ -18,24 +18,23 @@ class largo_series_posts_widget extends WP_Widget {
 		$preserve = $post;
 
 		// instance: num, series (id), title, heading
-		extract( $args );
 
 		//get the posts
- 		$series_posts = largo_get_series_posts( $instance['series'], $instance['num'] );
+		$series_posts = largo_get_series_posts( $instance['series'], $instance['num'] );
 
- 		if ( ! $series_posts ) return; //output nothing if no posts found
+		if ( empty( $series_posts ) ) return; //output nothing if no posts found
 
 
 		$instance['title_link'] = get_term_link( (int) $instance['series'], 'series' );
 		$term = get_term( $instance['series'], 'series' );
 		$title = apply_filters( 'widget_title', $term->name, $instance, $this->id_base );
 
-		echo $before_widget;
+		echo $args['before_widget'];
 
-		if ( $title ) echo $before_title . $title . $after_title;
+		if ( ! empty( $title ) ) echo $args['before_title'] . $title . $args['after_title'];
 
-	 	//first post
-	 	$series_posts->the_post();
+		//first post
+		$series_posts->the_post();
 
 		$context = array(
 			'instance' => $instance,
@@ -62,9 +61,9 @@ class largo_series_posts_widget extends WP_Widget {
 			echo '</ul>';
 		}
 
- 		echo '<a class="more" href="' . get_term_link( (int) $instance['series'], 'series' ) . '">' . __('Complete Coverage', 'largo') . "</a>";
+		echo '<a class="more" href="' . get_term_link( (int) $instance['series'], 'series' ) . '">' . __('Complete Coverage', 'largo') . "</a>";
 
-		echo $after_widget;
+		echo $args['after_widget'];
 
 		// Restore global $post
 		wp_reset_postdata();

--- a/inc/widgets/largo-staff.php
+++ b/inc/widgets/largo-staff.php
@@ -81,13 +81,15 @@ class largo_staff_widget extends WP_Widget {
 	public function form( $instance ) {
 		$roles = get_editable_roles();
 
-		if (isset($instance['title']))
+		if (isset($instance['title'])) {
 			$title = $instance['title'];
-		else
+		} else {
 			$title = 'Staff Members';
+		}
 
-		if (empty($instance['roles']))
+		if (empty($instance['roles'])) {
 			$instance['roles']['author'] = 'on';
+		}
 
 		?>
 		<p>
@@ -97,11 +99,22 @@ class largo_staff_widget extends WP_Widget {
 
 		<p>
 			<label><?php _e( 'Include:' ); ?></label><br/>
-			<?php foreach ($roles as $key => $role) { ?>
-			<label><input <?php checked($instance['roles'][$key], 'on', true); ?>
+			<?php foreach ($roles as $key => $role) {
+				if (
+					isset( $instance['roles'] )
+					&& isset( $instance['roles'][$key] )
+				) {
+					$checked = checked( $instance['roles'][$key], 'on', false );
+				} else {
+					$checked = '';
+				}
+				?>
+				<label><input <?php echo $checked; ?>
 					type="checkbox"
 					id="<?php echo $this->get_field_id($key); ?>"
-					name="<?php echo $this->get_field_name($key); ?>"> <?php echo $role['name']; ?>s</label><br />
+					name="<?php echo $this->get_field_name($key); ?>"> <?php echo $role['name']; ?>s
+				</label>
+				<br />
 			<?php } ?>
 		</p>
 

--- a/inc/widgets/largo-tag-list.php
+++ b/inc/widgets/largo-tag-list.php
@@ -14,14 +14,13 @@ class largo_tag_list_widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 		global $post;
-		extract( $args );
 
 		// only useful on post pages
 		if ( !is_single() ) return;
 
 		$title = apply_filters('widget_title', empty( $instance['title'] ) ? __( 'Tags ', 'largo' ) : $instance['title'], $instance, $this->id_base);
 
-		echo $before_widget;
+		echo $args['before_widget'];
 		?>
 		  <!-- Post tags -->
 		<?php if ( largo_has_categories_or_tags() ): ?>
@@ -33,7 +32,7 @@ class largo_tag_list_widget extends WP_Widget {
 			</div>
 		<?php endif;
 
-		echo $after_widget;
+		echo $args['after_widget'];
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/inc/widgets/largo-taxonomy-list.php
+++ b/inc/widgets/largo-taxonomy-list.php
@@ -27,7 +27,6 @@ class largo_taxonomy_list_widget extends WP_Widget {
 	 * @uses largo_taxonomy_list_widget::render_term_list
 	 */
 	function widget( $args, $instance ) {
-		extract( $args );
 
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? __( 'Series', 'largo' ) : $instance['title'], $instance, $this->id_base );
 		$is_dropdown = ! empty( $instance['dropdown'] ) ? '1' : '0';
@@ -35,9 +34,10 @@ class largo_taxonomy_list_widget extends WP_Widget {
 		/*
 		 * Before the widget
 		 */
-		echo $before_widget;
-		if ( $title )
-			echo $before_title . $title . $after_title;
+		echo $args['before_widget'];
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
 
 		// Set us up the term args
 		$term_args = array(
@@ -105,7 +105,7 @@ class largo_taxonomy_list_widget extends WP_Widget {
 			echo '</ul>';
 		}
 
-		echo $after_widget;
+		echo $args['after_widget'];
 	}
 
 	/**
@@ -254,12 +254,12 @@ class largo_taxonomy_list_widget extends WP_Widget {
 		$instance = wp_parse_args( (array) $instance, array( 'title' => '', 'taxonomy' => '' ) );
 		$title = esc_attr( $instance['title'] );
 		$count = isset( $instance['count'] ) ? esc_attr( $instance['count'] ) : 5;
-		$sort = esc_attr( $instance['sort'] );
+		$sort = isset( $instance['sort'] ) ? esc_attr( $instance['sort'] ) : '';
 		$instance['taxonomy'] = isset( $instance['taxonomy'] ) ? $instance['taxonomy'] : 'series';
 		$dropdown = isset( $instance['dropdown'] ) ? (bool) $instance['dropdown'] : false;
 		$thumbnails = isset( $instance['thumbnails'] ) ? (bool) $instance['thumbnails'] : false;
 		$use_headline = isset( $instance['use_headline'] ) ? (bool) $instance['use_headline'] : false;
-		$exclude = $instance['exclude'];
+		$exclude = isset( $instance['exclude'] ) ? $instance['exclude'] : '';
 
 		// Create <option>s of taxonomies for the <select>
 		$taxonomies = get_taxonomies( null, 'objects' );
@@ -281,12 +281,13 @@ class largo_taxonomy_list_widget extends WP_Widget {
 			'id_desc' => __( 'Most Recent First', 'largo' )
 		); // list from https://developer.wordpress.org/reference/functions/get_terms/
 		$sort_order_options = '';
+
 		foreach ( $sort_orders as $order => $label ) {
 			$sort_order_options .= sprintf(
 				'<option value="%1$s" %2$s>%3$s</option>',
 					$order,
-					selected( $instance['sort'], $order, false ),
-					$label
+					selected( $sort, $order, false ),
+					wp_kses_post( $label )
 			);
 		}
 
@@ -306,7 +307,7 @@ class largo_taxonomy_list_widget extends WP_Widget {
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'sort' ); ?>"><?php _e( 'How should the terms be ordered?', 'largo' ); ?></label>
-			<select class="widefat" id="<?php echo $this->get_field_id( 'sort' ); ?>" name="<?php echo $this->get_field_name( 'sort' ); ?>" type="text" value="<?php echo $instance['sort'] ?>">
+			<select class="widefat" id="<?php echo $this->get_field_id( 'sort' ); ?>" name="<?php echo $this->get_field_name( 'sort' ); ?>" type="text" value="<?php echo $sort; ?>">
 				<?php echo $sort_order_options; ?>
 			</select>
 		</p>

--- a/inc/widgets/largo-twitter.php
+++ b/inc/widgets/largo-twitter.php
@@ -20,9 +20,8 @@ class largo_twitter_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
-		extract( $args );
 
-		echo $before_widget;
+		echo $args['before_widget'];
 		
 		// Build the placeholder URLs used by various widget types
 		// Note that these are not strictly necessary (widget will render as long as the data-widget-id attribute is correct
@@ -35,8 +34,11 @@ class largo_twitter_widget extends WP_Widget {
 				break;
 			case 'list':
 				$widget_href = 'https://twitter.com/' . $instance['twitter_username'] . '/lists/' . $instance['twitter_list_slug'];
-				/* translators: Tweets from [list URL] */
-				$widget_text = __( 'A Twitter List by ' . $instance['twitter_username'], 'largo' );
+				$widget_text = sprintf(
+					/* translators: A Twitter List by [twitter user name] */
+					__( 'A Twitter List by %1$s', 'largo' ),
+					$instance['twitter_username']
+				);
 				break;
 			case 'collection':
 				$widget_href = 'https://twitter.com/' . $instance['twitter_username'] . '/timelines/' . $instance['twitter_collection_id'];
@@ -53,11 +55,19 @@ class largo_twitter_widget extends WP_Widget {
 			esc_attr( $widget_text )
 		);
 		// N.B. - the JS is enqueued in largo_footer_js (inc/enqueue.php)
-	
+
 		echo $widget_embed;
 
-		echo $after_widget;
-		
+		echo $args['after_widget'];
+
+		wp_enqueue_script(
+			'largo_twitter_widget',
+			'//platform.twitter.com/widgets.js',
+			array(),
+			null,
+			true
+		);
+
 		self::$rendered = true;
 
 	}
@@ -76,17 +86,21 @@ class largo_twitter_widget extends WP_Widget {
 			'widget_ID' 		=> '',
 			'twitter_username' 	=> largo_twitter_url_to_username( of_get_option( 'twitter_link' ) ),
 			'widget_type' 		=> 'timeline',
+			'twitter_list_slug' => '',
+			'twitter_collection_id' => '',
+			'twitter_collection_title' => '',
 		);
 		$instance = wp_parse_args( (array) $instance, $defaults );
+
 		?>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'widget_type' ); ?>"><?php _e('Widget Type', 'largo'); ?></label>
 			<select id="<?php echo $this->get_field_id( 'widget_type' ); ?>" name="<?php echo $this->get_field_name( 'widget_type' ); ?>" class="widefat" style="width:90%;">
-			    <option <?php selected( $instance['widget_type'], 'timeline'); ?> value="timeline"><?php _e( 'Timeline', 'largo' ); ?></option>
-			    <option <?php selected( $instance['widget_type'], 'likes'); ?> value="likes"><?php _e( 'Likes', 'largo' ); ?></option>
-			    <option <?php selected( $instance['widget_type'], 'list'); ?> value="list"><?php _e( 'List', 'largo' ); ?></option>
-			    <option <?php selected( $instance['widget_type'], 'collection'); ?> value="collection"><?php _e( 'Collection', 'largo' ); ?></option>
+				<option <?php selected( $instance['widget_type'], 'timeline'); ?> value="timeline"><?php _e( 'Timeline', 'largo' ); ?></option>
+				<option <?php selected( $instance['widget_type'], 'likes'); ?> value="likes"><?php _e( 'Likes', 'largo' ); ?></option>
+				<option <?php selected( $instance['widget_type'], 'list'); ?> value="list"><?php _e( 'List', 'largo' ); ?></option>
+				<option <?php selected( $instance['widget_type'], 'collection'); ?> value="collection"><?php _e( 'Collection', 'largo' ); ?></option>
 			</select>
 		</p>
 
@@ -104,12 +118,12 @@ class largo_twitter_widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'twitter_list_slug' ); ?>"><?php _e( 'Twitter List Slug (for list widget):', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'twitter_list_slug' ); ?>" name="<?php echo $this->get_field_name( 'twitter_list_slug' ); ?>" value="<?php echo esc_attr( $instance['twitter_list_slug'] ); ?>" style="width:90%;" />
 		</p>
-		
+
 		<p>
 			<label for="<?php echo $this->get_field_id( 'twitter_collection_id' ); ?>"><?php _e( 'Collection ID (for collection widget):', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'twitter_collection_id' ); ?>" name="<?php echo $this->get_field_name( 'twitter_collection_id' ); ?>" value="<?php echo esc_attr( $instance['twitter_collection_id'] ); ?>" style="width:90%;" />
 		</p>
-		
+
 		<p>
 			<label for="<?php echo $this->get_field_id( 'twitter_collection_title' ); ?>"><?php _e( 'Collection Title (for collection widget):', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'twitter_collection_title' ); ?>" name="<?php echo $this->get_field_name( 'twitter_collection_title' ); ?>" value="<?php echo esc_attr( $instance['twitter_collection_title'] ); ?>" style="width:90%;" />

--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -181,7 +181,7 @@ class Navis_Media_Credit {
         ), $atts );
         $atts = apply_filters( 'navis_image_layout_defaults', $atts );
 
-        if ( $atts['id'] && empty( $atts['credit'] ) {
+        if ( $atts['id'] && empty( $atts['credit'] ) ) {
             $post_id = str_replace( 'attachment_', '', $atts['id'] );
             $creditor = navis_get_media_credit( $post_id );
             $credit = ! empty( $creditor ) ? $creditor->to_string() : '';
@@ -203,7 +203,7 @@ class Navis_Media_Credit {
 			);
 		}
 
-        if ( !empty( $atts['caption'] ) {
+        if ( !empty( $atts['caption'] ) ) {
             $out .= sprintf( '<p class="wp-caption-text">%s</p>', wp_kses_post( $atts['caption'] ) );
         }
 

--- a/lib/navis-media-credit/navis-media-credit.php
+++ b/lib/navis-media-credit/navis-media-credit.php
@@ -180,26 +180,33 @@ class Navis_Media_Credit {
             'caption' => '',
         ), $atts );
         $atts = apply_filters( 'navis_image_layout_defaults', $atts );
-        extract( $atts );
 
-        if ( $id && ! $credit ) {
-            $post_id = str_replace( 'attachment_', '', $id );
+        if ( $atts['id'] && empty( $atts['credit'] ) {
+            $post_id = str_replace( 'attachment_', '', $atts['id'] );
             $creditor = navis_get_media_credit( $post_id );
             $credit = ! empty( $creditor ) ? $creditor->to_string() : '';
         }
 
-        if ( $id ) {
-            $id = 'id="' . esc_attr($id) . '" ';
+        // XXX: maybe remove module and image classes at some point
+		$out = sprintf(
+			'<div id="%s" class="wp-caption module image %s" style="max-width: %spx;">%s',
+			esc_attr( $atts['id'] ),
+			esc_attr( $atts['align'] ),
+			esc_attr( $atts['width'] ),
+			do_shortcode( $content )
+		);
+
+		if ( isset( $credit ) ) {
+			$out .= sprintf(
+				'<p class="wp-media-credit">%s</p>',
+				wp_kses_post( $credit )
+			);
+		}
+
+        if ( !empty( $atts['caption'] ) {
+            $out .= sprintf( '<p class="wp-caption-text">%s</p>', wp_kses_post( $atts['caption'] ) );
         }
 
-        // XXX: maybe remove module and image classes at some point
-        $out = sprintf( '<div %s class="wp-caption module image %s" style="max-width: %spx;">%s', $id, $align, $width, do_shortcode( $content ) );
-        if ( $credit ) {
-            $out .= sprintf( '<p class="wp-media-credit">%s</p>', $credit );
-        }
-        if ( $caption ) {
-            $out .= sprintf( '<p class="wp-caption-text">%s</p>', $caption );
-        }
         $out .= "</div>";
 
         return $out;


### PR DESCRIPTION
## Changes

Removes `extract()` calls from most places in Largo:

- [x] `./inc/users.php`
- [x] `./homepages/homepage-class.php:		extract($vars);`
- [x] `./inc/editor.php:    extract( shortcode_atts( array(`
- [x] `./inc/helpers.php: * @return  string  the Facebook username or id extracted from the input string`
- [x] `./inc/helpers.php: * @return 	string	the twitter username extracted from the input string`
- [x] `./inc/pagination.php:		extract( $r, EXTR_SKIP );`
- [x] `./inc/widgets/largo-about.php:		extract( $args );`
- [x] `./inc/widgets/largo-author-bio.php:		extract( $args );`
- [x] `./inc/widgets/largo-disclaimer-widget.php:		extract( $args );`
- [x] `./inc/widgets/largo-donate.php:		extract( $args );`
- [x] `./inc/widgets/largo-facebook.php:		extract( $args );`
- [x] `./inc/widgets/largo-follow.php:		extract( $args );`
- [x] `./inc/widgets/largo-image-widget.php:		extract( $args );`
- [x] `./inc/widgets/largo-image-widget.php:			// Using extracted vars now`
- [x] `./inc/widgets/largo-image-widget.php:			extract( $instance );`
- [x] `./inc/widgets/largo-post-series-links.php:		extract( $args );`
- [x] `./inc/widgets/largo-prev-next-post-links.php:		extract( $args );`
- [x] `./inc/widgets/largo-recent-comments.php:		extract( $args );`
- [x] `./inc/widgets/largo-recent-posts.php:		extract( $args );`
- [x] `./inc/widgets/largo-related-posts.php:		extract( $args );`
- [x] `./inc/widgets/largo-series-posts.php:		extract( $args );`
- [x] `./inc/widgets/largo-tag-list.php:		extract( $args );`
- [x] `./inc/widgets/largo-taxonomy-list.php:		extract( $args );`
- [x] `./inc/widgets/largo-twitter.php:		extract( $args );`
- [x] `./js/tinymce/plugins/largo/window.php:		<li><input type="radio" name="mod_width" value="extract" id="extract"> Extract from Embed (non-responsive)</li>`
- [x] `./lib/class-tgm-plugin-activation.php:		 * Helper function to extract the file path of the plugin file from the`
- [x] `./lib/class-tgm-plugin-activation.php:					 * Constructor. Parses default args with new ones and extracts them for use.`
- [x] `./lib/navis-media-credit/navis-media-credit.php:        extract( $atts );`

The remaining places:

```
./homepages/homepage-class.php:		extract($vars);
./partials/content.php:extract( $args );
./tests/inc/test-users.php:		extract($vars);
./tests/inc/test-users.php:		extract($vars);
./tests/inc/test-users.php:		extract($args);
```

Also:
- Twitter Widget JS is no longer enqueued in `largo_footer_js()`; instead being enqueued directly from the widget.
- Fixes some `undefined index` errors in widget form and update functions.
- Whitespace cleanup in some places

## Why

Because `extract()` is risky.