### PR TITLE
Remove HTML from labels of Co-Authors Plus additional profile fields.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Removes separator `<span>` on search results page; puts the search result url on a new line instead of next to the date. Also adds a `overflow-wrap: breakword;` style to the search-result URL to make sure it doesn't overflow the result container. [Pull request #1710](https://github.com/INN/largo/pull/1710) for [issue #1509](https://github.com/INN/largo/issues/1509).
 - Fixes a `ReferenceError` in navigation menu JavaScript. [Pull request #1715](https://github.com/INN/largo/pull/1715) for [issue #1714](https://github.com/INN/largo/issues/1714).
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
+- Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #]() for [issue #1720](https://github.com/INN/largo/issues/1720).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Removes separator `<span>` on search results page; puts the search result url on a new line instead of next to the date. Also adds a `overflow-wrap: breakword;` style to the search-result URL to make sure it doesn't overflow the result container. [Pull request #1710](https://github.com/INN/largo/pull/1710) for [issue #1509](https://github.com/INN/largo/issues/1509).
 - Fixes a `ReferenceError` in navigation menu JavaScript. [Pull request #1715](https://github.com/INN/largo/pull/1715) for [issue #1714](https://github.com/INN/largo/issues/1714).
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
-- Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #]() for [issue #1720](https://github.com/INN/largo/issues/1720).
+- Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/inc/users.php
+++ b/inc/users.php
@@ -49,17 +49,17 @@ function largo_filter_guest_author_fields( $fields_to_return, $groups ) {
 	if ( in_array( 'all', $groups ) || in_array( 'contact-info', $groups ) ) {
 		$fields_to_return[] = array(
 			'key'      => 'twitter',
-			'label'    => 'Twitter<br><em>https://twitter.com/username</em>',
+			'label'    => 'Twitter URL: https://twitter.com/username',
 			'group'    => 'contact-info',
 		);
 		$fields_to_return[] = array(
 			'key'      => 'fb',
-			'label'    => 'Facebook<br><em>https://www.facebook.com/username</em>',
+			'label'    => 'Facebook URL: https://www.facebook.com/username',
 			'group'    => 'contact-info',
 		);
 		$fields_to_return[] = array(
 			'key'      => 'linkedin',
-			'label'    => 'LinkedIn<br><em>http://www.linkedin.com/in/username</em>',
+			'label'    => 'LinkedIn URL: http://www.linkedin.com/in/username',
 			'group'    => 'contact-info',
 		);
 		$fields_to_return[] = array(


### PR DESCRIPTION
## Changes

- Removes HTML from the labels Largo passes to Co-Authors Plus, fixing https://github.com/INN/largo/issues/1720

Old:
![Screen Shot 2019-06-10 at 16 03 05 ](https://user-images.githubusercontent.com/1754187/59223167-437c7d80-8b99-11e9-94c9-b3f98702290c.png)

New:
![Screen Shot 2019-06-12 at 22 21 30 ](https://user-images.githubusercontent.com/1754187/59399900-a7eb3880-8d63-11e9-90fb-c50f0b248b97.png)
