### PR TITLE
1804-date-time-changes-wp-5-3 | use time() in stead of WP timestamp

### DIFF
--- a/inc/post-tags.php
+++ b/inc/post-tags.php
@@ -49,11 +49,11 @@ if ( ! function_exists( 'largo_modified_time' ) ) {
  * @see https://github.com/INN/Largo/pull/1265
  */
 function largo_time_diff( $time ) {
-	$time_difference = current_time( 'timestamp' ) - $time;
+	$time_difference = time() - $time;
 
 	if ( $time_difference < 86400 ) {
 		$output = sprintf( __( '<span class="time-ago">%s ago</span>', 'largo' ),
-			human_time_diff( $time, current_time( 'timestamp' ) )
+			human_time_diff( $time, time() )
 		);
 	} else {
 		$output = date( 'F j, Y', $time );


### PR DESCRIPTION
Don't retrieve time as WP timestamp but as Unix timestamp.

## Changes

This pull request makes the following changes:

- replaced current_time( 'timestamp' ) with time()

## Why

Because WP is phasing out WP timestamps (https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/)

For issue https://github.com/INN/largo/issues/1804

Steps to test this PR:

1. Make a post in WP admin
2. View the post
3. Look at the date under de title. Should be something like: XX seconds/minutes ago
