### PR TITLE
1784-only-show-thumb-if-exists | only show thumb if set + apply WP co…

### DIFF
--- a/partials/widget-content.php
+++ b/partials/widget-content.php
@@ -5,28 +5,30 @@ if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && l
 	largo_maybe_top_term();
 }
 
+if ( ! empty( $thumb ) ) {
+	// default img size
+	$img_size = '60x60';
+	// the thumbnail image (if we're using one)
+	if ( $thumb == 'small' ) {
+		$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
+		$img_attr = array( 'class' => $img_location . '-align' );
+		$img_attr['class'] .= " attachment-small";
+	} elseif ( $thumb == 'medium' ) {
+		$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
+		$img_attr = array('class' => $img_location . '-align');
+		$img_attr['class'] .= " attachment-thumbnail";
+		$img_size = 'post-thumbnail';
+	} elseif ( $thumb == 'large' ) {
+		$img_attr = array();
+		$img_attr['class'] = " attachment-large";
+		$img_size = 'large';
+	}
 
-// the thumbnail image (if we're using one)
-if ($thumb == 'small') {
-	$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
-	$img_attr = array( 'class' => $img_location . '-align' );
-	$img_attr['class'] .= " attachment-small";
-	?>
-		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), '60x60', $img_attr); ?></a>
-	<?php
-} elseif ($thumb == 'medium') {
-	$img_location = ! empty( $instance['image_align'] ) ? $instance['image_align'] : 'left';
-	$img_attr = array('class' => $img_location . '-align');
-	$img_attr['class'] .= " attachment-thumbnail";
-	?>
-		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'post-thumbnail', $img_attr); ?></a>
-	<?php
-} elseif ($thumb == 'large') {
-	$img_attr = array();
-	$img_attr['class'] = " attachment-large";
-	?>
-		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'large', $img_attr); ?></a>
-	<?php
+	if ( get_the_post_thumbnail( get_the_ID(), $img_size ) ) {
+		?>
+		<a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), $img_size, $img_attr ); ?></a>
+		<?php
+	}
 }
 
 // the headline and optionally the post-type icon


### PR DESCRIPTION
Check if featured image is set before outputting it.

## Changes

This pull request makes the following changes:

- add a check if thumbnail exists
- applied WP coding style to some existing code
- general check of $thumb exists (in case the widget-content.php partial is called from a file that has no $thumb set)
- removed duplicated code (so DRY) -> set a new var $img_size and use that to output the link tag + image

## Why

So no empty link tag is output.

For issue https://github.com/INN/largo/issues/1784

Steps to test this PR:

1. make a post without featured image
2. Go to wp-admin and add the Largo Recent Posts widget in a widget area
3. Go to the site where you can view the selected widget area
4. Look in the html source and see that no empty link tag is there
