### PR TITLE
Save the Largo Release Checklist in Largo's developer docs

### DIFF
--- a/docs/SUPPORT.rst
+++ b/docs/SUPPORT.rst
@@ -1,0 +1,12 @@
+Support
+=======
+
+.. this file was added for https://github.com/INN/largo/issues/1713
+   we're trying a ``docs/SUPPORT.rst` file to see if it triggers GitHub's automated support file detection
+
+Largo has many forms of documentation.
+
+- User documentation is available at `largo.inn.org <https://largo.inn.org>`_ and `support.inn.org <https://support.inn.org>`_
+- Developer documentation is available at `largo.readthedocs.io <https://largo.readthedocs.io>`_.
+- We're also available via email at `support@inn.org <mailto:support@inn.org>`_.
+

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,55 +1,7 @@
 Function reference by file
 ==========================
 
-* `functions.php <functions.html>`_
-* `feed-mailchimp.php <feed-mailchimp.html>`_
-* `archive.php <archive.html>`_
-* `options.php <options.html>`_
-* `inc/conditionals.php <inc/conditionals.html>`_
-* `inc/widgets.php <inc/widgets.html>`_
-* `inc/header-footer.php <inc/header-footer.html>`_
-* `inc/update.php <inc/update.html>`_
-* `inc/post-templates.php <inc/post-templates.html>`_
-* `inc/dashboard.php <inc/dashboard.html>`_
-* `inc/open-graph.php <inc/open-graph.html>`_
-* `inc/sidebars.php <inc/sidebars.html>`_
-* `inc/custom-feeds.php <inc/custom-feeds.html>`_
-* `inc/featured-content.php <inc/featured-content.html>`_
-* `inc/post-tags.php <inc/post-tags.html>`_
-* `inc/nav-menus.php <inc/nav-menus.html>`_
-* `inc/enqueue.php <inc/enqueue.html>`_
-* `inc/term-meta.php <inc/term-meta.html>`_
-* `inc/editor.php <inc/editor.html>`_
-* `inc/metabox-api.php <inc/metabox-api.html>`_
-* `inc/users.php <inc/users.html>`_
-* `inc/related-content.php <inc/related-content.html>`_
-* `inc/term-sidebars.php <inc/term-sidebars.html>`_
-* `inc/post-social.php <inc/post-social.html>`_
-* `inc/avatars.php <inc/avatars.html>`_
-* `inc/post-metaboxes.php <inc/post-metaboxes.html>`_
-* `inc/term-icons.php <inc/term-icons.html>`_
-* `inc/ajax-functions.php <inc/ajax-functions.html>`_
-* `inc/helpers.php <inc/helpers.html>`_
-* `inc/verify.php <inc/verify.html>`_
-* `inc/custom-less-variables.php <inc/custom-less-variables.html>`_
-* `inc/featured-media.php <inc/featured-media.html>`_
-* `inc/images.php <inc/images.html>`_
-* `inc/byline_class.php <inc/byline_class.html>`_
-* `inc/deprecated.php <inc/deprecated.html>`_
-* `inc/taxonomies.php <inc/taxonomies.html>`_
-* `inc/customizer/customizer.php <inc/customizer/customizer.html>`_
-* `inc/wp-taxonomy-landing/functions/cftl-series-order.php <inc/wp-taxonomy-landing/functions/cftl-series-order.html>`_
-* `inc/wp-taxonomy-landing/functions/cftl-admin.php <inc/wp-taxonomy-landing/functions/cftl-admin.html>`_
-* `inc/avatars/functions.php <inc/avatars/functions.html>`_
-* `inc/widgets/largo-image-widget.php <inc/widgets/largo-image-widget.html>`_
-* `inc/widgets/largo-twitter.php <inc/widgets/largo-twitter.html>`_
-* `inc/widgets/largo-facebook.php <inc/widgets/largo-facebook.html>`_
-* `inc/widgets/largo-about.php <inc/widgets/largo-about.html>`_
-* `inc/widgets/largo-recent-comments.php <inc/widgets/largo-recent-comments.html>`_
-* `inc/widgets/largo-recent-posts.php <inc/widgets/largo-recent-posts.html>`_
-* `inc/widgets/largo-post-series-links.php <inc/widgets/largo-post-series-links.html>`_
-* `inc/widgets/largo-taxonomy-list.php <inc/widgets/largo-taxonomy-list.html>`_
-* `inc/widgets/largo-author-bio.php <inc/widgets/largo-author-bio.html>`_
-* `homepages/homepage.php <homepages/homepage.html>`_
-* `homepages/zones/zones.php <homepages/zones/zones.html>`_
-* `homepages/layouts/HomepageSingleWithSeriesStories.php <homepages/layouts/HomepageSingleWithSeriesStories.html>`_
+.. toctree::
+   :glob:
+
+   **

