### PR TITLE
Use empty() check in conditional in largo_maybe_top_term

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -361,7 +361,7 @@ function largo_maybe_top_term( $args = array() ) {
 	$args = array_merge( $args, array( 'echo' => False ) );
 	$top_term = largo_top_term( $args );
 
-	if ( $top_term ) { ?>
+	if ( ! empty( $top_term ) ) { ?>
 		<h5 class="top-tag"><?php echo $top_term; ?></h5>
 	<?php }
 }


### PR DESCRIPTION
## Changes

- Uses an `empty( $top_term )` check, rather than using the bare value of `$top_term`

## Why

Because doing so improves code quality.