### PR TITLE
Fix Twitter metadata being improperly output to page before global nav

### DIFF
--- a/inc/open-graph.php
+++ b/inc/open-graph.php
@@ -47,14 +47,14 @@ if ( ! function_exists( 'largo_opengraph' ) ) {
 		} elseif ( is_front_page() ) {
 			printf(
 				'<meta property="og:title" content="%1$s - %2$s" />',
-				esc_attr( bloginfo( 'name' ) ),
-				esc_attr( bloginfo( 'description' ) )
+				esc_attr( get_bloginfo( 'name' ) ),
+				esc_attr( get_bloginfo( 'description' ) )
 			);
 			?>
 				<meta property="og:type" content="website" />
 				<meta property="og:url" content="<?php echo esc_attr( home_url() ); ?>"/>
-				<meta property="og:description" content="<?php esc_attr( bloginfo( 'description' ) ); ?>" />
-				<meta name="description" content="<?php bloginfo( 'description' ); ?>" />
+				<meta property="og:description" content="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>" />
+				<meta name="description" content="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>" />
 			<?php
 		} else {
 			// not a single post, not the front page.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Replaces several uses of `bloginfo()` in Largo's open graph functions with `get_bloginfo()`, which doesn't echo immediately upon being run.

## Why

![Screen Shot 2019-07-17 at 17 04 59 ](https://user-images.githubusercontent.com/1754187/61412778-bcb57180-a8b7-11e9-95e7-1a50ba2c4763.png)

This was the old content:

```html
<meta name="twitter:card" content="summary">
<meta name="twitter:site" content="@benlkeith">
Largo TestA Largo Test Site
<meta property="og:title" content=" - " />
<meta property="og:type" content="website" />
<meta property="og:url" content="https://largo.test"/>
<meta property="og:description" content="A Largo Test Site" />
<meta name="description" content="A Largo Test Site" />
```

This is the new content:

```html
<meta name="twitter:card" content="summary">
<meta name="twitter:site" content="@benlkeith">
<meta property="og:title" content="Largo Test - A Largo Test Site" />
<meta property="og:type" content="website" />
<meta property="og:url" content="https://largo.test"/>
<meta property="og:description" content="A Largo Test Site" />
<meta name="description" content="A Largo Test Site" />
```

The diff:
```diff
3,4c3
< Largo TestA Largo Test Site
< <meta property="og:title" content=" - " />
---
> <meta property="og:title" content="Largo Test - A Largo Test Site" />
```


<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Resolves #1754

## Testing/Questions

Features that this PR affects:

- The opengraph

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Does it work on Current, @joshdarby?

Steps to test this PR:

1. Check out the new branch.
