### PR TITLE
Register the new image size 96x96 for avatars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ This release contains bug fixes for Largo 0.6.
 
 ### Fixes
 
+- Defines a new image size `96x96` for use on avatars and small square listing images. This is a bug fix; Largo has referred to such an image size for a long time but never made sure that such images existed. Sites worried about this may want to regenerate thumbnail images. [Pull request #1672](https://github.com/INN/largo/issues/1672) for [issue #1619](https://github.com/INN/largo/issues/1619).
 - Increases contrast of the floating social button icons against the background, to improve accessibility. [Pull request #1635](https://github.com/INN/largo/pull/1635/).
 - Fixes issue where floating social buttons were not clickable, because of z-index ordering. [Pull request #1635](https://github.com/INN/largo/pull/1635/) for [issue #1576](https://github.com/INN/largo/issues/1576).
 - Fixes links in social media buttons not respecting the blog's character set. [Pull request #1635](https://github.com/INN/largo/pull/1635/) for [issue #1283](https://github.com/INN/largo/issues/1283).

--- a/functions.php
+++ b/functions.php
@@ -257,6 +257,7 @@ class Largo {
 		add_theme_support( 'post-thumbnails' );
 		set_post_thumbnail_size( 140, 140, true ); // thumbnail
 		add_image_size( '60x60', 60, 60, true ); // small thumbnail
+		add_image_size( '96x96', 96, 96, true ); // avatars
 		add_image_size( 'medium', MEDIUM_WIDTH, MEDIUM_HEIGHT ); // medium width scaling
 		add_image_size( 'large', LARGE_WIDTH, LARGE_HEIGHT ); // large width scaling
 		add_image_size( 'full', FULL_WIDTH, FULL_HEIGHT ); // full width scaling


### PR DESCRIPTION
Fixes https://github.com/INN/largo/issues/1619

Largo had previously been assuming that `96x96` was registered; this was not the case.