### PR TITLE
Actually implement 'title-tag' theme support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,12 +18,14 @@ Thanks to Mike Schinkel for his work on [pull request 1469](https://github.com/I
 ## Changes
 - Fixes numerous undefined variable errors.
 - Users who have the capability to edit a given post will see the edit link on the frontend, where before users with the capability to edit published posts in general saw the link to edit the post in the frontend. [PR #1559](https://github.com/INN/largo/pull/1559) for [issue #1543](https://github.com/INN/largo/issues/1543).
+- Largo now uses WordPress' `title-tag` support for `<title>` tag output, which means that site title tags shoud now be modifiable by plugins. [PR #]() for [issue 1470](https://github.com/INN/largo/issues/1470).
 
 ### Removed
 - Removes the default inclusion of Google Analytics with INN's Largo Project IDs. [PR #1502](https://github.com/INN/largo/pull/1502) as part of [issue #1495](https://github.com/INN/largo/issues/1495), and by request.
 - Removes the INN Member RSS widget, because the RSS feed it draws from is no longer supported or maintained by INN. Because the RSS feed was occasionally empty, the widget would result in 500 errors. [RP #1535](https://github.com/INN/largo/pulls/1535) for [issue #1511](https://github.com/INN/largo/issues/1511) and [#893](https://github.com/INN/largo/issues/893).
 - Removes lingering traces of the Largo Featured Widget. [PR #1563](https://github.com/INN/largo/pull/1563) and [#1469](https://github.com/INN/largo/pull/1469) for [issue 1467](https://github.com/INN/largo/issues/1467), from Github user [mikeschinkel](https://github.com/mikeschinkel).
 - Removes many uses of `extract()` in widgets and theme functions, and improves code quality in widgets.
+- Removes the `<title>` element from `header.php`, since Largo declares `title-tag` theme support. [PR #]() for [issue 1470](https://github.com/INN/largo/issues/1470).
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.

--- a/header.php
+++ b/header.php
@@ -18,22 +18,17 @@
 	 * @since 0.1
 	 */
 	?>
-	<title>
-		<?php
-			global $page, $paged;
-			wp_title( '|', true, 'right' );
-			bloginfo( 'name' ); // Add the blog name.
-
-			// Add the blog description for the home/front page.
-			$site_description = get_bloginfo( 'description', 'display' );
-			if ( $site_description && ( is_home() || is_front_page() ) )
-				echo " | $site_description";
-
-			// Add a page number if necessary:
-			if ( $paged >= 2 || $page >= 2 )
-				echo ' | ' . 'Page ' . max( $paged, $page );
-		?>
-	</title>
+	<?php
+		// Fallback <title> tag on WP pre 4.1
+		// @link https://make.wordpress.org/core/2014/10/29/title-tags-in-4-1/
+		// @since 0.6
+		if ( ! function_exists( '_wp_render_title_tag' ) ) {
+			printf(
+				'<title>%1$s</title>',
+				wp_title( '|', false, 'right' )
+			);
+		}
+	?>
 	<link rel="profile" href="https://gmpg.org/xfn/11" />
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 <?php

--- a/header.php
+++ b/header.php
@@ -31,12 +31,13 @@
 	?>
 	<link rel="profile" href="https://gmpg.org/xfn/11" />
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
-<?php
-	if ( is_singular() && get_option( 'thread_comments' ) )
-		wp_enqueue_script( 'comment-reply' );
+	<?php
+		if ( is_singular() && get_option( 'thread_comments' ) ) {
+			wp_enqueue_script( 'comment-reply' );
+		}
 
-	wp_head();
-?>
+		wp_head();
+	?>
 </head>
 
 <body <?php body_class(); ?>>

--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -638,12 +638,14 @@ add_action( 'wp_ajax_largo_fetch_video_oembed', 'largo_fetch_video_oembed' );
 function largo_featured_media_post_classes( $classes ) {
 	global $post;
 
-	$featured = largo_get_featured_media( $post->ID );
-	if ( !empty( $featured ) ) {
-		$classes = array_merge( $classes, array(
-			'featured-media',
-			'featured-media-' . $featured['type']
-		));
+	if ( is_a( $post, 'WP_Post' ) ) {
+		$featured = largo_get_featured_media( $post->ID );
+		if ( !empty( $featured ) ) {
+			$classes = array_merge( $classes, array(
+				'featured-media',
+				'featured-media-' . $featured['type']
+			));
+		}
 	}
 
 	return $classes;

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -95,3 +95,49 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 	}
 }
 add_action( 'wp_head', 'largo_opengraph' );
+
+/**
+ * Filter wp_title() to add our custom metadata
+ *
+ * @since 0.6
+ * @link https://github.com/INN/largo/issues/1470
+ * @param Array $parts An array of title parts.
+ * @return Array.
+ */
+function largo_wp_title_parts_filter( $parts ) {
+	global $page, $paged;
+
+	// Add the blog description for the home/front page.
+	if ( is_home() || is_front_page() ) {
+		$site_description = get_bloginfo( 'description', 'display' );
+		if ( ! empty ( $site_description ) ) {
+			$parts[] = $site_description;
+		}
+	}
+
+	// Add a page number if necessary:
+	if ( isset( $paged ) || isset( $page ) ) {
+		if ( $paged >= 2 || $page >= 2 ) {
+			$parts[] = sprintf(
+				// translators: %1$s is the page number.
+				__( 'Page %1$s' , 'largo' ),
+				max( $paged, $page )
+			);
+		}
+	}
+
+	$parts[] = get_bloginfo( 'name' ); // Add the blog name.
+	error_log(var_export( $parts, true));
+
+
+	foreach ( $parts as $i => $part ) {
+		if ( empty( $part ) ) {
+			unset( $parts[$i] );
+		}
+	}
+
+	add_filter( 'wp_title', 'largo_wp_title_filter', 10, 3 );
+
+	return $parts;
+}
+add_filter( 'wp_title_parts', 'largo_wp_title_parts_filter' );

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -141,3 +141,13 @@ function largo_wp_title_parts_filter( $parts ) {
 	return $parts;
 }
 add_filter( 'wp_title_parts', 'largo_wp_title_parts_filter' );
+
+/**
+ * Return to using |
+ *
+ * @since Largo 0.6
+ * @link https://developer.wordpress.org/reference/functions/wp_get_document_title/
+ */
+add_filter( 'document_title_separator', function( $sep ) {
+	return '|';
+});

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -411,12 +411,14 @@ function largo_top_term( $options = array() ) {
  */
 function largo_post_class_top_term( $classes ) {
 	global $post;
-	$top_term = get_post_meta( $post->ID, 'top_term', TRUE );
-	$term = get_term_by( 'id', $top_term, 'post_tag' );
+	if ( is_a( $post, 'WP_Post' ) ) {
+		$top_term = get_post_meta( $post->ID, 'top_term', TRUE );
+		$term = get_term_by( 'id', $top_term, 'post_tag' );
 
-	// Don't output the class .top-term-- if there isn't a top term saved
-	if ( !empty( $term ) ) {
-		$classes[] = 'top-term-' . $term->taxonomy . '-' . $term->slug;
+		// Don't output the class .top-term-- if there isn't a top term saved
+		if ( !empty( $term ) ) {
+			$classes[] = 'top-term-' . $term->taxonomy . '-' . $term->slug;
+		}
 	}
 
 	return $classes;

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -91,7 +91,8 @@ function _tags_associated_with_category( $cat_id, $max = 5 ) {
         $tag_keys = array_keys( $tags );
     }
     else {
-        $tag_keys = array_splice( array_keys( $tags ), 0, $max );
+		$temporary_array_keys = array_keys( $tags );
+		$tag_keys = array_splice( $temporary_array_keys, 0, $max );
     }
 
     // Create an array of the selected tag objects

--- a/partials/archive-category-primary-feature.php
+++ b/partials/archive-category-primary-feature.php
@@ -1,7 +1,7 @@
 <article id="post-<?php echo $featured_post->ID ?>" <?php post_class('clearfix row-fluid', $featured_post->ID); ?>>
 <?php if ( has_post_thumbnail($featured_post->ID) ) { ?>
 	<div class="span4 <?php largo_hero_class($featured_post->ID); ?>">
-		<a href="<?php echo post_permalink($featured_post->ID); ?>"><?php echo get_the_post_thumbnail($featured_post->ID, 'rect_thumb'); ?></a>
+		<a href="<?php echo get_permalink($featured_post->ID); ?>"><?php echo get_the_post_thumbnail($featured_post->ID, 'rect_thumb'); ?></a>
 	</div>
 
 	<div class="span8">
@@ -10,7 +10,7 @@
 <?php } ?>
 		<header>
 			<h2 class="entry-title">
-				<a href="<?php echo post_permalink($featured_post->ID); ?>"
+				<a href="<?php echo get_permalink($featured_post->ID); ?>"
 					title="<?php echo __( 'Permalink to', 'largo' ) . esc_attr(strip_tags($featured_post->post_title)); ?>"
 					rel="bookmark"><?php echo $featured_post->post_title; ?></a>
 			</h2>

--- a/partials/archive-category-secondary-feature.php
+++ b/partials/archive-category-secondary-feature.php
@@ -1,14 +1,14 @@
 <article id="post-<?php echo $featured_post->ID; ?>" <?php post_class('span3', $featured_post->ID); ?>>
 	<?php if ( has_post_thumbnail($featured_post->ID) ) { ?>
 		<div class="<?php largo_hero_class($featured_post->ID); ?>">
-			<a href="<?php echo post_permalink($featured_post->ID); ?>">
+			<a href="<?php echo get_permalink($featured_post->ID); ?>">
 				<?php echo get_the_post_thumbnail($featured_post->ID, 'rect_thumb'); ?>
 			</a>
 		</div>
 	<?php } ?>
 
 	<h2 class="entry-title">
-		<a href="<?php echo post_permalink($featured_post->ID); ?>"
+		<a href="<?php echo get_permalink($featured_post->ID); ?>"
 			title="<?php echo __( 'Permalink to', 'largo' ) . esc_attr(strip_tags($featured_post->post_title)); ?>"	
 			rel="bookmark"><?php echo $featured_post->post_title; ?></a>
 	</h2>


### PR DESCRIPTION
## Changes

- removes `<title>` from `header.php`, for https://github.com/INN/largo/issues/1470, continuing work begun in https://github.com/INN/largo/pull/1245 by @mspseudolus.
- fixes an Undefined error in `largo_featured_media_post_classes()` and `largo_post_class_top_term()`
- fixes a pass-by-reference error in `_tags_associated_with_category()`
- replaces deprecated `post_permalink()` calls with `get_permalink()`

## Why

Title tag changes fix https://github.com/INN/largo/issues/1470

PHP errors as part of https://github.com/INN/largo/issues/1492