### PR TITLE
Add term class to largo_top_term() output, prevent largo_category_and_tags() from using wrong post in fallback scenario.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,17 +12,20 @@ This release contains bug fixes for Largo 0.6.
 ### Feature updates
 
 - Updates INN's logos in the `img/` folder. If your child theme redefines the function `inn_logo()`, please update that function to reference the new SVG image locations in `img/`. [Pull request #1633](https://github.com/INN/largo/pull/1633) for [issue #1621](https://github.com/INN/largo/issues/1631)
+- Adds the term's taxonomy slug and term slug in the format `taxonomy-term` as a class on the term in the output of `largo_top_term()`, `largo_category_and_tags()`, and `largo_maybe_top_term()`. [Pull request](https://github.com/INN/largo/pull/1648) for [issue #1646](https://github.com/INN/largo/issues/1646).
 
 ### Fixes
 
 - Increases contrast of the floating social button icons against the background, to improve accessibility. [Pull request #1635](https://github.com/INN/largo/pull/1635/).
-- Fixes issue where `[module]content[/module]` was not rendering `content` in the output of the `largo_module_shortcode()` function. [Pull request #1645](https://github.com/INN/largo/pull/1645) for [issue #1639](https://github.com/INN/largo/issues/1639).
 - Fixes issue where floating social buttons were not clickable, because of z-index ordering. [Pull request #1635](https://github.com/INN/largo/pull/1635/) for [issue #1576](https://github.com/INN/largo/issues/1576).
 - Fixes links in social media buttons not respecting the blog's character set. [Pull request #1635](https://github.com/INN/largo/pull/1635/) for [issue #1283](https://github.com/INN/largo/issues/1283).
+- Fixes issue where `[module]content[/module]` was not rendering `content` in the output of the `largo_module_shortcode()` function. [Pull request #1645](https://github.com/INN/largo/pull/1645) for [issue #1639](https://github.com/INN/largo/issues/1639).
 - Function `largo_post_social_links` now respects the blog character set option. [Pull request #1635](https://github.com/INN/largo/pull/1635/) for [issue #1283](https://github.com/INN/largo/issues/1283).
 - Fixes PHP notices in class `Bootstrap_Walker_Nav_Menu`. [Pull request #1624](https://github.com/INN/largo/pull/1624) and [#1625](https://github.com/INN/largo/pull/1625) for [issue #1623](https://github.com/INN/largo/issues/1623) as part of [issue #1492](https://github.com/INN/largo/issues/1492).
 - Fixes a regression in the behavior of the Largo Follow widget. [Pull request #1600](https://github.com/INN/largo/pull/1600) for [issue #1599](https://github.com/INN/largo/issues/1599).
-- Fixes issue where post excerpt and featured media were not being used for open graph tags on post types that are `is_singular()` but not `is_single()`. [Pull request #1604)(https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
+- Fixes issue where post excerpt and featured media were not being used for open graph tags on post types that are `is_singular()` but not `is_single()`. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
+- Prevents `largo_top_term()` from calling `largo_category_and_tags()` when the post ID argument passed to `largo_top_term()` does not match `get_the_ID`'s post ID, because there is presently no way to pass that ID to `largo_category_and_tags()`. [Pull request #1648](https://github.com/INN/largo/pull/1648) for [issue #1647](https://github.com/INN/largo/issues/1647).
+- Fixes improper post ID argument passed to `largo_top_term()` in the homepage featured stories zone. [Pull request #1648](https://github.com/INN/largo/pull/1648).
 - Removes duplicate site title in opengraph tags for non-archive, non-`is_front_page()`, non-`is_singular()` URLs. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1602](https://github.com/INN/largo/issues/1602).
 - Removes search form from global nav bar when on the search page, so that there's only one search form. [Pull request #1604](https://github.com/INN/largo/pull/1604).
 - Cleans up the search page when no query has been entered. [Pull request #1604](https://github.com/INN/largo/pull/1604) for [issue #1603](https://github.com/INN/largo/issues/1603).

--- a/homepages/zones/zones.php
+++ b/homepages/zones/zones.php
@@ -137,13 +137,16 @@ function homepage_feature_stories_list() {
 	$featured_stories = largo_home_featured_stories( $max );
 	foreach ( $featured_stories as $featured ) {
 		$shown_ids[] = $featured->ID;
-?>
-		<article class="featured-story">
-			<h5 class="top-tag"><?php largo_top_term( 'post=' . $featured->ID ); ?></h5>
-			<h4 class="related-story"><a href="<?php echo esc_url( get_permalink( $featured->ID ) ); ?>">
-				<?php echo $featured->post_title; ?></a></h4>
-		</article>
-<?php
+		?>
+			<article class="featured-story">
+				<?php largo_maybe_top_term( array( 'post' => $featured->ID ) ); ?>
+				<h4 class="related-story">
+					<a href="<?php echo esc_url( get_permalink( $featured->ID ) ); ?>">
+						<?php echo $featured->post_title; ?>
+					</a>
+				</h4>
+			</article>
+		<?php
 	}
 	$ret = ob_get_contents();
 	ob_end_clean();

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -268,12 +268,17 @@ if ( ! function_exists( 'largo_categories_and_tags' ) ) {
 
 				if ( $link ) {
 					$output[] = sprintf(
-						__( '<%1$s class="post-category-link"><a href="%2$s" title="Read %3$s in the %4$s category">%5$s%4$s</a></%1$s>', 'largo' ),
+						__( '<%1$s class="post-category-link %6$s"><a href="%2$s" title="Read %3$s in the %4$s category">%5$s%4$s</a></%1$s>', 'largo' ),
 						$item_wrapper,
 						( $rss ? get_category_feed_link( $cat->term_id ) : get_category_link( $cat->term_id ) ),
 						of_get_option( 'posts_term_plural' ),
 						$cat->name,
-						$icon
+						$icon,
+						sprintf(
+							'%1$s-%2$s',
+							$cat->taxonomy,
+							$cat->slug
+						)
 					);
 				} else {
 					$output[] = $cat->name;
@@ -289,12 +294,17 @@ if ( ! function_exists( 'largo_categories_and_tags' ) ) {
 
 				if ( $link ) {
 					$output[] = sprintf(
-						__( '<%1$s class="post-tag-link"><a href="%2$s" title="Read %3$s tagged with: %4$s">%5$s%4$s</a></%1$s>', 'largo' ),
+						__( '<%1$s class="post-tag-link %6$s"><a href="%2$s" title="Read %3$s tagged with: %4$s">%5$s%4$s</a></%1$s>', 'largo' ),
 						$item_wrapper,
 						( $rss ?  get_tag_feed_link( $tag->term_id ) : get_tag_link( $tag->term_id ) ),
 						of_get_option( 'posts_term_plural' ),
 						$tag->name,
-						$icon
+						$icon,
+						sprintf(
+							'%1$s-%2$s',
+							$tag->taxonomy,
+							$tag->slug
+						)
 					);
 				} else {
 					$output[] = $tag->name;
@@ -363,17 +373,26 @@ function largo_top_term( $options = array() ) {
 	 */
 	if ( $term_id && $term_id !== 'none' && !empty( $taxonomy ) ) {
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
+
 		$link = ( $args['link'] ) ? array( '<a href="%2$s" title="Read %3$s in the %4$s category">','</a>' ) : array( '', '' ) ;
+
 		// get the term object
 		$term = get_term( $term_id, $taxonomy );
+
 		if ( is_wp_error( $term ) ) return;
+
 		$output = sprintf(
-			'<%1$s class="post-category-link">'.$link[0].'%5$s%4$s'.$link[1].'</%1$s>',
+			'<%1$s class="post-category-link _top_term_output %6$s">'.$link[0].'%5$s%4$s'.$link[1].'</%1$s>',
 			$args['wrapper'],
 			get_term_link( $term ),
 			of_get_option( 'posts_term_plural' ),
 			$term->name,
-			$icon
+			$icon,
+			sprintf(
+				'%1$s-%2$s',
+				$term->taxonomy,
+				$term->slug
+			)
 		);
 	}
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -333,7 +333,7 @@ function largo_top_term( $options = array() ) {
 		'echo' => TRUE,
 		'link' => TRUE,
 		'use_icon' => FALSE,
-		'wrapper' => 'span',
+		'wrapper' => 'span', // an HTML tag ID
 		'exclude' => array(),	//only for compatibility with largo_categories_and_tags
 	);
 
@@ -400,10 +400,33 @@ function largo_top_term( $options = array() ) {
 	 * No output?
 	 * generate a link to the post's category or tags
 	 */
-	if ( empty( $output ) ) {
-		$output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude']);
-		if ( is_array( $output ) && ! empty( $output[0] ) ) {
-			$output = ( is_array( $output ) ) ? $output[0] : '';
+	if (
+		empty( $output )
+		&& 'none' !== $term_id
+		&& (int) $args['post'] === get_the_ID()
+	) {
+
+		// Can't pass a post ID to largo_categories_and_tags, so this may return the wrong links.
+		$lcat_output = largo_categories_and_tags( 1, false, $args['link'], $args['use_icon'], '', $args['wrapper'], $args['exclude'] );
+
+		if ( is_string( $lcat_output ) ) {
+			$output = $lcat_output;
+		} elseif ( is_array( $lcat_output ) ) {
+			if ( empty( $lcat_output ) ) {
+				$output = '';
+			} else {
+				foreach ( $lcat_output as $o ) {
+					if ( empty( $o ) ) {
+						continue;
+					}
+					if ( is_string( $o ) ) {
+						$output = $o;
+						break;
+					}
+				}
+			}
+		} else {
+			$output = '';
 		}
 	}
 


### PR DESCRIPTION
## Changes:

- For https://github.com/INN/largo/issues/1647, prevent `largo_top_term()` from calling `largo_category_and_tags()` when the post ID passed to `largo_top_term()` does not match `get_the_ID`'s post ID, because there is presently no way to pass that ID to `largo_category_and_tags()`.
- For https://github.com/INN/largo/issues/1646, adds `taxonomy-slug` output as class on `largo_top_term()` for the top term, and in `largo_category_and_tags()` to support that output in a fallback case.
- Fixes problem in the homepage featured stories zone where the post ID was not properly specified to `largo_top_term()`, and changed to `largo_maybe_top_term()` while I was in there. This means that `largo_top_term()` will have the specified post ID in that zone, and in combination with the `largo_category_and_tags()` change above, if there's no top term set on a post, there'll be no empty `h5` element there.