--- a/docs/developers/child-themes/advanced-development.rst
+++ b/docs/developers/child-themes/advanced-development.rst
@@ -1,0 +1,14 @@
+Advanced Theme Development and Modification
+-------------------------------------------
+
+We've created a `Largo-Sample-Child-Theme repository <https://github.com/INN/Largo-Sample-Child-Theme>`_ to illustrate how we organize child themes that extend Largo.
+
+Visit the repository page to learn more about the following as they pertain to Largo-based child themes:
+
+- `Unit Tests and Continuous Integration <https://github.com/INN/Largo-Sample-Child-Theme/blob/master/tests/readme.md>`_
+- `Stylesheets (LESS and CSS) <https://github.com/INN/Largo-Sample-Child-Theme/blob/master/less/readme.md>`_
+- `Theme Directory Layout <https://github.com/INN/Largo-Sample-Child-Theme#theme-directory-structure>`_
+- `Custom Theme Javascript or CSS <https://github.com/INN/Largo-Sample-Child-Theme#removing-or-replacing-largo-javascript-or-css>`_
+- `Removing or replacing Largo Javascript or CSS <https://github.com/INN/Largo-Sample-Child-Theme#removing-or-replacing-largo-javascript-or-css>`_
+
+You can also look at other themes we've made. These themes are nested in what we call Umbrella Repositories, which contain themes and related files in a framework allowing for deployment. A list of these Umbrella Repositories can be found `by searching for 'umbrella-' on INN's GitHub page <https://github.com/INN?utf8=%E2%9C%93&q=umbrella-&type=&language=>`_. If you'd like to set up you own umbrella repo, see `our umbrella boilerplate <https://github.com/INN/umbrella-boilerplate>`_.

--- a/docs/developers/child-themes/basic-style-changes.rst
+++ b/docs/developers/child-themes/basic-style-changes.rst
@@ -1,0 +1,16 @@
+Changing Basic Styling
+----------------------
+
+Largo has a built-in way to change some basic styling options.
+
+To enable this option, from the *Appearance* > *Theme Options* screen click on the "Advanced" tab and check the box labelled "Enable Custom LESS to CSS For Theme Customization" and then save the settings.
+
+.. image:: http://assets.apps.inn.org/largo-docs/enable-less-css.png
+
+You will now see an additional menu item under the Appearance menu labelled "CSS Variables". From this menu you will be able to change some basic styling attributes of your Largo site, including the color scheme, fonts and font-sizes.
+
+.. image:: http://assets.apps.inn.org/largo-docs/less-css-menu.png
+
+This option is only intended for making some basic changes to your site's styles. For anything more complex you will need to create a child theme.
+
+

--- a/docs/developers/child-themes/creating.rst
+++ b/docs/developers/child-themes/creating.rst
@@ -1,8 +1,3 @@
-Using Child Themes
-==================
-
-Child themes are `a feature of WordPress <https://largo.readthedocs.io/en/write-the-docs/developers/childthemes.html>`_ that allow you to extend and override the parent theme that the child theme is based upon. We encourage you to create a child theme for your project.
-
 Creating Child Themes
 ---------------------
 
