### PR TITLE
Add a second parameter to the largo_byline filter, containing an array of the arguments used in largo_byline()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ This release contains bug fixes for Largo 0.6.
 
 - Updates INN's logos in the `img/` folder. If your child theme redefines the function `inn_logo()`, please update that function to reference the new SVG image locations in `img/`. [Pull request #1633](https://github.com/INN/largo/pull/1633) for [issue #1621](https://github.com/INN/largo/issues/1631)
 - Adds the term's taxonomy slug and term slug in the format `taxonomy-term` as a class on the term in the output of `largo_top_term()`, `largo_category_and_tags()`, and `largo_maybe_top_term()`. [Pull request](https://github.com/INN/largo/pull/1648) for [issue #1646](https://github.com/INN/largo/issues/1646).
-- The arguments set on `largo_byline()` are now passed to the `largo_byline` filter as an array of argument name => argument value. [Pull request #]() for [issue #1646](https://github.com/INN/largo/issues/1656).
+- The arguments set on `largo_byline()` are now passed to the `largo_byline` filter as an array of argument name => argument value. [Pull request #1657](https://github.com/INN/largo/pull/1657) for [issue #1646](https://github.com/INN/largo/issues/1656).
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ This release contains bug fixes for Largo 0.6.
 
 - Updates INN's logos in the `img/` folder. If your child theme redefines the function `inn_logo()`, please update that function to reference the new SVG image locations in `img/`. [Pull request #1633](https://github.com/INN/largo/pull/1633) for [issue #1621](https://github.com/INN/largo/issues/1631)
 - Adds the term's taxonomy slug and term slug in the format `taxonomy-term` as a class on the term in the output of `largo_top_term()`, `largo_category_and_tags()`, and `largo_maybe_top_term()`. [Pull request](https://github.com/INN/largo/pull/1648) for [issue #1646](https://github.com/INN/largo/issues/1646).
+- The arguments set on `largo_byline()` are now passed to the `largo_byline` filter as an array of argument name => argument value. [Pull request #]() for [issue #1646](https://github.com/INN/largo/issues/1656).
 
 ### Fixes
 

--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -161,9 +161,18 @@ if ( ! function_exists( 'largo_byline' ) ) {
 		 *
 		 * @since 0.5.4
 		 * @param string $partial The HTML of the output of largo_byline(), before the edit link is added.
+		 * @param array $array Associative array of argument name => argument value, with the arguments passed to largo_byline(). Since https://github.com/INN/largo/issues/1656
 		 * @link https://github.com/INN/Largo/issues/1070
 		 */
-		$byline = apply_filters( 'largo_byline', $byline );
+		$byline = apply_filters(
+			'largo_byline',
+			$byline,
+			array(
+				'echo' => $echo,
+				'exclude_date' => $exclude_date,
+				'post' => $post
+			)
+		);
 
 		if ( $echo ) {
 			echo $byline;


### PR DESCRIPTION
## Changes

- The arguments set on `largo_byline()` are now passed to the `largo_byline` filter as an array of argument name => argument value. [Pull request #]() for [issue #1646](https://github.com/INN/largo/issues/1656).