### PR TITLE
updating largo_byline call in partials

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 though this project doesn't succeed in adhering to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Largo 0.6.1
+
+This release contains bugfixes for Largo 0.6.
+
+### Fixes
+
+- Updates templates to make sure that bylines are output. [Pull request #1574](https://github.com/INN/largo/pull/1574).
+
 ## [Largo 0.6](https://github.com/INN/largo/compare/v0.5.5.4...v0.6)
 
 Special thanks to our community contributors:

--- a/changelog.md
+++ b/changelog.md
@@ -46,7 +46,7 @@ Special thanks to our community contributors:
 
 ### Upgrade notices
 - If your child theme has significant custom styling, or has custom post templates, your theme may need to provide additional styles to ensure Gutenberg compatibility.
-- A future version of Largo will require the third parameter of `largo_byline()` to be specified in all calls. [PR #1561](https://github.com/INN/largo/pull/1561) for [issue #1517](https://github.com/INN/largo/issues/1517) adds code that, in testing environments with `WP_DEBUG` or `LARGO_DEBUG` set to `true`, will result in server log messages. This is necessary to prevent mismatches between the Loop's global `$post` and the desired byline output. The third parameter of `largo_byline()` may be a `WP_Post` instance or a post ID. Example call: `largo_byline( null, null, get_the_ID() );`.
+- A future version of Largo will require the third parameter of `largo_byline()` to be specified in all calls. [PR #1561](https://github.com/INN/largo/pull/1561) for [issue #1517](https://github.com/INN/largo/issues/1517) adds code that, in testing environments with `WP_DEBUG` or `LARGO_DEBUG` set to `true`, will result in server log messages. This is necessary to prevent mismatches between the Loop's global `$post` and the desired byline output. The third parameter of `largo_byline()` may be a `WP_Post` instance or a post ID. Example call: `largo_byline( true, false, get_the_ID() );`.
 
 ## [Largo 0.5.5.4](https://github.com/INN/largo/releases/tag/v0.5.5.4)
 

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -28,7 +28,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 		?>
 				<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'large' ); ?></a>
 				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-				<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+				<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 				<?php largo_excerpt( $post, 4 ); ?>
 				<?php if ( largo_post_in_series() ):
 					$feature = largo_get_the_main_feature();

--- a/partials/content-roundup.php
+++ b/partials/content-roundup.php
@@ -25,7 +25,7 @@ $featured = has_term( 'homepage-featured', 'prominence' );
 		<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
 	</h2>
 
-	<h5 class="byline visuallyhidden"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+	<h5 class="byline visuallyhidden"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 
 	<?php the_content(); ?>
 

--- a/partials/content-single-classic.php
+++ b/partials/content-single-classic.php
@@ -14,7 +14,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) )
 			echo '<h2 class="subtitle">' . $subtitle . '</h2>';
 		?>
-		<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+		<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 
 		<?php
 			if ( !of_get_option( 'single_social_icons' ) == false ) {

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -16,7 +16,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
 			<h2 class="subtitle"><?php echo $subtitle ?></h2>
 		<?php endif; ?>
-		<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+		<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 
 		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
 			largo_post_social_links();

--- a/partials/content.php
+++ b/partials/content.php
@@ -72,7 +72,7 @@ if ( $featured ) {
 
 		<?php
 			if ( $show_byline ) { ?>
-				<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+				<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 			<?php }
 		?>
 

--- a/partials/sticky-posts.php
+++ b/partials/sticky-posts.php
@@ -50,7 +50,7 @@ if ( $query->have_posts() ) {
 						<?php } ?>
 
 						<h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-						<h5 class="byline"><?php largo_byline( null, null, get_the_ID() ); ?></h5>
+						<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
 
 						<div class="entry-content">
 						<?php

--- a/series-landing.php
+++ b/series-landing.php
@@ -45,7 +45,7 @@ $content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 
 		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<?php
 		if ( $opt['show_series_byline'] )
-			echo '<h5 class="byline">' . largo_byline( false, null, get_the_ID() ) . '</h5>';
+			echo '<h5 class="byline">' . largo_byline( false, false, get_the_ID() ) . '</h5>';
 		if ( $opt['show_sharebar'] )
 			largo_post_social_links();
 		?>


### PR DESCRIPTION
## Changes
Updates first two default parameters in `largo_byline` to `true, false` in various content partials.

## Why
Having them set to `null, null` was causing bylines not to render by default.