@@ -35,30 +30,3 @@ To use this child theme, `simply download and unzip it <https://github.com/INN/L
 Now that you have a child theme created, login to your WordPress site and go to Appearance > Themes. Find your child theme, click "activate" and then you should see your new child theme in action on your site and can begin customizing.
 
 
-Changing Basic Styling
-----------------------
-
-Largo has a built-in way to change some basic styling options.
-
-To enable this option, from the *Appearance* > *Theme Options* screen click on the "Advanced" tab and check the box labelled "Enable Custom LESS to CSS For Theme Customization" and then save the settings.
-
-.. image:: http://assets.apps.inn.org/largo-docs/enable-less-css.png
-
-You will now see an additional menu item under the Appearance menu labelled "CSS Variables". From this menu you will be able to change some basic styling attributes of your Largo site, including the color scheme, fonts and font-sizes.
-
-.. image:: http://assets.apps.inn.org/largo-docs/less-css-menu.png
-
-This option is only intended for making some basic changes to your site's styles. For anything more complex you will need to create a child theme.
-
-Advanced Theme Development and Modification
--------------------------------------------
-
-We've created a `Largo-Sample-Child-Theme repository <https://github.com/INN/Largo-Sample-Child-Theme>`_ to illustrate how we organize child themes that extend Largo.
-
-Visit the repository page to learn more about the following as they pertain to Largo-based child themes:
-
-- `Unit Tests and Continuous Integration <https://github.com/INN/Largo-Sample-Child-Theme/blob/master/tests/readme.md>`_
-- `Stylesheets (LESS and CSS) <https://github.com/INN/Largo-Sample-Child-Theme/blob/master/less/readme.md>`_
-- `Theme Directory Layout <https://github.com/INN/Largo-Sample-Child-Theme#theme-directory-structure>`_
-- `Custom Theme Javascript or CSS <https://github.com/INN/Largo-Sample-Child-Theme#removing-or-replacing-largo-javascript-or-css>`_
-- `Removing or replacing Largo Javascript or CSS <https://github.com/INN/Largo-Sample-Child-Theme#removing-or-replacing-largo-javascript-or-css>`_

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -55,23 +55,19 @@ We encourage all INN member organizations looking to add features to or otherwis
 Child Themes
 ------------
 
-What *is* a child theme?
-````````````````````````
+A child theme is a theme that inherits the functionality and styling of another theme, called the parent theme. Child themes are the recommended way of modifying an existing theme. Child themes are `a feature of WordPress <https://developer.wordpress.org/themes/advanced-topics/child-themes/>`_ that allow you to extend and override the parent theme that the child theme is based upon. We encourage you to create a child theme for your website.
 
-From the `WordPress Codex <https://codex.wordpress.org/Child_Themes>`_:
+You should use a child theme in order to make it easier to upgrade to future versions of the Largo parent theme. Child themes allow you to put your modifications to Largo in a place that won't be wiped out when you update Largo. WordPress has a `tutorial you can follow <https://developer.wordpress.org/themes/advanced-topics/child-themes/>`_ that explains how to create and configure a child theme.
 
-  A child theme is a theme that inherits the functionality and styling of another theme, called the parent theme. Child themes are the recommended way of modifying an existing theme.
-
-Why should you use a child theme?
-`````````````````````````````````
-In order to make it easier to upgrade to future versions of the Largo parent theme, you will want to add any customizations that are unique to your site by creating a child theme. WordPress has a `tutorial you can follow <http://codex.wordpress.org/Child_Themes>`_ that explains how to create and configure a child theme.
-
-**More:** `Using Child Themes <../developers/childthemes.html>`_.
 
 .. toctree::
-    :maxdepth: 2
+   :glob:
 
