### PR TITLE
Remove default 'Series' title from Largo Taxonomy List Widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,11 +13,12 @@ This release contains bugfixes for Largo 0.6.
 
 - Uses [`filemtime()`](https://secure.php.net/manual/en/function.filemtime.php) as the version number for more enqueued assets, meaning that cachebusting will be handled by file modification time and not by Largo version. [Pull Request #1575](https://github.com/INN/largo/pull/1575) for [issue #1550](https://github.com/INN/largo/issues/1550).
 - For many assets where no version number was provided for enqueued assets, `largo_version()` is now used.  [Pull Request #1575](https://github.com/INN/largo/pull/1575) for [issue #1550](https://github.com/INN/largo/issues/1550).
-- Removes the list of recommended plugins displayed on new installations of Largo. [Pull Request #1580](https://github.com/INN/largo/pull/1580) for [issue #1570](https://github.com/INN/largo/issues/1570).
+- Removes the list of recommended plugins displayed on new installations of Largo. [Pull Request #1580](https://github.com/INN/largo/pull/1580) for [issue #1570](https://github.com/INN/largo/issues/1570). We'll be bringing this list back in an updated form on an INN website; stay tuned.
 
 ### Fixes
 
 - Updates templates to make sure that bylines are output. [Pull request #1574](https://github.com/INN/largo/pull/1574).
+- Allows the Largo Taxonomy List Widget to have an empty title. [Pull request #1582](https://github.com/INN/largo/pull/1582) for [issue #1581](https://github.com/INN/largo/issues/1581).
 
 ## [Largo 0.6](https://github.com/INN/largo/compare/v0.5.5.4...v0.6)
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@ This release contains bugfixes for Largo 0.6.
 ### Fixes
 
 - Updates templates to make sure that bylines are output. [Pull request #1574](https://github.com/INN/largo/pull/1574).
-- Allows the Largo Taxonomy List Widget to have an empty title. [Pull request #1582](https://github.com/INN/largo/pull/1582) for [issue #1581](https://github.com/INN/largo/issues/1581).
+- Allows the Largo Taxonomy List Widget to have an empty title. [Pull request #1583](https://github.com/INN/largo/pull/1583) for [issue #1581](https://github.com/INN/largo/issues/1581).
 
 ## [Largo 0.6](https://github.com/INN/largo/compare/v0.5.5.4...v0.6)
 

--- a/inc/widgets/largo-taxonomy-list.php
+++ b/inc/widgets/largo-taxonomy-list.php
@@ -28,7 +28,7 @@ class largo_taxonomy_list_widget extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 
-		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? __( 'Series', 'largo' ) : $instance['title'], $instance, $this->id_base );
+		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 		$is_dropdown = ! empty( $instance['dropdown'] ) ? '1' : '0';
 
 		/*


### PR DESCRIPTION
## Changes

- Fixes https://github.com/INN/largo/issues/1581 by removing the "if the title is empty" fallback title in the Largo Taxonomy List Widget
- Follows up on https://github.com/INN/largo/pull/1580 by noting that we'll have a list of recommended plugins on an INN website in the future.

## Why

Because I wanted to use the Tax List Widget on a project without having a title set.

Because we'll have a list in the future, and making that announcement now to match the recommendation removal provides continuity.