### PR TITLE
Check if $instance['title'] is empty rather than $title for Largo Image Widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 - Fixes an undefined variable error in certain edge cases of the site `og:description` and `description` meta tags. [Pull request #1724](https://github.com/INN/largo/pull/1724) for [issue #1721](https://github.com/INN/largo/issues/1721).
 - Co-Authors Plus profile field descriptions no longer contain escaped HTML. [Pull request #1726](https://github.com/INN/largo/pull/1726) for [issue #1720](https://github.com/INN/largo/issues/1720).
 - Fixes multiple `Undefined variable: post` errors in `homepage/templates/top-stories.php`. [Pull request #1728](https://github.com/INN/largo/pull/1728) for [issue #1723](https://github.com/INN/largo/issues/1723).
+- Fixes an issue where the widget title wasn't displaying in the Largo Image Widget, due to trying to use the `$title` variable which was removed when we stopped using `extract` in [pull request #1565](https://github.com/INN/largo/pull/1565/). [Pull request #]() for [issue #1717](https://github.com/INN/largo/issues/1717).
 
 ## [Largo 0.6.3](https://github.com/INN/largo/compare/v0.6.2...v0.6.3)
 

--- a/inc/widgets/largo-image-widget.php
+++ b/inc/widgets/largo-image-widget.php
@@ -81,7 +81,7 @@ class largo_image_widget extends WP_Widget {
 			//output the widget
 			echo $args['before_widget'];
 
-			if ( !empty( $title ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
+			if ( !empty( $instance['title'] ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
 
 			echo self::get_image_html( $instance, true );
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Fixes an issue where the widget title wasn't displaying in the Largo Image Widget, due to trying to use the `$title` variable which was removed when we stopped using `extract` in [pull request #1565](https://github.com/INN/largo/pull/1565/).

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1717.

## Testing/Questions

Features that this PR affects:

- Largo Image Widget

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Are all other instances of title ok on other widgets?

Steps to test this PR:

1. Add Largo Image Widget to a sidebar.
2. Add a title to the Largo Image Widget.
3. Verify the title displays for the widget.