### PR TITLE
Fix for #1624 and #1623: Bootstrap_Nav_Walker::start_el() continued

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ This release contains bug fixes for Largo 0.6.
 
 ### Fixes
 
-- Fixes PHP notices in class `Bootstrap_Walker_Nav_Menu`. [Pull request #1624](https://github.com/INN/largo/pull/1624) for [issue #1623](https://github.com/INN/largo/issues/1623) as part of [issue #1492](https://github.com/INN/largo/issues/1492).
+- Fixes PHP notices in class `Bootstrap_Walker_Nav_Menu`. [Pull request #1624](https://github.com/INN/largo/pull/1624) and [#1625](https://github.com/INN/largo/pull/1625) for [issue #1623](https://github.com/INN/largo/issues/1623) as part of [issue #1492](https://github.com/INN/largo/issues/1492).
 - Fixes a regression in the behavior of the Largo Follow widget. [Pull request #1600](https://github.com/INN/largo/pull/1600) for [issue #1599](https://github.com/INN/largo/issues/1599).
 - Fixes issue where post excerpt and featured media were not being used for open graph tags on post types that are `is_singular()` but not `is_single()`. [Pull request #1604)(https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
 - Removes duplicate site title in opengraph tags for non-archive, non-`is_front_page()`, non-`is_singular()` URLs. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).

--- a/inc/nav-menus.php
+++ b/inc/nav-menus.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Output a donate button from theme options
  * used by default in the global nav area
@@ -77,14 +76,13 @@ class Bootstrap_Walker_Nav_Menu extends Walker_Nav_Menu {
 	}
 
 	public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
-
 		$indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
 
 		$li_attributes = '';
 		$class_names = $value = '';
 
 		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
-		$classes[] = ( isset( $args['has_children'] ) && $args['has_children'] ) ? 'dropdown' : '';
+		$classes[] = ( isset( $args->has_children ) && $args->has_children ) ? 'dropdown' : '';
 		$classes[] = ($item->current || $item->current_item_ancestor) ? 'active' : '';
 		$classes[] = 'menu-item-' . $item->ID;
 
@@ -100,14 +98,14 @@ class Bootstrap_Walker_Nav_Menu extends Walker_Nav_Menu {
 		$attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
 		$attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
 		$attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
-		$attributes .= (( $args['has_children'] ) && ($depth == 0))	    ? ' class="dropdown-toggle"' : '';
+		$attributes .= (( $args->has_children ) && ($depth == 0)) ? ' class="dropdown-toggle"' : '';
 
-		$item_output = $args['before'];
+		$item_output = $args->before;
 		$item_output .= '<a'. $attributes .'>';
-		$item_output .= $args['link_before'] . apply_filters( 'the_title', $item->title, $item->ID ) . $args['link_after'];
-		$item_output .= ( ( $args['has_children'] ) && ($depth == 0)) ? ' <b class="caret"></b></a>' : '';
-		$item_output .= ( ( $args['has_children'] ) && ($depth != 0)) ? ' <i class="icon-arrow-right"></i></a>' : '</a>';
-		$item_output .= $args['after'];
+		$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+		$item_output .= ( ( $args->has_children ) && ($depth == 0)) ? ' <b class="caret"></b></a>' : '';
+		$item_output .= ( ( $args->has_children ) && ($depth != 0)) ? ' <i class="icon-arrow-right"></i></a>' : '</a>';
+		$item_output .= $args->after;
 
 		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
 	}


### PR DESCRIPTION
## Changes

As noted in https://github.com/INN/largo/issues/1623#issuecomment-459913666, cannot use object of type stdClass as array in `largo/inc/nav-menus.php:87`. This PR reverts to the pre-#1624 behavior of accessing the various aspects of the `$args` argument as object properties, not as array keys.

I'm not sure what caused #1623, in the end, and that's worrisome.

However, this patch unbreaks the error that #1624 introduced.