### PR TITLE
Fix undefined $description in largo_opengraph() and apply WP Code Standards

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Updates `largo_home_single_top` function to get `homepage_feature_term` and `top_story_term` values from slug instead of by name. If these prominence names were updated to anything else, `homepage_feature_term` and `top_story_term` would be false and fallback to `__('Homepage Featured', 'largo')`. [Pull request #1709](https://github.com/INN/largo/pull/1709) for [issue #1445](https://github.com/INN/largo/issues/1445).
 - Removes separator `<span>` on search results page; puts the search result url on a new line instead of next to the date. Also adds a `overflow-wrap: breakword;` style to the search-result URL to make sure it doesn't overflow the result container. [Pull request #1710](https://github.com/INN/largo/pull/1710) for [issue #1509](https://github.com/INN/largo/issues/1509).
 - Fixes a `ReferenceError` in navigation menu JavaScript. [Pull request #1715](https://github.com/INN/largo/pull/1715) for [issue #1714](https://github.com/INN/largo/issues/1714).
+- Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -5,98 +5,97 @@
  * @package Largo
  */
 
-/**
- * Adds appropriate open graph, twittercards, and google publisher tags
- * to the header based on the page type displayed
- *
- * @uses largo_twitter_url_to_username()
- * @since 0.3
- */
 if ( ! function_exists( 'largo_opengraph' ) ) {
+	/**
+	 * Adds appropriate open graph, twittercards, and google publisher tags
+	 * to the header based on the page type displayed
+	 *
+	 * @uses largo_twitter_url_to_username()
+	 * @since 0.3
+	 */
 	function largo_opengraph() {
 
 		global $post;
 
-		// set a default thumbnail, if a post has a featured image use that instead
-		if ( is_singular() && has_post_thumbnail( $post->ID ) ) {
-			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			$thumbnailURL = $image[0];
-		} else if ( of_get_option( 'logo_thumbnail_sq' ) ) {
-			$thumbnailURL = of_get_option( 'logo_thumbnail_sq' );
-		} else {
-			$thumbnailURL = false;
+		// start the output, some attributes will be the same for all page types
+		echo '<meta name="twitter:card" content="summary">';
+
+		if ( of_get_option( 'twitter_link' ) ) {
+			echo '<meta name="twitter:site" content="@' . largo_twitter_url_to_username( of_get_option( 'twitter_link' ) ) . '">';
 		}
 
-		// start the output, some attributes will be the same for all page types ?>
+		// output appropriate OG tags by page type
+		if ( is_singular() ) {
+			if ( have_posts() ) {
+				the_post(); // we need to queue up the post to get the post specific info
+				
+				if ( get_the_author_meta( 'twitter' ) && !get_post_meta( $post->ID, 'largo_byline_text' ) )
+					echo '<meta name="twitter:creator" content="@' . largo_twitter_url_to_username( get_the_author_meta( 'twitter' ) ) . '">';
+				?>
+				<meta property="og:title" content="<?php the_title(); ?>" />
+				<meta property="og:type" content="article" />
+				<meta property="og:url" content="<?php the_permalink(); ?>"/>
+				<meta property="og:description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
+				<meta name="description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
+				<?php
+			} // have_posts
 
-		<meta name="twitter:card" content="summary">
+			rewind_posts();
 
-		<?php
-			if ( of_get_option( 'twitter_link' ) )
-				echo '<meta name="twitter:site" content="@' . largo_twitter_url_to_username( of_get_option( 'twitter_link' ) ) . '">';
-		?>
+		} else if ( is_front_page() ) {
+			?>
+				<meta property="og:title" content="<?php bloginfo( 'name' ); echo ' - '; bloginfo( 'description' ); ?>" />
+				<meta property="og:type" content="website" />
+				<meta property="og:url" content="<?php echo home_url(); ?>"/>
+				<meta property="og:description" content="<?php bloginfo( 'description' ); ?>" />
+				<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
+			<?php
+		} else {
+			// not a single post, not the front page
+			?>
+				<meta property="og:title" content="<?php wp_title(); ?>" />
+				<meta property="og:type" content="article" />
+				<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
+			<?php
 
-		<?php // output appropriate OG tags by page type
-			if ( is_singular() ) {
+			$description = '';
+			//let's try to get a better description when available
+			if ( is_category() && category_description() ) {
+				$description = category_description();
+			} elseif ( is_author() ) {
 				if ( have_posts() ) {
 					the_post(); // we need to queue up the post to get the post specific info
-					
-					if ( get_the_author_meta( 'twitter' ) && !get_post_meta( $post->ID, 'largo_byline_text' ) )
-						echo '<meta name="twitter:creator" content="@' . largo_twitter_url_to_username( get_the_author_meta( 'twitter' ) ) . '">';
-					?>
-					<meta property="og:title" content="<?php the_title(); ?>" />
-					<meta property="og:type" content="article" />
-					<meta property="og:url" content="<?php the_permalink(); ?>"/>
-					<meta property="og:description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
-					<meta name="description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
-					<?php
-				} // have_posts
-
+					if ( get_the_author_meta( 'description' ) )
+						$description = get_the_author_meta( 'description' );
+				}
 				rewind_posts();
-
-			} elseif ( is_front_page() ) {
-				?>
-					<meta property="og:title" content="<?php bloginfo( 'name' ); echo ' - '; bloginfo( 'description' ); ?>" />
-					<meta property="og:type" content="website" />
-					<meta property="og:url" content="<?php echo home_url(); ?>"/>
-					<meta property="og:description" content="<?php bloginfo( 'description' ); ?>" />
-					<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
-				<?php
 			} else {
-				// not a single post, not the front page
-				?>
-					<meta property="og:title" content="<?php wp_title(); ?>" />
-					<meta property="og:type" content="article" />
-					<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
-				<?php
-
-				$description = '';
-				//let's try to get a better description when available
-				if ( is_category() && category_description() ) {
-					$description = category_description();
-				} elseif ( is_author() ) {
-					if ( have_posts() ) {
-						the_post(); // we need to queue up the post to get the post specific info
-						if ( get_the_author_meta( 'description' ) )
-							$description = get_the_author_meta( 'description' );
-					}
-					rewind_posts();
-				} else {
-					$description = get_bloginfo( 'description' );
-				}
-				if ( !empty( $description ) ) {
-					echo '<meta property="og:description" content="' . strip_tags( esc_html( $description ) ) . '" />';
-					echo '<meta name="description" content="' . strip_tags( esc_html( $description ) ) . '" />';
-				}
+				$description = get_bloginfo( 'description' );
 			}
-
-			// a few more attributes that are common to all page types
-			echo '<meta property="og:site_name" content="'  . get_bloginfo() . '" />';
-
-			// thumbnail url
-			if ( $thumbnailURL ) {
-				echo '<meta property="og:image" content="' . esc_url( $thumbnailURL ) . '" />';
+			if ( !empty( $description ) ) {
+				echo '<meta property="og:description" content="' . strip_tags( esc_html( $description ) ) . '" />';
+				echo '<meta name="description" content="' . strip_tags( esc_html( $description ) ) . '" />';
 			}
+		}
+
+		// a few more attributes that are common to all page types
+		echo '<meta property="og:site_name" content="'  . get_bloginfo() . '" />';
+
+		// set a default thumbnail; if a post has a featured image use that instead.
+		if ( is_singular() && has_post_thumbnail( $post->ID ) ) {
+			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
+			$thumbnail_url = $image[0];
+		} else if ( of_get_option( 'logo_thumbnail_sq' ) ) {
+			$thumbnail_url = of_get_option( 'logo_thumbnail_sq' );
+		} else {
+			$thumbnail_url = false;
+		}
+
+
+		// thumbnail url
+		if ( $thumbnail_url ) {
+			echo '<meta property="og:image" content="' . esc_attr( $thumbnail_url ) . '" />';
+		}
 
 	}
 }

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Functions related to social media knowledge tags
+ *
+ * @package Largo
+ */
+
+/**
  * Adds appropriate open graph, twittercards, and google publisher tags
  * to the header based on the page type displayed
  *
@@ -43,25 +49,27 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 					<meta property="og:url" content="<?php the_permalink(); ?>"/>
 					<meta property="og:description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
 					<meta name="description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
-			<?php
+					<?php
 				} // have_posts
 
 				rewind_posts();
 
-			} elseif ( is_front_page() ) { ?>
-
-				<meta property="og:title" content="<?php bloginfo( 'name' ); echo ' - '; bloginfo( 'description' ); ?>" />
-				<meta property="og:type" content="website" />
-				<meta property="og:url" content="<?php echo home_url(); ?>"/>
-				<meta property="og:description" content="<?php bloginfo( 'description' ); ?>" />
-				<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
-		<?php
+			} elseif ( is_front_page() ) {
+				?>
+					<meta property="og:title" content="<?php bloginfo( 'name' ); echo ' - '; bloginfo( 'description' ); ?>" />
+					<meta property="og:type" content="website" />
+					<meta property="og:url" content="<?php echo home_url(); ?>"/>
+					<meta property="og:description" content="<?php bloginfo( 'description' ); ?>" />
+					<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
+				<?php
 			} else {
-		?>
-				<meta property="og:title" content="<?php wp_title(); ?>" />
-				<meta property="og:type" content="article" />
-				<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
-			<?php
+				// not a single post, not the front page
+				?>
+					<meta property="og:title" content="<?php wp_title(); ?>" />
+					<meta property="og:type" content="article" />
+					<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
+				<?php
+
 				$description = '';
 				//let's try to get a better description when available
 				if ( is_category() && category_description() ) {
@@ -80,14 +88,15 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 					echo '<meta property="og:description" content="' . strip_tags( esc_html( $description ) ) . '" />';
 					echo '<meta name="description" content="' . strip_tags( esc_html( $description ) ) . '" />';
 				}
-			} // else
+			}
 
 			// a few more attributes that are common to all page types
 			echo '<meta property="og:site_name" content="'  . get_bloginfo() . '" />';
 
 			// thumbnail url
-			if ( $thumbnailURL )
+			if ( $thumbnailURL ) {
 				echo '<meta property="og:image" content="' . esc_url( $thumbnailURL ) . '" />';
+			}
 
 	}
 }

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -62,6 +62,7 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 				<meta property="og:type" content="article" />
 				<meta property="og:url" content="<?php echo esc_url( largo_get_current_url() ); ?>"/>
 			<?php
+				$description = '';
 				//let's try to get a better description when available
 				if ( is_category() && category_description() ) {
 					$description = category_description();
@@ -75,7 +76,7 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 				} else {
 					$description = get_bloginfo( 'description' );
 				}
-				if ( $description ) {
+				if ( !empty( $description ) ) {
 					echo '<meta property="og:description" content="' . strip_tags( esc_html( $description ) ) . '" />';
 					echo '<meta name="description" content="' . strip_tags( esc_html( $description ) ) . '" />';
 				}

--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -17,41 +17,47 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 
 		global $post;
 
-		// start the output, some attributes will be the same for all page types
+		// start the output; some attributes will be the same for all page types.
 		echo '<meta name="twitter:card" content="summary">';
 
-		if ( of_get_option( 'twitter_link' ) ) {
-			echo '<meta name="twitter:site" content="@' . largo_twitter_url_to_username( of_get_option( 'twitter_link' ) ) . '">';
+		$twitter_url =  largo_twitter_url_to_username( of_get_option( 'twitter_link' ) );
+		if ( ! empty( $twitter_url ) ) {
+			echo '<meta name="twitter:site" content="@' . esc_attr( $twitter_url ) . '">';
 		}
 
-		// output appropriate OG tags by page type
+		// output appropriate OG tags by page type.
 		if ( is_singular() ) {
 			if ( have_posts() ) {
-				the_post(); // we need to queue up the post to get the post specific info
-				
-				if ( get_the_author_meta( 'twitter' ) && !get_post_meta( $post->ID, 'largo_byline_text' ) )
-					echo '<meta name="twitter:creator" content="@' . largo_twitter_url_to_username( get_the_author_meta( 'twitter' ) ) . '">';
+				the_post(); // we need to queue up the post to get the post specific info.
+
+				if ( get_the_author_meta( 'twitter' ) && ! get_post_meta( $post->ID, 'largo_byline_text' ) ) {
+					echo '<meta name="twitter:creator" content="@' . esc_attr( largo_twitter_url_to_username( get_the_author_meta( 'twitter' ) ) ) . '">';
+				}
 				?>
 				<meta property="og:title" content="<?php the_title(); ?>" />
 				<meta property="og:type" content="article" />
 				<meta property="og:url" content="<?php the_permalink(); ?>"/>
-				<meta property="og:description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
-				<meta name="description" content="<?php echo strip_tags( esc_html( get_the_excerpt() ) ); ?>" />
+				<meta property="og:description" content="<?php echo esc_attr( wp_strip_all_tags( esc_html( get_the_excerpt() ) ) ); ?>" />
+				<meta name="description" content="<?php echo esc_attr( wp_strip_all_tags( esc_html( get_the_excerpt() ) ) ); ?>" />
 				<?php
 			} // have_posts
 
 			rewind_posts();
 
-		} else if ( is_front_page() ) {
+		} elseif ( is_front_page() ) {
+			printf(
+				'<meta property="og:title" content="%1$s - %2$s" />',
+				esc_attr( bloginfo( 'name' ) ),
+				esc_attr( bloginfo( 'description' ) )
+			);
 			?>
-				<meta property="og:title" content="<?php bloginfo( 'name' ); echo ' - '; bloginfo( 'description' ); ?>" />
 				<meta property="og:type" content="website" />
-				<meta property="og:url" content="<?php echo home_url(); ?>"/>
-				<meta property="og:description" content="<?php bloginfo( 'description' ); ?>" />
+				<meta property="og:url" content="<?php echo esc_attr( home_url() ); ?>"/>
+				<meta property="og:description" content="<?php esc_attr( bloginfo( 'description' ) ); ?>" />
 				<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
 			<?php
 		} else {
-			// not a single post, not the front page
+			// not a single post, not the front page.
 			?>
 				<meta property="og:title" content="<?php wp_title(); ?>" />
 				<meta property="og:type" content="article" />
@@ -59,47 +65,51 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 			<?php
 
 			$description = '';
-			//let's try to get a better description when available
+			// let's try to get a better description when available.
 			if ( is_category() && category_description() ) {
 				$description = category_description();
 			} elseif ( is_author() ) {
 				if ( have_posts() ) {
-					the_post(); // we need to queue up the post to get the post specific info
-					if ( get_the_author_meta( 'description' ) )
+					the_post(); // we need to queue up the post to get the post specific info.
+					if ( get_the_author_meta( 'description' ) ) {
 						$description = get_the_author_meta( 'description' );
+					}
 				}
 				rewind_posts();
 			} else {
 				$description = get_bloginfo( 'description' );
 			}
-			if ( !empty( $description ) ) {
-				echo '<meta property="og:description" content="' . strip_tags( esc_html( $description ) ) . '" />';
-				echo '<meta name="description" content="' . strip_tags( esc_html( $description ) ) . '" />';
+			if ( ! empty( $description ) ) {
+				echo '<meta property="og:description" content="' . esc_attr( wp_strip_all_tags( esc_html( $description ) ) ) . '" />';
+				echo '<meta name="description" content="' . esc_attr( wp_strip_all_tags( esc_html( $description ) ) ) . '" />';
 			}
 		}
 
-		// a few more attributes that are common to all page types
-		echo '<meta property="og:site_name" content="'  . get_bloginfo() . '" />';
+		// add a few more attributes that are common to all page types.
+		echo '<meta property="og:site_name" content="' . esc_attr( get_bloginfo() ) . '" />';
+
+		/*
+		 * Images
+		 */
 
 		// set a default thumbnail; if a post has a featured image use that instead.
 		if ( is_singular() && has_post_thumbnail( $post->ID ) ) {
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 			$thumbnail_url = $image[0];
-		} else if ( of_get_option( 'logo_thumbnail_sq' ) ) {
+		} elseif ( ! empty( of_get_option( 'logo_thumbnail_sq' ) ) ) {
 			$thumbnail_url = of_get_option( 'logo_thumbnail_sq' );
 		} else {
 			$thumbnail_url = false;
 		}
 
-
-		// thumbnail url
+		// output the social media image.
 		if ( $thumbnail_url ) {
 			echo '<meta property="og:image" content="' . esc_attr( $thumbnail_url ) . '" />';
 		}
 
 	}
 }
-// don't add this if Yoast is active
+// don't add this if Yoast is active!
 if ( ! class_exists( 'WPSEO_OpenGraph' ) ) {
 	add_action( 'wp_head', 'largo_opengraph' );
 }
@@ -118,7 +128,7 @@ function largo_wp_title_parts_filter( $parts ) {
 	// Add the blog description for the home/front page.
 	if ( is_home() || is_front_page() ) {
 		$site_description = get_bloginfo( 'description', 'display' );
-		if ( ! empty ( $site_description ) ) {
+		if ( ! empty( $site_description ) ) {
 			$parts[] = $site_description;
 		}
 	}

--- a/tests/inc/test-open-graph.php
+++ b/tests/inc/test-open-graph.php
@@ -48,6 +48,6 @@ EOT;
 		$test = '-';
 		$expected = '|';
 		$result = apply_filters( 'document_title_separator', $test );
-		assertEquals( $expected, $result, "Largo's filter on document_title_separator appears to not be engaged.");
+		$this->assertEquals( $expected, $result, "Largo's filter on document_title_separator appears to not be engaged.");
 	}
 }

--- a/tests/inc/test-open-graph.php
+++ b/tests/inc/test-open-graph.php
@@ -24,7 +24,7 @@ EOT;
 	}
 	function test_largo_opengraph__twitter() {
 		$test = 'https://twitter.com/inn';
-		of_set_owption( 'twitter_link', $test );
+		of_set_option( 'twitter_link', $test );
 		ob_start();
 		largo_opengraph();
 		$capture = ob_get_clean();

--- a/tests/inc/test-open-graph.php
+++ b/tests/inc/test-open-graph.php
@@ -1,0 +1,53 @@
+<?php
+
+class OpenGraphTestFunctions extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		$this->post_excerpt = <<<EOT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque cursus purus id pharetra dapibus.
+EOT;
+
+		$this->post_id = $this->factory->post->create(array(
+			'post_excerpt' => $this->post_excerpt,
+		));
+	}
+
+	/**
+	 * Things to test for largo_opengraph():
+	 * - opengraph tags output for page are appropriate to context
+	 * - opengraph tags contain appropriate metadata
+	 */
+	function test_largo_opengraph() {
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+	function test_largo_opengraph__twitter() {
+		$test = 'https://twitter.com/inn';
+		of_set_owption( 'twitter_link', $test );
+		ob_start();
+		largo_opengraph();
+		$capture = ob_get_clean();
+		$this->assertContains(
+			esc_attr( largo_twitter_url_to_username( $test ) ),
+			$capture,
+			"The twitter account 'inn' is not found in the open graph output"
+		);
+	}
+
+	function test_largo_wp_title_parts_filter() {
+		// needs test cases for:
+		// - home page
+		// - front page
+		// - a paginated post
+		// - that the returned $parts contains no empty $part
+		$this->markTestIncomplete("This test has not yet been implemented.");
+	}
+
+	function test_document_title_separator() {
+		$test = '-';
+		$expected = '|';
+		$result = apply_filters( 'document_title_separator', $test );
+		assertEquals( $expected, $result, "Largo's filter on document_title_separator appears to not be engaged.");
+	}
+}


### PR DESCRIPTION
## Changes

- Fixes undefined `$description` in largo_opengraph() on Co-Authors Plus author archive pages. Fixes #1721.
- Runs the largo_opengraph() function through the WordPress PHPCS code standards checker, and fixes many items.
- Cleans up whitespace in the function and rearranges code to make it more readable.

## Testing

~I thought that we had automated tests for this; we don't.~ The barest-minimum test set has been stubbed out.

## Why

For #1721.