### PR TITLE
Make sure the gallery doesn't have a `navis-before` child on open

### DIFF
--- a/lib/navis-slideshows/js/navis-slideshows.js
+++ b/lib/navis-slideshows/js/navis-slideshows.js
@@ -252,7 +252,7 @@
                     maybeHideStickyNav();
 
                     // If the image isn't linked
-                    if (gallery[0].localName !== "a"){
+                    if (gallery[0].localName !== "a" && gallery.find('.navis-before').length == 0){
                         gallery.addClass('navis-slideshow navis-single navis-full');
 
                         // Add the close (X) button


### PR DESCRIPTION
If it does have that child, the bad settings won't be applied.

## Changes

This pull request makes the following changes:

- Added another conditional on the navis image click trigger to first check if the gallery has a `.navis-before` child before firing functions to modify styles and add the X button.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1700 

## Testing/Questions

Features that this PR affects:

- Navis slideshow images

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Does it work as expected now?

Steps to test this PR:

Given a single image in an image block that is aligned left or right, take the following steps to reproduce this bug:

1. Click/tap on the image to open the image in a Navis modal.
    1. the modal opens
    2. The image width is set to 100%: https://github.com/INN/largo/blob/e2ac830239452658c285860b330d521c6a0f300e/lib/navis-slideshows/js/navis-slideshows.js#L271
2. Click/tap on the image in the Navis modal.
    1. Nothing happens that the user can see, but the function `addCloseX` is called again, adding a duplicate `X` in the modal (which is invisible to the user because it's stacked atop the current X, using the same CSS rules for positioning)
    2. The 100% image width is saved as the pre-click image attribute https://github.com/INN/largo/blob/e2ac830239452658c285860b330d521c6a0f300e/lib/navis-slideshows/js/navis-slideshows.js#L263-L268 and is now relayed to the event handler that calls `closeSingle` https://github.com/INN/largo/blob/e2ac830239452658c285860b330d521c6a0f300e/lib/navis-slideshows/js/navis-slideshows.js#L274-L276
3. Click on the X to exit the modal.
    1. The 100% from the second click is used as the pre-click image width by `closeSingle` when the image is closed: https://github.com/INN/largo/blob/e2ac830239452658c285860b330d521c6a0f300e/lib/navis-slideshows/js/navis-slideshows.js#L177
4. The image should still be its normal size. Previously it would be 100% of the column width rather than its previous appearance.