-    childthemes
+   child-themes/creating
+   child-themes/basic-style-changes
+   child-themes/advanced-development
+   upgrade-largo
+   child-themes/*
 
 Custom Post Templates
 ---------------------

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -10,6 +10,32 @@ If you use Largo for a project we'd love to hear from you so can we add you to o
 
 The preferred way of building a site with Largo is by creating a WordPress child theme. We have created a `sample, heavily documented, child theme <childthemes.html#advanced-theme-development-and-modification>`_ to help you understand the way we structure our child themes in the hopes that it will give you a solid framework to get started. There is more information on setting up Largo and `using child themes <../users/download.html#creating-child-themes>`_ in the download and installation section of our documentation.
 
+Bug Reports and Feature Requests
+--------------------------------
+
+Our preferred way for you to submit bug reports, requests for new features or even questions about how things work in Largo is by `opening a new issue on the Largo github repository <https://github.com/INN/Largo/issues>`_.
+
+Contributing to Largo
+---------------------
+
+We welcome (and encourage) anyone who wants to contribute back to the project.
+
+To begin, `please review our contribution guidelines <https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md>`_.
+
+We have many ways you can contribute and not all are technical. Wherever possible we will flag issues that we believe are `good for beginners <https://github.com/INN/Largo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+for+beginners%22>`_ or for less/non-technical contributors (`writing/improving documentation <https://github.com/INN/Largo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+needs+docs%22>`_, etc.).
+
+Our roadmap, open issues, suggested features and discussion can always be found in the issues section of the `Largo github repository <https://github.com/INN/Largo/issues>`_.
+
+We also have documentation on the `Anatomy of a Pull Request and Submission Protocol <https://github.com/INN/docs/blob/master/how-to-work-with-us/pull-requests.md>`_ and `Contributing to the INN Nerds docs repo using Github.com <https://github.com/INN/docs/blob/master/how-to-work-with-us/via-github.md>`_ which explain, at a high level, the process of contributing to Github projects, generally.
+
+If you would like to help with the documentation, here are some resources:
+
+- `Sphinx' PHP domain-specific markup <http://mark-story.com/posts/view/sphinx-phpdomain-released>`_
+- `Sphinx reStructuredText primer and quickstart guide <http://sphinx-doc.org/rest.html>`_
+
+
+If you have feedback on this collection of documentation, please `get in touch <../feedback.html>`_.
+
 Setting up a development environment
 ------------------------------------
 
@@ -80,32 +106,6 @@ It may be helpful to  `read Largo's source on Github <https://github.com/INN/Lar
 .. toctree::
     :maxdepth: 2
 
-    /api/index
     constants
     hooksfilters
-
-Bug Reports and Feature Requests
---------------------------------
-
-Our preferred way for you to submit bug reports, requests for new features or even questions about how things work in Largo is by `opening a new issue on the Largo github repository <https://github.com/INN/Largo/issues>`_.
-
-Contributing to Largo
----------------------
-
-We welcome (and encourage) anyone who wants to contribute back to the project.
-
-To begin, `please review our contribution guidelines <https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md>`_.
-
-We have many ways you can contribute and not all are technical. Wherever possible we will flag issues that we believe are `good for beginners <https://github.com/INN/Largo/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+for+beginners%22>`_ or for less/non-technical contributors (`writing/improving documentation <https://github.com/INN/Largo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+needs+docs%22>`_, etc.).
-
-Our roadmap, open issues, suggested features and discussion can always be found in the issues section of the `Largo github repository <https://github.com/INN/Largo/issues>`_.
-
-We also have documentation on the `Anatomy of a Pull Request and Submission Protocol <https://github.com/INN/docs/blob/master/how-to-work-with-us/pull-requests.md>`_ and `Contributing to the INN Nerds docs repo using Github.com <https://github.com/INN/docs/blob/master/how-to-work-with-us/via-github.md>`_ which explain, at a high level, the process of contributing to Github projects, generally.
-
-If you would like to help with the documentation, here are some resources:
-
-- `Sphinx' PHP domain-specific markup <http://mark-story.com/posts/view/sphinx-phpdomain-released>`_
-- `Sphinx reStructuredText primer and quickstart guide <http://sphinx-doc.org/rest.html>`_
-
-
-If you have feedback on this collection of documentation, please `get in touch <../feedback.html>`_.
+    /api/index

--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -92,6 +92,7 @@ A few brief technical notes that might be helpful as you get started:
     :maxdepth: 2
 
     technicalnotes
+    release-checklist
     grunt-commands
     hooksfilters
     plugin-compat

--- a/docs/developers/release-checklist.rst
+++ b/docs/developers/release-checklist.rst
@@ -1,0 +1,93 @@
+Release Checklist
+=================
+
+This document provides a reference implementation of a Largo release checklist, fulfulling the requirement set forth in `issue #809 <https://github.com/INN/largo/issues/809>`_ for a static copy of the release checklist.
+
+Examples of the release checklist are:
+
+- `0.6.1 <https://github.com/INN/largo/issues/1590>`_
+- `0.6.2 <https://github.com/INN/largo/issues/1690>`_
+- `0.6.3 <https://github.com/INN/largo/issues/1694>`_
+- `0.6.4 <https://github.com/INN/largo/issues/1704>`_
+
+Here's the reference list, in Markdown so that it can be copied into a new GitHub issue:::
+
+    This is copied from `docs/developers/release-checklist.rst`, which is the reference issue for the pre-release checklist.
+
+    The owner of the release needs to complete the following steps **BEFORE** merging to master and tagging the release:
+
+    - [ ] run the [theme check plugin](https://wordpress.org/plugins/theme-check/) and address any outstanding issues. 
+    - [ ] using [WP sample data](https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml), go through the entire [theme unit tests checklist]
+    - [ ] Update the INN Sandbox repo submodule https://github.com/INN/umbrella-innsandbox and take a look around http://demo.innsandbox.wpengine.com, making sure to test all testable items.
+    - [ ] design checklist tktk (add to the list of theme unit tests, including style guidance, patterns that need to be followed, etc., eventually this will be codified in the INN/Largo style guide)
+        - [ ] click around: don't just visually check the homepage, but also internal pages: https://github.com/INN/docs/blob/master/checklists/child-themes.md
+        - [ ] Homepage `/`
+            - [ ] Blog
+            - [ ] Big Story, full-width image
+            - [ ] Big story, list of featured stories
+            - [ ] Big Story, list of stories from same series
+            - [ ] Top Stories
+            - [ ] Legacy Three Column
+        - [ ] Articles `/?p=1234`
+        - [ ] Series `/series/slug/` `/?series=1234`
+        - [ ] Category archive pages `/category/slug/`
+        - [ ] Series archive pages `/series/slug/`
+        - [ ] Series landing pages `/slug/`
+        - [ ] Search results `/?s=words`
+        - [ ] Pages `/slug/`
+        - [ ] Tag archives `/tag/slug`
+        - [ ] Load More Posts
+        - [ ] Sticky nav
+            - [ ] Mobile
+            - [ ] Desktop
+        - [ ] Non-sticky nav
+        - [ ] Widgets
+            - [ ] Default background
+            - [ ] Reverse Background
+            - [ ] No Background
+        - [ ] Article
+            - [ ] Social buttons
+            - [ ] Type
+            - [ ] Fonts rendered are fonts specified in stylesheet ( In Chrome: "Inspect element" on a `<p>`, then look at the bottom of the "Computed" tab. )
+            - [ ] Image display
+            - [ ] slideshows, see https://github.com/INN/largo/issues/1664
+        - [ ] Footer
+    - [ ] check that the LESS Customizer works
+    - [ ] test the plugins described in `docs/developers/plugin-compat.rst`
+    - [ ] move any outstanding issues to future milestones or backlog
+    - [ ] resolve all secret issues, private issues, or issues with the theme that are otherwise documented outside of this public repository
+    - [ ] update the changelog
+        - [ ] New features list
+        - [ ] bugfixes
+        - [ ] potentially breaking changes and upgrade notices
+    - [ ] run `grunt build`
+    - [ ] write release announcement
+        - [ ] GitHub release drafted
+            - can be copied from `changelog.md`
+            - [ ] includes encouragement to say hi if you're using the theme. (This fulfills the "who's using our stuff?" goal in https://github.com/INN/largo/issues/1495)
+        - [ ] labs.inn.org blog post written and saved as draft, based on changelog
+    - [ ] update all version numbers. `0.6.4-prerelease.x` all become `0.6.4`.
+    - [ ] merge 0.5-dev into 0.5
+
+    Releasing:
+
+    - [ ] tag and sign release `git tag -s v0.6.4`
+    - [ ] publish the draft GitHub release at https://github.com/INN/largo/releases
+    - [ ] close milestone
+
+    After release is published:
+
+    - [ ] publish launch announcement blog post
+    - [ ] tweet announcement and schedule 2-5 for the next 7 days (TweetDeck, HootSuite) with simple download prompt or tweets detailing new features, like "Newsroom Staff Pages should be clean and useful. We think so too. See Largo 0.X's new...." Make sure these tweets get cross-tweeted between INN accounts.
+    - [ ] recompile LESS on all child themes, and see https://github.com/INN/docs/blob/master/checklists/child-themes.md
+    - [ ] new release needs to be deployed to our sites
+        - inndev
+        - innsandbox
+        - inndevlearn
+    - [ ] notify non-INN sites
+    - [ ] update version number on largo.inn.org, like in INN/umbrella-inndev#36
+    - [ ] bump version number in active-development branch to `0.6.5-prerelease`, as described inhttps://github.com/INN/largo/pull/1705
+    - [ ] compare this ticket to the template used to create this ticket, and update the template
+    - [ ] create the 0.6.5 release ticket from the template used to create this issue
+
+After copying all that into a new ticket, be sure to update version numbers.

--- a/docs/developers/release-checklist.rst
+++ b/docs/developers/release-checklist.rst
@@ -17,8 +17,8 @@ Here's the reference list, in Markdown so that it can be copied into a new GitHu
     The owner of the release needs to complete the following steps **BEFORE** merging to master and tagging the release:
 
     - [ ] run the [theme check plugin](https://wordpress.org/plugins/theme-check/) and address any outstanding issues. 
-    - [ ] using [WP sample data](https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml), go through the entire [theme unit tests checklist]
-    - [ ] Update the INN Sandbox repo submodule https://github.com/INN/umbrella-innsandbox and take a look around http://demo.innsandbox.wpengine.com, making sure to test all testable items.
+    - [ ] using [WP sample data](https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml), go through the entire [theme unit tests checklist](https://codex.wordpress.org/Theme_Unit_Test)
+    - [ ] Update the INN Sandbox repo submodules https://github.com/INN/umbrella-innsandbox/tree/master/wp-content/themes and take a look around the sandbox sites, making sure to test all testable items.
     - [ ] design checklist tktk (add to the list of theme unit tests, including style guidance, patterns that need to be followed, etc., eventually this will be codified in the INN/Largo style guide)
         - [ ] click around: don't just visually check the homepage, but also internal pages: https://github.com/INN/docs/blob/master/checklists/child-themes.md
         - [ ] Homepage `/`

--- a/docs/developers/release-checklist.rst
+++ b/docs/developers/release-checklist.rst
@@ -65,6 +65,7 @@ Here's the reference list, in Markdown so that it can be copied into a new GitHu
         - [ ] GitHub release drafted
             - can be copied from `changelog.md`
             - [ ] includes encouragement to say hi if you're using the theme. (This fulfills the "who's using our stuff?" goal in https://github.com/INN/largo/issues/1495)
+            - [ ] includes link to "how to update Largo" docs added for https://github.com/INN/largo/issues/1713
         - [ ] labs.inn.org blog post written and saved as draft, based on changelog
     - [ ] update all version numbers. `0.6.4-prerelease.x` all become `0.6.4`.
     - [ ] merge 0.5-dev into 0.5

--- a/docs/developers/upgrade-largo.rst
+++ b/docs/developers/upgrade-largo.rst
@@ -1,0 +1,112 @@
+Upgrading Largo
+===============
+
+We do our best to make sure that the update process for any version of Largo is as smooth as possible. However, you should always test a Largo update before upgrading your live site.
+
+The questions you'll need answers to before you update your live site:
+
+.. conotents::
+   :local:
+
+What is the new Largo version?
+------------------------------
+
+The latest Largo release is always listed at https://github.com/INN/largo/releases
+
+Make a note of the version number given there.
+
+What version of Largo does your site use now?
+---------------------------------------------
+
+There are several ways to determine what version of Largo you're using.
+
+Using the Dashboard
+~~~~~~~~~~~~~~~~~~~
+
+Log into your site's WordPress Dashboard and visit **Appearance > Themes**. Find Largo in the list and make a note of the version number displayed. 
+
+While you're in here, make a note of which theme is the active theme. If you're not using Largo, but the active theme has a note like "This is a child theme of Project Largo - Base Theme," then you're using a child theme.
+
+Using code inspection
+~~~~~~~~~~~~~~~~~~~~~
+
+1. Go to the site's homepage, and use your browser's tools to "View source". In Chrome, a handy way to do this is to prefix the url ``https://example.org`` with ``view-source:`` like so: ``view-source:https://example.org``
+2. Search in the source code (control/command F) for the string ``themes/largo``. Example results:
+	- Case 1: ``https://31lz132jjnab134mc12u4xg5-wpengine.netdna-ssl.com/wp-content/themes/largo/lib/navis-slideshows/css/slides.css?ver=1.0`` on the site ``https://example.org``
+	- Case 2: ``https://example.org/wp-content/themes/largo/js/load-more-posts.min.js?ver=0.5.5.2``
+	- Case 3: ``https://example.org/wp-content/themes/largo-0.5.5.2/js/load-more-posts.min.js?ver=0.5.5.2``
+3. Determine the base URL of the Largo theme.
+	- Case 1 above shows that the site ``https://example.org`` is using a CDN to deliver some assets. Replace ``https://31lz132jjnab134mc12u4xg5-wpengine.netdna-ssl.com`` with ``https://example.org`` to form the URL ``https://example.org/wp-content/themes/largo/lib/navis-slideshows/css/slides.css?ver=1.0``, and proceed the Default Case below.
+	- Case 2 shows a URL ending in ``?ver=0.5.5.2``, and ``0.5.5.2`` is a version number from the list of tagged releases found at https://github.com/INN/largo/tags. This is a strong signal that the site's version of Largo is 0.5.5.2, but should be confirmed by following the Default Case below.
+	- Case 3 shows a theme directory of ``/largo-0.5.5.2/``, which is not a good indication of the version number. Sites that were installed using a specific version of Largo in a theme directory that contained the version number in the directory name must install subsequent upgrades to that same directory name, such that a site running Largo 0.6.1 might have a URL ``https://example.org/wp-content/themes/largo-0.5.5.2/js/load-more-posts.min.js?ver=0.6.2``. If the version number in the theme directory name matches the version number at the end of the query string, as is the case with ``https://example.org/wp-content/themes/largo/js/load-more-posts.min.js?ver=0.5.5.2``, this is a strong signal that the theme version is that number. However, this should be confirmed by following the default case instructions below.
+	- Default Case: take the URL ``https://example.org/wp-content/themes/largo/lib/navis-slideshows/css/slides.css?ver=1.0`` and remove everything after the Largo directory name. The base theme URL is ``https://example.org/wp-content/themes/largo/``
+4. Now that you have the theme base URL, append ``style.css``. ``https://example.org/wp-content/themes/largo/`` becomes ``https://example.org/wp-content/themes/largo/style.css``. You should see a label ``Version:`` followed by a number.
+	- ``Version: 0.1`` This is really early Largo, or `v0.1 <https://github.com/INN/largo/blob/v0.1/style.css>`_, or `v0.2 <https://github.com/INN/largo/blob/v0.2/style.css>`_, `v0.3 <https://github.com/INN/largo/blob/v0.3/style.css>`_, or a version of 0.3 on the ``v0.3-maintenance`` branch: https://github.com/INN/largo/blob/v0.3-maintenance/style.css
+	- ``Version: 0.2`` Doesn't exist; tagged release ``v0.2`` had a version number of ``0.1``
+	- ``Version: 0.3`` This may be an in-development version of Largo after ``v0.3`` was tagged, before ``v0.4`` was tagged.
+	- Version numbers matching [a tagged release](https://github.com/INN/largo/releases): probably that version number.
+	- ``Version: 0.X-prerelease`` Version numbers like this indicate the site is running a development build of Largo that preceded the ``0.X`` in the version number.
+5. If ``style.css`` is not available, check ``readme.md`` or ``readme.txt`` or ``package.json``. Those typically contain the version number.
+
+Using filesystem inspection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Connect to your site using a FTP, SFTP, or SSH client. (Contact your hosting provider to determine what they support.)
+2. Navigate to your site's ``wp-content/themes/`` directory.
+3. Search through the list of installed themes until you find the Largo theme folder.
+4. Examine ``style.css`` as described above.
+
+Using wp-cli
+~~~~~~~~~~~~
+
+See the documentation for the `wp theme command <https://developer.wordpress.org/cli/commands/theme/>`_ to learn more about how to use that command to get information about theme versions.
+
+Does your site have a child theme?
+----------------------------------
+
+By Dashboard inspection
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If you saw the note mentioned above, saying that your active theme was a child theme of Largo, then yes, you have a child theme.
+
+By website source code inspection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Return to the source code, and search for ``/themes/``. Make a note of any URLs that have a path other than ``/themes/largo``, such as ``/themes/largo-child/style.css``.
+2. Follow the instructions given above to find the site's child theme's base URL, then check out its ``style.css`` or ``readme.txt`` or ``readme.md``.
+
+Using wp-cli
+~~~~~~~~~~~~
+
+See the documentation for the `wp theme command <https://developer.wordpress.org/cli/commands/theme/>`_ to learn more how to use that command to get information about child themes.
+
+Do you have a staging site?
+---------------------------
+
+Talk to your hosting provider if you are unsure whether you have a staging site.
+
+- WP Engine: https://wpengine.com/support/staging/
+- Flywheel: https://getflywheel.com/why-flywheel/staging-sites/
+- Pantheon: https://pantheon.io/docs/pantheon-workflow/
+
+How do you upgrade?
+-------------------
+
+If no staging site is available to you, you'll want to back up your site thoroughly before testing any Largo upgrade in your live site. Contact your host to learn more about what backups are available to you.
+
+If a staging site is available to you, your process will be something like this:
+
+1. Copy your live site to your staging site
+2. Review the release notes for the new version of Largo. Release notes are found at https://github.com/INN/largo/releases and at https://labs.inn.org.
+3. Replace the contents of the existing Largo folder in your staging site with the contents of the release .zip downloaded from https://github.com/INN/largo/releases
+4. Log into your staging site and follow the instructions to update your site's database.
+5. Review your newly-upgraded staging site for:
+    - problems listed in the release notes
+    - problems listed in https://github.com/INN/docs/blob/master/checklists/child-themes.md
+6. Update your child theme as necessary for compatibility.
+7. When you're sure your site is happily bug-free:
+    1. Back up your live site.
+    2. Copy the upgraded child theme and parent theme to your live site.
+    3. Copy any configuration changes you made to your live site.
+
+INN Labs would be happy to work with you on your site's upgrade process; contact us at support@inn.org for details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,5 +30,5 @@ For Developers
     :maxdepth: 3
 
     developers/index
-    developers/constants
+    api/index
     feedback

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,14 +21,10 @@ Twitter: https://twitter.com/largoproject
 
 Mailing List: http://eepurl.com/yu0bT
 
-.. _dev-docs:
-
-For Developers
---------------
-
 .. toctree::
     :maxdepth: 3
 
     developers/index
-    api/index
     feedback
+    SUPPORT
+    api/index


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Copies a slightly-modified version of the Markdown checklist in https://github.com/INN/largo/issues/1704 into a copyable code block in a reStructuredText file, with some surrounding documentation and instructions on how to use the checklist. This addresses #809.
- Adds that file to the index of developer documentation
- Updates the API docs portion of the developer docs to use globbing to get _all_ the docs files, replacing the previous hardcoded list
- Because of the new length of the API docs, moves the API docs to the bottom of the pages where it appears
- Moves the contribution and feedback sections of several docs to the top, so that they're above the API docs.

## Why

For #809, and to improve largo.readthedocs.io

## Testing/Questions

Features that this PR affects:

- https://largo.readthedocs.io

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] are there any blatant typos?
- [ ] Do the post-release checklist items make sense?

Steps to test this PR:

1. In a new terminal —  here referred to as "terminal A" — spin up your Python virtualenv that contains `sphinx`: `workon largo`
2. Inside that virtualenv in terminal A, run `grunt watch`.
3. In a new terminal — here referred to as "terminal B" — do the following:
    - cd docs
    - touch index.rst (to trigger Grunt Watch's build of the docs)
    - cd _build/html
    - python -m SimpleHTTPServer (starts a simple HTTP server to give you local access to the docs)
4. In a browser, visit the URL that the Python server gave you
5. Poke around
