### PR TITLE
1492 continued: Bylines, Largo Recent Posts Widget, partials/widget-content.php

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,11 +17,12 @@ This release contains bug fixes for Largo 0.6.
 - Removes search form from global nav bar when on the search page, so that there's only one search form. [Pull request #1604](https://github.com/INN/largo/pull/1604).
 - Cleans up the search page when no query has been entered. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1603](https://github.com/INN/largo/issues/1603).
 - Defines the index 'class' in `partials/widget-content.php` when using a large image. [Pull request #1606](https://github.com/INN/largo/pull/1606) for issues [#1605](https://github.com/INN/largo/issues/1605) and [#1492](https://github.com/INN/largo/issues/1492).
+- If Co-Authors Plus is active, and if a post has an `author` term, but the term has no corresponding `guest-author` post, when running `largo_byline()`, the byline will now contain an HTML comment informing why the byline is empty. If the `WP_DEBUG` or `LARGO_DEBUG` constants are true, Largo will add a message to the server's error log of the form "post 123 should have at least one co-author, but has none!" [Pull request #1607](https://github.com/INN/largo/pull/1607) for [Automattic/Co-Authors-Plus#637](https://github.com/Automattic/Co-Authors-Plus/issues/637) and as part of the general cleanup ticket [#1492](https://github.com/INN/largo/issues/1492).
+- Further cleans up undefined variables.
 
 ### Upgrade notices
 
 - If you have a custom `partials/nav-global.php` you may want to copy the `if ( ! is_search() ) { ... }` logic from [pull request #1604](https://github.com/INN/largo/pull/1604/) to reduce user confusion about which search form to use.
-
 
 ## [Largo 0.6.1](https://github.com/INN/largo/compare/v0.6...v0.6.1)
 

--- a/inc/byline_class.php
+++ b/inc/byline_class.php
@@ -262,9 +262,22 @@ class Largo_CoAuthors_Byline extends Largo_Byline {
 			$authors = implode( ', ', array_slice( $out, 0, -1 ) );
 			$authors .= ' <span class="and">' . __( 'and', 'largo' ) . '</span> ' . $out[$key];
 		} else {
-			$authors = $out[0];
+			if ( isset( $out[0] ) ) {
+				$authors = $out[0];
+			} else {
+				$cap_error_message = sprintf(
+					esc_html__( 'post %1$s should have at least one co-author, but has none!', 'largo' ),
+					$this->post_id
+				);
+				if ( WP_DEBUG || LARGO_DEBUG ) {
+					error_log(var_export( $cap_error_message, true));
+				}
+				$authors = sprintf(
+					'<!-- %1$s -->',
+					$cap_error_message
+				);
+			}
 		}
-
 
 		// Now assemble the One True Byline
 		ob_start();

--- a/inc/widgets/largo-recent-posts.php
+++ b/inc/widgets/largo-recent-posts.php
@@ -54,17 +54,23 @@ class largo_recent_posts_widget extends WP_Widget {
 
 		$query_args = array (
 			'post__not_in' 	 => get_option( 'sticky_posts' ),
-			'posts_per_page' => $instance['num_posts'],
+			'posts_per_page' => isset( $instance['num_posts'] ) ? $instance['num_posts'] : 3,
 			'post_status'	=> 'publish'
 		);
 
 		if ( isset( $instance['avoid_duplicates'] ) && $instance['avoid_duplicates'] === 1 ) {
 			$query_args['post__not_in'] = $shown_ids;
 		}
-		if ( $instance['cat'] != '' ) $query_args['cat'] = $instance['cat'];
-		if ( $instance['tag'] != '') $query_args['tag'] = $instance['tag'];
-		if ( $instance['author'] != '') $query_args['author'] = $instance['author'];
-		if ( $instance['taxonomy'] != '') {
+		if ( ! empty( $instance['cat'] ) ) {
+			$query_args['cat'] = $instance['cat'];
+		}
+		if ( ! empty( $instance['tag'] ) ) {
+			$query_args['tag'] = $instance['tag'];
+		}
+		if ( ! empty( $instance['author'] ) ) {
+			$query_args['author'] = $instance['author'];
+		}
+		if ( ! empty( $instance['taxonomy'] ) && ! empty( $instance['term'] ) ) {
 			$query_args['tax_query'] = array(
 				array(
 					'taxonomy'	=> $instance['taxonomy'],
@@ -112,7 +118,7 @@ class largo_recent_posts_widget extends WP_Widget {
 		// close the ul
 		echo '</ul>';
 
-		if( $instance['linkurl'] !='' ) {
+		if( ! empty( $instance['linkurl'] ) ) {
 			echo '<p class="morelink"><a href="' . esc_url( $instance['linkurl'] ) . '">' . esc_html( $instance['linktext'] ) . '</a></p>';
 		}
 		echo $args['after_widget'];

--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -41,13 +41,19 @@ if ($thumb == 'small') {
 </h5>
 
 <?php // byline on posts
-if ( isset( $instance['show_byline'] ) && $instance['show_byline'] == true) { ?>
-	<span class="byline"><?php echo largo_byline( false, $instance['hide_byline_date'], get_the_ID() ); ?></span>
-<?php }
+if ( isset( $instance['show_byline'] ) && $instance['show_byline'] == true) {
+	$hide_byline_date = ( ! empty( $instance['hide_byline_date'] ) ) ? $instance['hide_byline_date'] : true;
+	?>
+		<span class="byline"><?php echo largo_byline( false, $hide_byline_date, get_the_ID() ); ?></span>
+	<?php
+}
 
 // the excerpt
-if ( $excerpt == 'num_sentences' ) { ?>
-	<p><?php echo largo_trim_sentences( get_the_content(), $instance['num_sentences'] ); ?></p>
-<?php } elseif ( $excerpt == 'custom_excerpt' ) { ?>
-	<p><?php echo get_the_excerpt(); ?></p>
-<?php }
+if ( $excerpt == 'num_sentences' ) {
+	$num_sentences = ( ! empty( $instance['num_sentences'] ) ) ? $instance['num_sentences'] : 2;
+	?>
+		<p><?php echo largo_trim_sentences( get_the_content(), $num_sentences ); ?></p>
+	<?php } elseif ( $excerpt == 'custom_excerpt' ) { ?>
+		<p><?php echo get_the_excerpt(); ?></p>
+	<?php
+}


### PR DESCRIPTION
## Changes

For #1492's ongoing hunt for undefined variables:

- further cleanup of partials/widget-content.php
- further cleanup of the Largo Recent Posts widget

To fix an uninitialized variable caused by the corner case where Co-Authors Plus is active, and a post has an `author` term, but the term has no corresponding `guest-author` post (https://github.com/Automattic/Co-Authors-Plus/issues/637):

- catch the uninitialized variable, output an HTML comment in the byline complaining that the post has no author term. If `WP_DEBUG` or `LARGO_DEBUG` are true, send that message to the error log.