### PR TITLE
Added `wp_body_open` hook under opening body tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 - Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
 - Fixes multiple `Undefined variable: post` errors in `homepage/templates/top-stories.php`. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
-- Added support for `wp_body_open` hook below opening body tag. [Pull request #]() for [issue #1698](https://github.com/INN/largo/issues/1698).
+- Added support for `wp_body_open` hook below opening body tag. [Pull request #1735](https://github.com/INN/largo/pull/1735) for [issue #1698](https://github.com/INN/largo/issues/1698).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 - Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
 - Fixes multiple `Undefined variable: post` errors in `homepage/templates/top-stories.php`. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
+- Added support for `wp_body_open` hook below opening body tag. [Pull request #]() for [issue #1698](https://github.com/INN/largo/issues/1698).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/header.php
+++ b/header.php
@@ -42,6 +42,21 @@
 
 <body <?php body_class(); ?>>
 
+	<?php 
+
+		/**
+		 * Fires right after the opening body tag.
+		 * 
+		 * @since 0.6.4
+		 */
+		if ( function_exists( 'wp_body_open' ) ) {
+			wp_body_open();
+		} else {
+			do_action( 'wp_body_open' );
+		}
+
+	?>
+
 	<div id="top"></div>
 
 	<?php


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds support for the `wp_body_open` hook after the opening body tag. Fires `wp_body_open()` if it exists (>= 5.2.2), and if not, just uses `do_action('wp_body_open');`.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1698.

## Testing/Questions

Features that this PR affects:

- Largo/child theme headers.

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Any other support we should add for this?

Steps to test this PR:

1. Attempt to hook into `wp_body_open` and make sure it fires where expected.