### PR TITLE
Prevent "Division by zero" in avatar functions.

### DIFF
--- a/inc/avatars/functions.php
+++ b/inc/avatars/functions.php
@@ -60,7 +60,19 @@ function largo_get_avatar_src( $id_or_email, $size ) {
 	});
 
 	$square_image_sizes = array_filter( $copy, function( $arg ) {
-		return ( $arg['width'] / $arg['height'] ) == 1;
+		// a function to filter whether the image size is square
+		if (
+			( isset( $arg['width'] ) && isset( $arg['height'] ) )
+			&&
+			( is_numeric( $arg['width'] ) && is_numeric( $arg['height'] ) )
+			&&
+			( $arg['width'] > 0  && $arg['height'] > 0 )
+		) {
+			$divided = $arg['width'] / $arg['height'];
+			return ( $divided  == 1 );
+		} else {
+			return false;
+		}
 	} );
 
 	$requested_size = array( $size, $size );


### PR DESCRIPTION
## Changes

Makes sure that neither the divisor nor the divisee are zero, non-numeric, or unset, when trying to get a list of square image sizes.

## Why

Fixes this:

> PHP message: PHP Warning:  Division by zero in /wp-content/themes/largo/inc/avatars/functions.php on line 63

Part of #1492.

## Before merging:

- [x] tests pass
- [x] check on a post with a byline; I've only thus far tested it on pages.