### PR TITLE
feat: #1785 Remove maximum scale

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,7 +7,7 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <?php
 	/**
 	 * The template for displaying the header


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Remove `maximum-scale`


## Additional information

### tested 

- with max-scale: https://current.org
- without max-scale: https://boostrap.com/


### screenshots
- before .

<img width="1260" alt="Screen Shot 2019-10-08 at 10 05 39 PM" src="https://user-images.githubusercontent.com/3014017/66408120-8e5bb400-ea18-11e9-8531-cf58409852d2.png">

- after . 

<img width="1260" alt="Screen Shot 2019-10-08 at 10 10 26 PM" src="https://user-images.githubusercontent.com/3014017/66408119-8e5bb400-ea18-11e9-88b4-6f292d28534b.png">

