### PR TITLE
Use .editorconfig to prevent tab and space mixed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
 root = true
 
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-indent_style = tab
-indent_size = 4
 trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml}]
-indent_size = 2
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Use editorCongfig to prevent tab and space mixed
- The config is origin from https://github.com/laravel/laravel/blob/master/.editorconfig , I changed `space` to `tab`

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #

## Testing/Questions

Features that this PR affects:

- 

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. <!-- list any configuration changes, settings, test content, or other things necessary to test this change. -->

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [x ] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [ x] Contributor agrees to the license terms of this repository.
