### PR TITLE
Change enqueues to use filemtime instead of no version number or Largo's version number

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ This release contains bugfixes for Largo 0.6.
 ### Changes
 
 - Uses [`filemtime()`](https://secure.php.net/manual/en/function.filemtime.php) as the version number for more enqueued assets, meaning that cachebusting will be handled by file modification time and not by Largo version. [Pull Request #1575](https://github.com/INN/largo/pull/1575) for [issue #1550](https://github.com/INN/largo/issues/1550).
-
+- For many assets where no version number was provided for enqueued assets, `largo_version()` is now used.  [Pull Request #1575](https://github.com/INN/largo/pull/1575) for [issue #1550](https://github.com/INN/largo/issues/1550).
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 
 This release contains bugfixes for Largo 0.6.
 
+### Changes
+
+- Uses [`filemtime()`](https://secure.php.net/manual/en/function.filemtime.php) as the version number for more enqueued assets, meaning that cachebusting will be handled by file modification time and not by Largo version. [Pull Request #1575](https://github.com/INN/largo/pull/1575) for [issue #1550](https://github.com/INN/largo/issues/1550).
+
+
 ### Fixes
 
 - Updates templates to make sure that bylines are output. [Pull request #1574](https://github.com/INN/largo/pull/1574).

--- a/inc/ajax-functions.php
+++ b/inc/ajax-functions.php
@@ -21,12 +21,13 @@ if ( !function_exists( 'largo_load_more_posts_enqueue_script' ) ) {
 	 */
 	function largo_load_more_posts_enqueue_script() {
 		$suffix = (LARGO_DEBUG)? '' : '.min';
-		$version = largo_version();
 
 		wp_enqueue_script(
 			'load-more-posts',
 			get_template_directory_uri() . '/js/load-more-posts'. $suffix . '.js',
-			array('jquery'), $version, false
+			array('jquery'),
+			filemtime( get_template_directory() . '/js/load-more-posts' . $suffix . '.js' ),
+			false
 		);
 	}
 	add_action( 'wp_enqueue_scripts', 'largo_load_more_posts_enqueue_script' );

--- a/inc/avatars/admin.php
+++ b/inc/avatars/admin.php
@@ -1,7 +1,12 @@
 <?php
 
 function largo_load_avatar_js() {
-	wp_enqueue_script('largo_avatar_js', get_template_directory_uri() . '/inc/avatars/js/avatars.js', array('jquery'));
+	wp_enqueue_script(
+		'largo_avatar_js',
+		get_template_directory_uri() . '/inc/avatars/js/avatars.js',
+		array('jquery'),
+		largo_version()
+	);
 	wp_localize_script('largo_avatar_js', 'largo_avatar_js_L10n', array(
 		'update_text' => __('Click "Update Profile" to save your avatar.', 'largo')
 	));

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -338,10 +338,18 @@ class Largo_Customizer {
 	 * Enqueue scripts and styles specific to the Largo Customizer
 	 */
 	public function action_customize_controls_enqueue_scripts() {
-
-		wp_enqueue_script( 'largo-customizer', get_template_directory_uri() . '/inc/customizer/js/customizer.js', array( 'jquery' ) );
-		wp_enqueue_style( 'largo-customizer', get_template_directory_uri() . '/inc/customizer/css/customizer.css' );
-
+		wp_enqueue_script(
+			'largo-customizer',
+			get_template_directory_uri() . '/inc/customizer/js/customizer.js',
+			array( 'jquery' ),
+			largo_version()
+		);
+		wp_enqueue_style(
+			'largo-customizer',
+			get_template_directory_uri() . '/inc/customizer/css/customizer.css',
+			array(),
+			largo_version()
+		);
 	}
 
 	/**

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -131,8 +131,19 @@ function largo_enqueue_admin_scripts() {
 
 	// Use minified assets if LARGO_DEBUG isn't true.
 	$suffix = (LARGO_DEBUG)? '' : '.min';
-	wp_enqueue_style( 'largo-admin-widgets', get_template_directory_uri().'/css/widgets-php' . $suffix . '.css' );
-	wp_enqueue_script( 'largo-admin-widgets', get_template_directory_uri() . '/js/widgets-php' . $suffix . '.js', array( 'jquery' ), '1.0', true );
+	wp_enqueue_style(
+		'largo-admin-widgets',
+		get_template_directory_uri() . '/css/widgets-php' . $suffix . '.css',
+		array(),
+		largo_version()
+	);
+	wp_enqueue_script(
+		'largo-admin-widgets',
+		get_template_directory_uri() . '/js/widgets-php' . $suffix . '.js',
+		array( 'jquery' ),
+		largo_version(),
+		true
+	);
 }
 add_action( 'admin_enqueue_scripts', 'largo_enqueue_admin_scripts' );
 

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -112,10 +112,10 @@ if ( ! function_exists( 'largo_enqueue_child_theme_css' ) ) {
 
 		if (is_object($theme->parent())) {
 			wp_enqueue_style(
-				'largow-child-styles',
+				'largo-child-styles',
 				get_stylesheet_directory_uri() . '/style.css',
 				array(),
-				filemtime( get_stylesheet_directory() . '/style.css'
+				filemtime( get_stylesheet_directory() . '/style.css' )
 			);
 		}
 	}

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -111,7 +111,12 @@ if ( ! function_exists( 'largo_enqueue_child_theme_css' ) ) {
 		$theme = wp_get_theme();
 
 		if (is_object($theme->parent())) {
-			wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/style.css', array('largo-stylesheet'));
+			wp_enqueue_style(
+				'largow-child-styles',
+				get_stylesheet_directory_uri() . '/style.css',
+				array(),
+				filemtime( get_stylesheet_directory() . '/style.css'
+			);
 		}
 	}
 	add_action( 'wp_enqueue_scripts', 'largo_enqueue_child_theme_css' );

--- a/inc/featured-media.php
+++ b/inc/featured-media.php
@@ -293,8 +293,8 @@ function largo_enqueue_featured_media_js( $hook ) {
 		'largo_featured_media',
 		get_template_directory_uri() . '/js/featured-media' . $suffix . '.js',
 		array( 'media-models', 'media-views' ),
-		false,
-		1
+		largo_version(),
+		true
 	);
 	wp_localize_script(
 		'largo_featured_media',
@@ -313,7 +313,9 @@ function largo_enqueue_featured_media_js( $hook ) {
 	);
 	wp_enqueue_style(
 		'largo_featured_media',
-		get_template_directory_uri(). '/css/featured-media' . $suffix . '.css'
+		get_template_directory_uri(). '/css/featured-media' . $suffix . '.css',
+		array(),
+		largo_version()
 	);
 
 	wp_localize_script( 'largo_featured_media', 'LFM', array(

--- a/inc/post-metaboxes.php
+++ b/inc/post-metaboxes.php
@@ -208,7 +208,11 @@ function largo_custom_sidebar_js() {
 	if ($typenow == 'post') {
 		$suffix = (LARGO_DEBUG)? '' : '.min';
 		wp_enqueue_script(
-			'custom-sidebar', get_template_directory_uri() . '/js/custom-sidebar' . $suffix . '.js', array('jquery'));
+			'custom-sidebar',
+			get_template_directory_uri() . '/js/custom-sidebar' . $suffix . '.js',
+			array('jquery'),
+			largo_version()
+		);
 
 		$post_templates = get_post_templates();
 		$default_sidebar_labels = array();
@@ -320,7 +324,12 @@ function largo_top_terms_js() {
 	global $typenow;
 	if( $typenow == 'post' ) {
 		$suffix = (LARGO_DEBUG)? '' : '.min';
-		wp_enqueue_script( 'top-terms', get_template_directory_uri() . '/js/top-terms' . $suffix . '.js', array( 'jquery' ) );
+		wp_enqueue_script(
+			'top-terms',
+			get_template_directory_uri() . '/js/top-terms' . $suffix . '.js',
+			array( 'jquery' ),
+			largo_version()
+		);
 	}
 }
 add_action( 'admin_enqueue_scripts', 'largo_top_terms_js' );

--- a/inc/term-icons.php
+++ b/inc/term-icons.php
@@ -122,7 +122,10 @@ class Largo_Term_Icons {
 	 */
 	function admin_enqueue_scripts( $hook_suffix ) {
 
-		if ( $hook_suffix == 'edit-tags.php' && !empty($_REQUEST['taxonomy']) ) {
+		if (
+			( $hook_suffix == 'edit-tags.php' || $hook_suffix == 'term.php' )
+			&& !empty($_REQUEST['taxonomy'])
+		) {
 			if ( !in_array( $_REQUEST['taxonomy'], $this->get_icon_taxonomies() ) ) {
 				// abort if the term doesn't belong to the taxonomies to have icons
 				return;
@@ -132,23 +135,53 @@ class Largo_Term_Icons {
 
 			$this->get_icons_config();
 
-			wp_enqueue_style( 'fontello', $this->_css_file );
+			wp_enqueue_style(
+				'fontello',
+				$this->_css_file,
+				array(),
+				largo_version()
+			);
 
 			$path = get_template_directory();
 			$dir = get_template_directory_uri();
 			$locale = explode( '_', get_locale() );
 
-			wp_enqueue_style( 'select2', $dir.'/js/select2/select2.css' );
-			wp_enqueue_script( 'select2', $dir.'/js/select2/select2.min.js', array( 'jquery' ) );
+			wp_enqueue_style(
+				'select2',
+				$dir.'/js/select2/select2.css',
+				array(),
+				largo_version()
+			);
+			wp_enqueue_script(
+				'select2',
+				$dir.'/js/select2/select2.min.js',
+				array( 'jquery' ),
+				largo_version()
+			);
 
 			if ( is_file( $path . '/js/select2/select2_locale_' . implode( '-', $locale ) . '.js' ) ) {
-				wp_enqueue_script( 'select2-locale-'. implode( '-', $locale ), $dir . '/js/select2/select2_locale_' . implode( '-', $locale ) . '.js' );
+				wp_enqueue_script(
+					'select2-locale-'. implode( '-', $locale ),
+					$dir . '/js/select2/select2_locale_' . implode( '-', $locale ) . '.js',
+					array(),
+					largo_version()
+				);
 			} elseif ( is_file( $path . '/js/select2/select2_locale_' . $locale[0] . '.js' ) ) {
-				wp_enqueue_script( 'select2-locale-'. $locale[0], $dir . '/js/select2/select2_locale_' . $locale[0] . '.js' );
+				wp_enqueue_script(
+					'select2-locale-'. $locale[0],
+					$dir . '/js/select2/select2_locale_' . $locale[0] . '.js',
+					array(),
+					largo_version()
+				);
 			}
 
 			$suffix = (LARGO_DEBUG)? '' : '.min';
-			wp_enqueue_script( 'custom-term-icons', $dir.'/js/custom-term-icons' . $suffix . '.js' );
+			wp_enqueue_script(
+				'custom-term-icons',
+				$dir.'/js/custom-term-icons' . $suffix . '.js',
+				array(),
+				largo_version()
+			);
 
 		}
 	}

--- a/inc/update.php
+++ b/inc/update.php
@@ -983,10 +983,11 @@ function largo_update_page_enqueue_js() {
 	if ( isset( $_GET['page']) && $_GET['page'] == 'update-largo' ) {
 		$suffix = ( LARGO_DEBUG ) ? '' : '.min';
 		wp_enqueue_script(
-			'largo_update_page', get_template_directory_uri() . '/js/update-page' . $suffix . '.js',
+			'largo_update_page',
+			get_template_directory_uri() . '/js/update-page' . $suffix . '.js',
 			array( 'jquery' ),
-			false,
-			1
+			filemtime( get_template_directory() . '/js/update-page' . $suffix . '.js' ),
+			true
 		);
 	}
 }

--- a/inc/widgets/largo-image-widget.php
+++ b/inc/widgets/largo-image-widget.php
@@ -13,6 +13,7 @@ if ( !defined('ABSPATH') )
  **/
 class largo_image_widget extends WP_Widget {
 
+	// not really sure what this means?
 	const VERSION = '4.0.7';
 
 	const CUSTOM_IMAGE_SIZE_SLUG = 'largo_image_widget_custom';
@@ -37,7 +38,12 @@ class largo_image_widget extends WP_Widget {
 	 */
 	function admin_setup() {
 		wp_enqueue_media();
-		wp_enqueue_script( 'largo-image-widget', get_template_directory_uri() . '/js/image-widget.js', array( 'jquery', 'media-upload', 'media-views' ), self::VERSION );
+		wp_enqueue_script(
+			'largo-image-widget',
+			get_template_directory_uri() . '/js/image-widget.js',
+			array( 'jquery', 'media-upload', 'media-views' ),
+			self::VERSION
+		);
 		wp_localize_script( 'largo-image-widget', 'LargoImageWidget', array(
 			'frame_title' => __( 'Select an Image', 'largo' ),
 			'button_title' => __( 'Insert Into Widget', 'largo' ),

--- a/inc/widgets/largo-twitter.php
+++ b/inc/widgets/largo-twitter.php
@@ -64,7 +64,7 @@ class largo_twitter_widget extends WP_Widget {
 			'largo_twitter_widget',
 			'//platform.twitter.com/widgets.js',
 			array(),
-			null,
+			largo_version(),
 			true
 		);
 

--- a/inc/wp-taxonomy-landing/functions/cftl-admin.php
+++ b/inc/wp-taxonomy-landing/functions/cftl-admin.php
@@ -676,8 +676,19 @@ function cftl_admin_scripts() {
 
 	if( $screen->base == 'post' && $screen->post_type == 'cftl-tax-landing') {
 		$url = get_template_directory_uri();
-		wp_enqueue_script( 'series', $url.'/inc/wp-taxonomy-landing/series.js', array('jquery', 'jquery-ui-sortable'), '0.0.1', true );
-		wp_enqueue_style( 'series', $url.'/inc/wp-taxonomy-landing/series.css' );
+		wp_enqueue_script(
+			'series',
+			$url . '/inc/wp-taxonomy-landing/series.js',
+			array('jquery', 'jquery-ui-sortable'),
+			largo_version(),
+			true
+		);
+		wp_enqueue_style(
+			'series',
+			$url . '/inc/wp-taxonomy-landing/series.css',
+			array(),
+			largo_version()
+		);
 	}
 }
 add_action( 'admin_enqueue_scripts', 'cftl_admin_scripts');

--- a/lib/options-framework/options-framework.php
+++ b/lib/options-framework/options-framework.php
@@ -172,9 +172,19 @@ if ( !function_exists( 'optionsframework_add_page' ) ) {
 /* Loads the CSS */
 
 function optionsframework_load_styles() {
-	wp_enqueue_style('optionsframework', OPTIONS_FRAMEWORK_DIRECTORY . 'css/optionsframework.css');
+	wp_enqueue_style(
+		'optionsframework',
+		OPTIONS_FRAMEWORK_DIRECTORY . 'css/optionsframework.css',
+		array(),
+		largo_version()
+	);
 	if ( !wp_style_is( 'wp-color-picker','registered' ) ) {
-		wp_register_style('wp-color-picker', OPTIONS_FRAMEWORK_DIRECTORY . 'css/color-picker.min.css');
+		wp_register_style(
+			'wp-color-picker',
+			OPTIONS_FRAMEWORK_DIRECTORY . 'css/color-picker.min.css',
+			array(),
+			largo_version()
+		);
 	}
 	wp_enqueue_style( 'wp-color-picker' );
 }
@@ -201,7 +211,12 @@ function optionsframework_load_scripts($hook) {
 	}
 
 	// Enqueue custom option panel JS
-	wp_enqueue_script( 'options-custom', OPTIONS_FRAMEWORK_DIRECTORY . 'js/options-custom.js', array( 'jquery','wp-color-picker' ) );
+	wp_enqueue_script(
+		'options-custom',
+		OPTIONS_FRAMEWORK_DIRECTORY . 'js/options-custom.js',
+		array( 'jquery','wp-color-picker' ),
+		largo_version()
+	);
 
 	// Inline scripts from options-interface.php
 	add_action( 'admin_head', 'of_admin_head' );

--- a/lib/options-framework/options-medialibrary-uploader.php
+++ b/lib/options-framework/options-medialibrary-uploader.php
@@ -68,7 +68,12 @@ if ( ! function_exists( 'optionsframework_mlu_js' ) ) :
 
 function optionsframework_mlu_js () {
 	// Registers custom scripts for the Media Library AJAX uploader.
-	wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_DIRECTORY .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );
+	wp_register_script(
+		'of-medialibrary-uploader',
+		OPTIONS_FRAMEWORK_DIRECTORY .'js/of-medialibrary-uploader.js',
+		array( 'jquery', 'thickbox' ),
+		largo_version()
+	);
 	wp_enqueue_script( 'of-medialibrary-uploader' );
 	wp_enqueue_script( 'media-upload' );
 }


### PR DESCRIPTION
## Changes
- uses filemtime for the child theme
- replaces site URL with more 

## Modified

filemtime as version

- [x] inc/enqueue.php:114:			wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/style.css', array('largo-stylesheet'));
- [x] inc/ajax-functions.php:26:		wp_enqueue_script(
- [x] inc/update.php:985:		wp_enqueue_script(

largo_version as version, for things that only change from Largo version to Largo version

- [x] inc/avatars/admin.php:4:	wp_enqueue_script('largo_avatar_js', get_template_directory_uri() . '/inc/avatars/js/avatars.js', array('jquery'));
- [x] inc/customizer/customizer.php:342:		wp_enqueue_script( 'largo-customizer', get_template_directory_uri() . '/inc/customizer/js/customizer.js', array( 'jquery' ) );
- [x] inc/customizer/customizer.php:343:		wp_enqueue_style( 'largo-customizer', get_template_directory_uri() . '/inc/customizer/css/customizer.css' );
- [x] inc/enqueue.php:129:	wp_enqueue_style( 'largo-admin-widgets', get_template_directory_uri().'/css/widgets-php' . $suffix . '.css' );
- [x] inc/enqueue.php:130:	wp_enqueue_script( 'largo-admin-widgets', get_template_directory_uri() . '/js/widgets-php' . $suffix . '.js', array( 'jquery' ), '1.0', true );
- [x] inc/featured-media.php:292:	wp_enqueue_script(
- [x] inc/featured-media.php:314:	wp_enqueue_style(
- [x] inc/post-metaboxes.php:210:		wp_enqueue_script(
- [x] inc/post-metaboxes.php:323:		wp_enqueue_script( 'top-terms', get_template_directory_uri() . '/js/top-terms' . $suffix . '.js', array( 'jquery' ) );
- [x] inc/term-icons.php:135:			wp_enqueue_style( 'fontello', $this->_css_file );
- [x] inc/term-icons.php:141:			wp_enqueue_style( 'select2', $dir.'/js/select2/select2.css' );
- [x] inc/term-icons.php:142:			wp_enqueue_script( 'select2', $dir.'/js/select2/select2.min.js', array( 'jquery' ) );
- [x] inc/term-icons.php:145:				wp_enqueue_script( 'select2-locale-'. implode( '-', $locale ), $dir . '/js/select2/select2_locale_' . implode( '-', $locale ) . '.js' );
- [x] inc/term-icons.php:147:				wp_enqueue_script( 'select2-locale-'. $locale[0], $dir . '/js/select2/select2_locale_' . $locale[0] . '.js' );
- [x] inc/term-icons.php:151:			wp_enqueue_script( 'custom-term-icons', $dir.'/js/custom-term-icons' . $suffix . '.js' );
- [x] inc/widgets/largo-twitter.php:63:		wp_enqueue_script(
- [x] inc/wp-taxonomy-landing/functions/cftl-admin.php:679:		wp_enqueue_script( 'series', $url.'/inc/wp-taxonomy-landing/series.js', array('jquery', 'jquery-ui-sortable'), '0.0.1', true );
- [x] inc/wp-taxonomy-landing/functions/cftl-admin.php:680:		wp_enqueue_style( 'series', $url.'/inc/wp-taxonomy-landing/series.css' );- [ ] lib/options-framework/options-framework.php:175:	wp_enqueue_style('optionsframework', OPTIONS_FRAMEWORK_DIRECTORY . 'css/optionsframework.css');
- [x] lib/options-framework/options-framework.php:179:	wp_enqueue_style( 'wp-color-picker' );
- [x] lib/options-framework/options-framework.php:204:	wp_enqueue_script( 'options-custom', OPTIONS_FRAMEWORK_DIRECTORY . 'js/options-custom.js', array( 'jquery','wp-color-picker' ) );
- [x] lib/options-framework/options-medialibrary-uploader.php:72:	wp_enqueue_script( 'of-medialibrary-uploader' );
- [x] lib/options-framework/options-medialibrary-uploader.php:73:	wp_enqueue_script( 'media-upload' );

## Not modified

Because the asset is unidentifiable
- [ ] homepages/homepage-class.php:92:					call_user_func_array('wp_enqueue_script', $asset);
- [ ] homepages/homepage-class.php:94:					call_user_func_array('wp_enqueue_style', $asset);

because the version number is for a rarely-updated script
- [x] functions.php:469:	wp_enqueue_script( 'navis-columns', $columns_src, array( 'jquery' ), '1.0', true );
- [x] inc/enqueue.php:89:		wp_enqueue_style( 'navis-slick', $slick_css, array(), '1.0' );
- [x] inc/enqueue.php:92:		wp_enqueue_script( 'jquery-slick', $slides_src, array( 'jquery' ), '3.0', true );
- [x] inc/enqueue.php:95:		wp_enqueue_style( 'navis-slides', $slides_css, array(), '1.0' );
- [x] inc/enqueue.php:98:		wp_enqueue_script( 'navis-slideshows', $show_src, array( 'jquery-slick' ), '0.11', true );
- [x] inc/widgets/largo-image-widget.php:40:		wp_enqueue_script( 'largo-image-widget', get_template_directory_uri() . '/js/image-widget.js', array( 'jquery', 'media-upload', 'media-views' ), self::VERSION );

because it's a core WordPress script registered elsewhere
- [x] header.php:36:			wp_enqueue_script( 'comment-reply' );
- [x] inc/custom-less-variables.php:519:		wp_enqueue_script( 'iris' ); // Colorpicker
- [x] inc/custom-less-variables.php:520:		wp_enqueue_script( 'largo_custom_less_variable', get_template_directory_uri().'/js/custom-less-variables.js', array( 'jquery', 'iris' ), '20130405', true );
- [x] inc/custom-less-variables.php:521:		wp_enqueue_style( 'largo_custom_less_variable', get_template_directory_uri().'/css/custom-less-variables.css', '20130405' );

already using largo_version:
- [x] inc/enqueue.php:18:		wp_enqueue_style(
- [x] inc/enqueue.php:27:		wp_enqueue_script(
- [x] inc/enqueue.php:36:		wp_enqueue_script(
- [x] inc/enqueue.php:63:		wp_enqueue_script(
- [x] inc/enqueue.php:69:		wp_enqueue_script(
- [x] inc/enqueue.php:273:		wp_enqueue_style(
- [x] inc/enqueue.php:297:		wp_enqueue_style(

## Why
For https://github.com/INN/largo/issues/1550