### PR TITLE
Fix Open Graph tags on singular post types, and minor search improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,13 +7,20 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 
 ## [Largo 0.6.2](https://github.com/INN/largo/compare/v0.6.1...0.5-dev)
 
+This release contains bug fixes for Largo 0.6.
+
 ### Fixes
 
 - Fixes a regression in the behavior of the Largo Follow widget. [Pull request #1600](https://github.com/INN/largo/pull/1600) for [issue #1599](https://github.com/INN/largo/issues/1599).
+- Fixes issue where post excerpt and featured media were not being used for open graph tags on post types that are `is_singular()` but not `is_single()`. [Pull request #1604)(https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
+- Removes duplicate site title in opengraph tags for non-archive, non-`is_front_page()`, non-`is_singular()` URLs. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
+- Removes search form from global nav bar when on the search page, so that there's only one search form. [Pull request #1604](https://github.com/INN/largo/pull/1604).
+- Cleans up the search page when no query has been entered. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1603](https://github.com/INN/largo/issues/1603).
+
 
 ## [Largo 0.6.1](https://github.com/INN/largo/compare/v0.6...v0.6.1)
 
-This release contains bugfixes for Largo 0.6.
+This release contains bug fixes for Largo 0.6.
 
 ### Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ This release contains bug fixes for Largo 0.6.
 - Removes search form from global nav bar when on the search page, so that there's only one search form. [Pull request #1604](https://github.com/INN/largo/pull/1604).
 - Cleans up the search page when no query has been entered. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1603](https://github.com/INN/largo/issues/1603).
 
+### Upgrade notices
+
+- If you have a custom `partials/nav-global.php` you may want to copy the `if ( ! is_search() ) { ... }` logic from [pull request #1604](https://github.com/INN/largo/pull/1604/) to reduce user confusion about which search form to use.
+
 
 ## [Largo 0.6.1](https://github.com/INN/largo/compare/v0.6...v0.6.1)
 

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -31,7 +31,7 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 		?>
 
 		<?php // output appropriate OG tags by page type
-			if ( is_single() ) {
+			if ( is_singular() ) {
 				if ( have_posts() ) {
 					the_post(); // we need to queue up the post to get the post specific info
 					

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -58,7 +58,7 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 		<?php
 			} else {
 		?>
-				<meta property="og:title" content="<?php bloginfo( 'name' ); wp_title(); ?>" />
+				<meta property="og:title" content="<?php wp_title(); ?>" />
 				<meta property="og:type" content="article" />
 				<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
 			<?php

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 		global $post;
 
 		// set a default thumbnail, if a post has a featured image use that instead
-		if ( is_single() && has_post_thumbnail( $post->ID ) ) {
+		if ( is_singular() && has_post_thumbnail( $post->ID ) ) {
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 			$thumbnailURL = $image[0];
 		} else if ( of_get_option( 'logo_thumbnail_sq' ) ) {

--- a/partials/nav-global.php
+++ b/partials/nav-global.php
@@ -40,17 +40,22 @@ if (
 						</ul>
 					<?php }
 					/* Check to display Donate Button */
-					if ( of_get_option( 'show_donate_button') )
+					if ( of_get_option( 'show_donate_button') ) {
 						largo_donate_button();
-					?>
-					<!-- BEGIN Header Search -->
-					<div id="header-search">
-						<form class="form-search" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-							<div class="input-append">
-								<input type="text" placeholder="<?php _e('Search', 'largo'); ?>" class="input-medium appendedInputButton search-query" value="" name="s" /><button type="submit" class="search-submit btn"><?php _e('GO', 'largo'); ?></button>
+					}
+
+					if ( ! is_search() ) {
+						?>
+							<div id="header-search">
+								<form class="form-search" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+									<div class="input-append">
+										<input type="text" placeholder="<?php _e('Search', 'largo'); ?>" class="input-medium appendedInputButton search-query" value="" name="s" /><button type="submit" class="search-submit btn"><?php _e('GO', 'largo'); ?></button>
+									</div>
+								</form>
 							</div>
-						</form>
-					</div>
+						<?php
+					}
+					?>
 				<!-- END Header Search -->
 				</div>
 			</nav>

--- a/search.php
+++ b/search.php
@@ -11,7 +11,7 @@ get_header();
 			<?php
 				$search_query = esc_html( get_search_query() );
 				if ( empty( $search_query ) ) {
-					echo wp_kses_post( __('Search:', 'largo') );
+					echo wp_kses_post( __('Search', 'largo') );
 				} else {
 					echo wp_kses_post( sprintf(
 						__('Search results for <span class="search-term">%s</span>', 'largo'),

--- a/search.php
+++ b/search.php
@@ -9,7 +9,15 @@ get_header();
 	<?php if (of_get_option('use_gcs') && of_get_option('gcs_id')) { ?>
 		<h1>
 			<?php
-				printf( __('Search results for <span class="search-term">%s</span>', 'largo'), get_search_query() );
+				$search_query = esc_html( get_search_query() );
+				if ( empty( $search_query ) ) {
+					echo wp_kses_post( __('Search:', 'largo') );
+				} else {
+					echo wp_kses_post( sprintf(
+						__('Search results for <span class="search-term">%s</span>', 'largo'),
+						$search_query
+					) );
+				}
 			?>
 		</h1>
 


### PR DESCRIPTION
## Changes
- Fixes issue where post excerpt and featured media were not being used for open graph tags on post types that are `is_singular()` but not `is_single()`. [Pull request # ]() for [issue #1602](https://github.com/INN/largo/issues/1602).
- Removes duplicate site title in opengraph tags for non-archive, non-`is_front_page()`, non-`is_singular()` URLs. [Pull request # ]() for [issue #1602](https://github.com/INN/largo/issues/1602).
- Removes search form from global nav bar when on the search page, so that there's only one search form. [Pull request # ]().
- Cleans up the search page when no query has been entered. [Pull request # ]() for [issue #1603](https://github.com/INN/largo/issues/1603).


## Screenshots

GCSE before:

<img width="969" alt="screen shot 2018-12-17 at 1 39 31 pm" src="https://user-images.githubusercontent.com/1754187/50108477-54a88b00-0203-11e9-95d8-91d8af7b75fc.png">

GCSE after:

<img width="985" alt="screen shot 2018-12-17 at 1 57 33 pm" src="https://user-images.githubusercontent.com/1754187/50108630-ba951280-0203-11e9-941d-d585874d0268.png">


## Why

- Fixes #1602, originating from a support request in INN internal website discussions. 
- Fixes #1603, matching https://github.com/INN/inn/pull/94