### PR TITLE
1526-replace-file-get-contents | replace file_get_contents with WP_Fi…

### DIFF
--- a/inc/avatars/admin.php
+++ b/inc/avatars/admin.php
@@ -58,10 +58,16 @@ add_action('show_user_profile',  'largo_add_avatar_field');
 
 function largo_save_avatar_field($user_id) {
 	if (has_files_to_upload(LARGO_AVATAR_INPUT_NAME)) {
-		if (isset( $_FILES[LARGO_AVATAR_INPUT_NAME])) {
+
+		// initialize WP_Filesystem
+		global $wp_filesystem;
+		require_once ( ABSPATH . '/wp-admin/includes/file.php' );
+		WP_Filesystem();
+
+		if ( isset( $_FILES[LARGO_AVATAR_INPUT_NAME] ) && $wp_filesystem->exists( $_FILES[LARGO_AVATAR_INPUT_NAME]['tmp_name'] ) ) {
 			$file = wp_upload_bits(
 				$_FILES[LARGO_AVATAR_INPUT_NAME]['name'], null,
-				@file_get_contents($_FILES[LARGO_AVATAR_INPUT_NAME]['tmp_name'])
+				$wp_filesystem->get_contents( $_FILES[LARGO_AVATAR_INPUT_NAME]['tmp_name'] )
 			);
 
 			if (FALSE === $file['error']) {


### PR DESCRIPTION
Replace file_get_contents with WP_Filesystem

## Changes

This pull request makes the following changes:

- replaced @file_get_contents with WP_Filesystem

## Why

Because you should never use @ and it is better to use native WP functions if they exist (over plain PHP).

For issue https://github.com/INN/largo/issues/1526

Steps to test this PR:

1. Go to you personal page in wp-admin and upload/change an avatar (not the gravatar one, but the avatar found at the bottom of the page)
