### PR TITLE
Plugin compatibility testing docs

### DIFF
--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -68,6 +68,7 @@ A few brief technical notes that might be helpful as you get started:
     technicalnotes
     grunt-commands
     hooksfilters
+    plugin-compat
 
 Function Reference
 ------------------

--- a/docs/developers/plugin-compat.rst
+++ b/docs/developers/plugin-compat.rst
@@ -1,0 +1,43 @@
+Plugin compatibility testing
+============================
+
+Largo aims to maintain compatibility with a number of plugins. This file includes a list of those plugins, and things that developers should test with those plugins when the plugin introduces breaking changes or when Largo makes changes to how it interfaces with those plugins.
+
+To add plugins or testing items to this list, edit ``docs/developers/plugin-compat.rst``.
+
+Co-Authors Plus
+---------------
+
+Co-Authors Plus and Largo are integrated in the following ways:
+
+- The Largo_Byline class and its inheritors and users check to see if CAP is active and if posts have CAP metadata.
+- Largo registers several additional metadata fields for CAP guest authors.
+- CAP user metadata is output on CAP author archive pages.
+
+A fuller list of things to test:
+
+- post with WordPress author
+- post with mixed authorship
+
+   - order of WP_User/Co-Author set in post editor is preserved in byline output
+   - names are joined by commas or 'and' as appropriate
+
+- post with solely co-authors
+
+   - order of WP_User/Co-Author set in post editor is preserved in byline output
+   - names are joined by commas or 'and' as appropriate
+
+- co-author author archive
+
+    - co-author thumbnail/bio/social are displayed as with WordPress users
+    - no posts not associated with the co-author are displayed
+    - https://github.com/INN/largo/issues/1539 does not occur
+
+Yoast WordPress SEO
+-------------------
+
+Largo includes by defauly some functionality for Search Engine Optimization, like improved ``<title>`` tags, Open Graph tags, and Twitter Card tags.
+
+Things to test:
+
+- That the functionality in Largo to not enqueue ``largo_opengraph()`` on the ``wp_head`` hook still works

--- a/docs/developers/technicalnotes.rst
+++ b/docs/developers/technicalnotes.rst
@@ -31,13 +31,6 @@ The Largo parent theme uses `LESS CSS <http://lesscss.org/>`_ to generate the st
 
 You will notice that the theme's main style.css is empty except for the header block because we enqueue our styles from ``css/style.css`` (the output of /less/style.less when it's compiled), overriding the WordPress default behavior of including the ``style.css`` file in the root of the theme directory.
 
-TGM Plugin Activation
----------------------
-
-We use `TGM Plugin Activation <https://github.com/thomasgriffin/TGM-Plugin-Activation>`_ to package a couple of plugins with the Largo theme that are not currently available in the WordPress plugin directory and to recommend plugins for a number of tasks that are commonly requested for news websites.
-
-- The rest of the theme files and the folder structure should be familiar to most WordPress developers, but if you have any questions, feel free to send us an email at largo@inn.org
-
 Compiling translation files
 ---------------------------
 

--- a/docs/developers/technicalnotes.rst
+++ b/docs/developers/technicalnotes.rst
@@ -37,8 +37,7 @@ Compiling translation files
 To rebuild the translation files, run the following commands: ::
 
 	grunt pot
-	msgmerge -o lang/es_ES.po.merged lang/es_ES.po lang/largo.pot
-	mv lang/es_ES.po.merged lang/es_ES.po
+	grunt msgmerge
 	grunt po2mo
 
 Images


### PR DESCRIPTION
## Changes

- Adds file to docs to list plugin compatibility testing items, for https://github.com/INN/largo/issues/1706
    - Co-Authors Plus
    - Yoast SEO
- Removes TGM Plugin Activation docs, because TGMPA was removed from Largo
in PR #1580 for issue #1570

## Testing

1. `workon largo` or whatever python virtual environment you're using
2. `grunt docs`
3. In a new shell, go to `docs/_build/html/` and run `python -m SimpleHTTPServer`. Make a note of the URL given.
4. In your browser, visit the URL. The path `/developers/plugin-compat.html` should show these docs.