### PR TITLE
Document existence of other image sizes, thumbnail size change

### DIFF
--- a/docs/developers/imagesizes.rst
+++ b/docs/developers/imagesizes.rst
@@ -35,6 +35,8 @@ The following image sizes are registered in Largo, using the constants defined b
       - Image size defined by: ``(FULL_WIDTH*2/3)xFULL_HEIGHT``
       - Default is 780px wide by a flexible height.
 
+Largo also sets the `post-thumbnail` and `thumbnail` image sizes to be 140x140, instead of the WordPress default.
+
 Constants
 ---------
 

--- a/docs/developers/imagesizes.rst
+++ b/docs/developers/imagesizes.rst
@@ -10,6 +10,9 @@ The following image sizes are registered in Largo, using the constants defined b
 
   - ``60x60``
       - 60x60px image crop.
+  - ``96x96``
+      - 96x96px image crop
+      - Used for avatars and small square listing images.
   - ``rect_thumb``
       - 800x600px image crop
       - Used for cat/tax archive pages.

--- a/docs/developers/imagesizes.rst
+++ b/docs/developers/imagesizes.rst
@@ -13,6 +13,9 @@ The following image sizes are registered in Largo, using the constants defined b
   - ``rect_thumb``
       - 800x600px image crop
       - Used for cat/tax archive pages.
+  - ``rect_thumb_half``
+      - 400x300px image crop
+      - Used for areas where fixed aspect ratio of `rect_thumb` is desired but too big.
   - ``medium``
       - Image size defined by constants: ``MEDIUM_WIDTHxMEDIUM_HEIGHT``
       - Default is 336px wide by a flexible height.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates developer documentation about image sizes to reflect the existence of `rect_thumb_half` and `96x96`
- Updates the same documentation about how Largo defines new dimensions for the `post-thumbnail` and `thumbnail` sizes.

## Why

* #1584 introduced a new image size `rect_thumb_half`, but the documentation doesn't mention it yet.
* #1672 introduced a new image size `96x96`, but the documentation doesn't mention it yet.
* For developers seeking to understand how using Largo will affect existing image sizes in use, noting the change in default thumbnail dimensions could be helpful.

## Testing/Questions

Features that this PR affects: none

Steps to test this PR: none

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [x] Contributor agrees to the license terms of this repository.
