### PR TITLE
Fix for `Undefined variable $post in homepage/templates/top-stories.php`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Fixes a `ReferenceError` in navigation menu JavaScript. [Pull request #1715](https://github.com/INN/largo/pull/1715) for [issue #1714](https://github.com/INN/largo/issues/1714).
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 - Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
-- Fixes a `Undefined variable: post` error in `homepage/templates/top-stories.php` on line 73. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
+- Fixes multiple `Undefined variable: post` errors in `homepage/templates/top-stories.php`. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Fixes a `ReferenceError` in navigation menu JavaScript. [Pull request #1715](https://github.com/INN/largo/pull/1715) for [issue #1714](https://github.com/INN/largo/issues/1714).
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 - Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
+- Fixes a `Undefined variable: post` error in `homepage/templates/top-stories.php` on line 73. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -29,7 +29,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 				<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'large' ); ?></a>
 				<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
 				<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
-				<?php largo_excerpt( $post, 4 ); ?>
+				<?php largo_excerpt( get_post(), 4 ); ?>
 				<?php if ( largo_post_in_series() ):
 					$feature = largo_get_the_main_feature();
 					$feature_posts = largo_get_recent_posts_for_term( $feature, 1, 1 );

--- a/homepages/templates/top-stories.php
+++ b/homepages/templates/top-stories.php
@@ -70,7 +70,7 @@ $topstory_classes = (largo_get_active_homepage_layout() == 'LegacyThreeColumn') 
 							} ?>
 							<h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
 							<a href="<?php the_permalink(); ?>"><?php the_post_thumbnail(); ?></a>
-							<?php largo_excerpt( $post, 3 ); ?>
+							<?php largo_excerpt( get_post(), 3 ); ?>
 						</div>
 					<?php elseif ( $count == 4 ) : ?>
 						<h4 class="subhead"><?php _e('More Headlines', 'largo'); ?></h4>


### PR DESCRIPTION
For #1723, if the Top Stories layout was active,
```Notice: Undefined variable: post in .../wp-content/themes/largo-dev/homepages/templates/top-stories.php on line 73``` 
would be returned since `$post` is undefined. 

Switched `largo_excerpt( $post, 3 );` to `largo_excerpt( get_post(), 3 );` to fix the issue.