### PR TITLE
Post-0.6.3, bump version number to 0.6.4-prerelease

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ copyright = u'2019, Institute for Nonprofit News'
 # built documents.
 #
 # The short X.Y version.
-version = '0.6.3'
+version = '0.6.4-prerelease'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "largo-project",
-  "version": "0.6.3",
+  "version": "0.6.4-prerelease",
   "repository": {
     "type": "git",
     "url": "https://github.com/INN/Largo.git"

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,8 @@ A responsive WordPress framework designed for news publishers and developed by t
 
 The project extends work done by [NPR's Project Argo](http://argoproject.org/).
 
-**Current version:** v0.6.3
+**Current version:** [v0.6.3](https://github.com/INN/largo/releases)
+**Working version:** 0.6.4-prerelease
 
 **Changelog** is available in this repository: [changelog.md](./changelog.md)
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://largoproject.org
 Description: A responsive news theme developed by the Institute for Nonprofit News (INN). Crafted specifically with the needs of news publishers in mind.
 Author: The INN Nerds
 Author URI: https://labs.inn.org/
-Version: 0.6.3
+Version: 0.6.4-prerelease
 Tags: two-columns, right-sidebar, custom-header, sticky-post, microformats, post-formats, theme-options, featured-images, threaded-comments, editor-style, custom-menu
 Text Domain: largo
 


### PR DESCRIPTION
I think we should be doing this so that sites that are running a prerelease build of 0.6.4 will have a different version number from sites running a stable 0.6.3 build. The `-prerelease` in the version number is so that sites running 0.6.4-prerelease will trigger the Largo update functions when they're finally updated to 0.6.4.

The `0.6.4-prerelease` string should be treated by [version_compare()](https://www.php.net/manual/en/function.version-compare.php) as less than `0.6.4`, according to the documentation for that function.