### PR TITLE
1739 widget titles

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -210,7 +210,7 @@ add_filter( 'widget_update_callback', 'largo_widget_update_extend', 10, 2 );
  */
 function largo_add_link_to_widget_title( $title, $instance = null ) {
   if (!empty($title) && !empty($instance['title_link'])) {
-    $title = '<a href="' . esc_url( $instance['title_link'] ) . '">' . $title . '</a>';
+    $title = '<a href="' . esc_url( $instance['title_link'] ) . '">' . esc_attr( $title ) . '</a>';
   }
   return $title;
 }

--- a/inc/widgets/largo-facebook.php
+++ b/inc/widgets/largo-facebook.php
@@ -20,18 +20,21 @@ class largo_facebook_widget extends WP_Widget {
 	}
 
 	function widget( $args, $instance ) {
+
+		$instance['title'] = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'] );
 		echo $args['before_widget'];
 
-			$page_url = esc_url( $instance['fb_page_url'] );
-			$height = isset( $instance['widget_height'] ) ? $instance['widget_height'] : 350;
-			
-			$output = '<div class="fb-page" data-adapt-container-width="true" data-href="' . $page_url . '"';
-			$output .= ' data-height="' . (int) $height . '"';
-			$output .= ! empty( $instance['show_faces'] ) ? ' data-show-facepile="true"' : ' data-show-facepile="false"';
-			if ( !empty( $instance['show_stream'] ) ) {
-				$output .= ' data-tabs="timeline"';
-			}
-			$output .= '><div class="fb-xfbml-parse-ignore"><blockquote cite="' . $page_url . '"><a href="' . $page_url . '">' . get_bloginfo( 'name' ) .'</a></blockquote></div></div>';
+		if ( !empty( $instance['title'] ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
+		$page_url = esc_url( $instance['fb_page_url'] );
+		$height = isset( $instance['widget_height'] ) ? $instance['widget_height'] : 350;
+
+		$output = '<div class="fb-page" data-adapt-container-width="true" data-href="' . $page_url . '"';
+		$output .= ' data-height="' . (int) $height . '"';
+		$output .= ! empty( $instance['show_faces'] ) ? ' data-show-facepile="true"' : ' data-show-facepile="false"';
+		if ( !empty( $instance['show_stream'] ) ) {
+			$output .= ' data-tabs="timeline"';
+		}
+		$output .= '><div class="fb-xfbml-parse-ignore"><blockquote cite="' . $page_url . '"><a href="' . $page_url . '">' . get_bloginfo( 'name' ) .'</a></blockquote></div></div>';
 
 		echo $output;
 
@@ -42,6 +45,7 @@ class largo_facebook_widget extends WP_Widget {
 
 	function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		$instance['fb_page_url'] = esc_url_raw( $new_instance['fb_page_url'] );
 		$instance['widget_height'] = (int) $new_instance['widget_height'];
 		$instance['show_faces'] = ! empty( $new_instance['show_faces'] ) ? 1 : 0;
@@ -75,6 +79,10 @@ class largo_facebook_widget extends WP_Widget {
 			<input class="checkbox" type="checkbox" <?php echo $show_faces; ?> id="<?php echo $this->get_field_id( 'show_faces' ); ?>" name="<?php echo $this->get_field_name( 'show_faces' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_faces' ); ?>"><?php _e( 'Show Faces?', 'largo'); ?></label>
 			<br />
 			<input class="checkbox" type="checkbox" <?php echo $show_stream; ?> id="<?php echo $this->get_field_id( 'show_stream' ); ?>" name="<?php echo $this->get_field_name( 'show_stream' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_stream' ); ?>"><?php _e( 'Show Stream?', 'largo' ); ?></label>
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title', 'largo'); ?>:</label>
+			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['title'])); ?>" />
 		</p>
 
 	<?php

--- a/inc/widgets/largo-facebook.php
+++ b/inc/widgets/largo-facebook.php
@@ -21,9 +21,9 @@ class largo_facebook_widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 
-		$instance['title'] = apply_filters( 'widget_title', ( empty( $instance['title'] ) ? '' : $instance['title'] ), $instance ) ;
 		echo $args['before_widget'];
 
+		$instance['title'] = apply_filters( 'widget_title', ( empty( $instance['title'] ) ? '' : $instance['title'] ), $instance ) ;
 		if ( !empty( $instance['title'] ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
 		$page_url = esc_url( $instance['fb_page_url'] );
 		$height = isset( $instance['widget_height'] ) ? $instance['widget_height'] : 350;
@@ -64,6 +64,10 @@ class largo_facebook_widget extends WP_Widget {
 		$show_faces = ! empty( $instance['show_faces'] ) ? 'checked="checked"' : '';
 		$show_stream = ! empty( $instance['show_stream'] ) ? 'checked="checked"' : '';
 		?>
+		<p>
+			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title', 'largo'); ?>:</label>
+			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['title'])); ?>" />
+		</p>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'fb_page_url' ); ?>"><?php _e( 'Facebook Page URL:', 'largo' ); ?></label>
@@ -79,10 +83,6 @@ class largo_facebook_widget extends WP_Widget {
 			<input class="checkbox" type="checkbox" <?php echo $show_faces; ?> id="<?php echo $this->get_field_id( 'show_faces' ); ?>" name="<?php echo $this->get_field_name( 'show_faces' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_faces' ); ?>"><?php _e( 'Show Faces?', 'largo'); ?></label>
 			<br />
 			<input class="checkbox" type="checkbox" <?php echo $show_stream; ?> id="<?php echo $this->get_field_id( 'show_stream' ); ?>" name="<?php echo $this->get_field_name( 'show_stream' ); ?>" /> <label for="<?php echo $this->get_field_id( 'show_stream' ); ?>"><?php _e( 'Show Stream?', 'largo' ); ?></label>
-		</p>
-		<p>
-			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title', 'largo'); ?>:</label>
-			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['title'])); ?>" />
 		</p>
 
 	<?php

--- a/inc/widgets/largo-facebook.php
+++ b/inc/widgets/largo-facebook.php
@@ -21,7 +21,7 @@ class largo_facebook_widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 
-		$instance['title'] = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'] );
+		$instance['title'] = apply_filters( 'widget_title', ( empty( $instance['title'] ) ? '' : $instance['title'] ), $instance ) ;
 		echo $args['before_widget'];
 
 		if ( !empty( $instance['title'] ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }

--- a/inc/widgets/largo-twitter.php
+++ b/inc/widgets/largo-twitter.php
@@ -22,7 +22,9 @@ class largo_twitter_widget extends WP_Widget {
 	function widget( $args, $instance ) {
 
 		echo $args['before_widget'];
-		
+		$instance['title'] = apply_filters( 'widget_title', ( empty( $instance['title'] ) ? '' : $instance['title'] ), $instance ) ;
+		if ( !empty( $instance['title'] ) ) { echo $args['before_title'] . $instance['title'] . $args['after_title']; }
+
 		// Build the placeholder URLs used by various widget types
 		// Note that these are not strictly necessary (widget will render as long as the data-widget-id attribute is correct
 		// The URL and text are just used as a fallback if the JS doesn't load
@@ -49,7 +51,7 @@ class largo_twitter_widget extends WP_Widget {
 				/* translators: Tweets by @username */
 				$widget_text = __( 'Tweets by @' . $instance['twitter_username'], 'largo' );
 		}
-			
+
 		$widget_embed = sprintf( '<a class="twitter-timeline" href="%1$s">%2$s</a>',
 			esc_url( $widget_href ),
 			esc_attr( $widget_text )
@@ -74,6 +76,7 @@ class largo_twitter_widget extends WP_Widget {
 
 	function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		$instance['twitter_username'] = sanitize_text_field( $new_instance['twitter_username'] );
 		$instance['twitter_list_slug'] = sanitize_text_field( $new_instance['twitter_list_slug'] );
 		$instance['widget_ID'] = sanitize_text_field( $new_instance['widget_ID'] );
@@ -93,6 +96,10 @@ class largo_twitter_widget extends WP_Widget {
 		$instance = wp_parse_args( (array) $instance, $defaults );
 
 		?>
+		<p>
+			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title', 'largo'); ?>:</label>
+			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr(strip_tags($instance['title'])); ?>" />
+		</p>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'widget_type' ); ?>"><?php _e('Widget Type', 'largo'); ?></label>
@@ -128,13 +135,12 @@ class largo_twitter_widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'twitter_collection_title' ); ?>"><?php _e( 'Collection Title (for collection widget):', 'largo' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'twitter_collection_title' ); ?>" name="<?php echo $this->get_field_name( 'twitter_collection_title' ); ?>" value="<?php echo esc_attr( $instance['twitter_collection_title'] ); ?>" style="width:90%;" />
 		</p>
-
 	<?php
 	}
 
 	/**
 	 * Returns true if this widget has been rendered one or more times.
-	 * 
+	 *
 	 * @since 0.5
 	 */
 	static function is_rendered() {


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

The title field is added to the widget in admin for both the Facebook and Twitter widgets and when not empty the title is displayed. If a corresponding title link is entered into the widget this is used as the title link.

I did add escaping to the title text in the `largo_add_link_to_widget_title` function but understand that affects all the widgets. So, happy to help test or remove as appropriate. I tested the Taxonomy and Tax list widgets with no adverse affects.

Apologies for the occasional whitespace change.

## Why

This PR applies consistent behavior for this widget
For #1739 and #1740 

## Testing/Questions

Features that this PR affects:

- Largo Facebook widget
- Largo Twitter widget
- Widgets that use `largo_add_link_to_widget_title` callback on `widget_title`

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Add widget to sidebar location
2. Fill in title field  in widget options and save
3. Title text is in the markup if entered into title field
4. Title text and title link url in the markup if both are filled in the widget options

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [x] Contributor agrees to the license terms of this repository.
