### PR TITLE
Remove filesystem paths from the filepaths that we run `validate_file()` on

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 
 - Fixed an issue where the CSS Variables theme option was not working due to improperly escaped regex's in `inc/custom-less-variables.php`. We fixed those expressions and also changed the `put_contents` and `get_contents` functions in the class to be static functions rather than protected. [Pull request #1772](https://github.com/INN/largo/pull/1772) for [issue #1771](https://github.com/INN/largo/issues/1771).
 - Removed conflicting duplicate HTML IDs by changing the element ID `header-social` to the class `header-social`, and updating CSS styles to reflect the new selector. [Pull request #1826](https://github.com/INN/largo/pull/1826) for [issue #1781](https://github.com/INN/largo/issues/1781), by [@seanchayes](https://github.com/seanchayes).
+- Correct the use of [`validate_file()`](https://developer.wordpress.org/reference/functions/validate_file/), to allow Largo to be used on Windows servers. [Pull request #1850](https://github.com/INN/largo/pull/1850) for [issue #1849](https://github.com/INN/largo/issues/1849).
 
 ### Potentially-breaking changes
 

--- a/functions.php
+++ b/functions.php
@@ -104,7 +104,7 @@ if ( ! isset( $largo ) )
  */
 if ( ! function_exists( 'optionsframework_init' ) ) {
 	define( 'OPTIONS_FRAMEWORK_DIRECTORY', get_template_directory_uri() . '/lib/options-framework/' );
-	if ( 0 == validate_file( get_template_directory() . '/lib/options-framework/options-framework.php' ) ) {
+	if ( 0 == validate_file( '/lib/options-framework/options-framework.php' ) ) {
 		require_once get_template_directory() . '/lib/options-framework/options-framework.php';
 	}
 }
@@ -203,7 +203,7 @@ class Largo {
 		}
 
 		foreach ( $includes as $include ) {
-			if ( 0 === validate_file( get_template_directory() . $include ) ) {
+			if ( 0 === validate_file( $include ) ) {
 				require_once( get_template_directory() . $include );
 			}
 		}
@@ -402,7 +402,7 @@ if ( of_get_option( 'custom_landing_enabled' ) && of_get_option( 'series_enabled
  * Perform load
  */
 foreach ( $includes as $include ) {
-	if ( 0 === validate_file( get_template_directory() . $include ) ) {
+	if ( 0 === validate_file( $include ) ) {
 		require_once( get_template_directory() . $include );
 	}
 }

--- a/homepages/homepage-class.php
+++ b/homepages/homepage-class.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( empty( $wp_filesystem ) ) {
-	if ( 0 === validate_file( ABSPATH . 'wp-admin/includes/file.php' ) ) {
+	if ( 0 === validate_file( 'wp-admin/includes/file.php' ) ) {
 		require_once( ABSPATH . 'wp-admin/includes/file.php' );
 		WP_Filesystem();
 	} else {

--- a/inc/avatars/admin.php
+++ b/inc/avatars/admin.php
@@ -76,7 +76,7 @@ function largo_save_avatar_field($user_id) {
 				$id = wp_insert_attachment($args, $file['file']);
 
 				if ( ! is_wp_error( $id ) ) {
-					if ( 0 === validate_file( ABSPATH . 'wp-admin/includes/image.php' ) ) {
+					if ( 0 === validate_file( 'wp-admin/includes/image.php' ) ) {
 						require_once( ABSPATH . 'wp-admin/includes/image.php' );
 					} else {
 						wp_die(


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes `get_template_directory()` and `ABSPATH` from the strings that we pass to `validate_file()`

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For  #https://github.com/INN/largo/issues/1849

## Testing/Questions

Features that this PR affects:

- File loading, only on non-Unix systems.

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] does it work on Windows?

Steps to test this PR:

1. On a Windows server, like with XAMPP, see if Largo loads.

## Additional information

INN Member/Labs Client requesting: see email to largo@inn.org