### PR TITLE
Updated custom-less-variables regex so they don't fail

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ though this project doesn't succeed in adhering to [Semantic Versioning](https:/
 
 ## [Largo 0.7.0](https://github.com/INN/largo/compare/v0.6.4...v0.7.0)
 
+### Fixes and minor improvements
+
+- Fixed an issue where the CSS Variables theme option was not working due to improperly escaped regex's in `inc/custom-less-variables.php`. We fixed those expressions and also changed the `put_contents` and `get_contents` functions in the class to be static functions rather than protected. [Pull request #1772](https://github.com/INN/largo/pull/1772) for [issue #1771](https://github.com/INN/largo/issues/1771).
+
 ## [Largo 0.6.4](https://github.com/INN/largo/compare/v0.6.3...v0.6.4)
 
 ### Developer-facing improvements

--- a/inc/custom-less-variables.php
+++ b/inc/custom-less-variables.php
@@ -289,7 +289,7 @@ class Largo_Custom_Less_Variables {
 		$variables_less = self::get_contents( self::variable_file_path() );
 
 		// Parse out the variables. Each is defined per line in format: @<varName>: <varValue>;
-		preg_match_all( '#^\s*@(?P<name>[\w-_]+):\s*(?P<value>[^;]*);#m', $variables_less, $matches );
+		preg_match_all( '#^\s*@(?P<name>[\w\-_]+):\s*(?P<value>[^;]*);#m', $variables_less, $matches );
 
 		foreach ( $matches[0] as $index => $rule ) {
 			$name = $matches['name'][$index];
@@ -770,7 +770,7 @@ class Largo_Custom_Less_Variables {
 		$less = self::get_contents( self::variable_file_path() );
 
 		// Parse
-		$pattern = '#/\*\*\s+(?<comment>.*)\s+\*/\s*@(?P<name>[\w-_]+):\s*(?P<value>[^;]*);#Us';
+		$pattern = '#/\*\*\s+(?<comment>.*)\s+\*/\s*@(?P<name>[\w\-_]+):\s*(?P<value>[^;]*);#Us';
 		$comment_pattern = '#^\s*\*\s*@(?P<prop>\w+)\s+(?P<value>.*)$#mU';
 
 		preg_match_all( $pattern, $less, $matches );

--- a/inc/custom-less-variables.php
+++ b/inc/custom-less-variables.php
@@ -128,7 +128,7 @@ class Largo_Custom_Less_Variables {
 	* @param string $file - path of file to write
 	* @param string $contents - the content to be written to the file
 	*/
-	protected function put_contents($file, $contents) {
+	static function put_contents($file, $contents) {
 		global $wp_filesystem;
 
 		if (empty($wp_filesystem)) {
@@ -144,7 +144,7 @@ class Largo_Custom_Less_Variables {
 	*
 	* @param string $file - path of file to read
 	*/
-	protected function get_contents($file) {
+	static function get_contents($file) {
 		global $wp_filesystem;
 
 		if (empty($wp_filesystem)) {


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updated the regex's in our `inc/custom-less-variables.php` file to work with newer versions of PHP since they were failing due to not being escaped properly.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1771 

## Testing/Questions

Features that this PR affects:

- LESS customizer

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] @benlk I'm still getting warnings on save that we shouldn't be calling `Largo_Custom_Less_Variables::get_contents()` statically. Do you know why it's not a static function like everything else in the class? Should we change it to a static function, change how we're calling it, or ignore it for now since it still functions?

Steps to test this PR:

1. Attempt to load and use the CSS variables customizer in theme options