### PR TITLE
URL change for Dashboard links

### DIFF
--- a/inc/dashboard.php
+++ b/inc/dashboard.php
@@ -70,13 +70,13 @@ function largo_dashboard_quick_links() {
 		<div class="list-widget">
 			<p>If you\'re having trouble with your site, want to request a new feature or are just interested in learning more about Project Largo, here are a few helpful links:</p>
 			<ul>
-				<li><a href="https://largo.inn.org/">Largo Project Website</a></li>
-				<li><a href="https://largo.readthedocs.io/">Largo Documentation</a></li>
-				<li><a href="mailto:support@inn.org">Contact Us</a></li>
-				<li><a href="https://support.inn.org/">Help Desk</a></li>
-				<li><a href="https://support.inn.org/">Knowledge Base</a></li>
+				<li><a href="https://largo.wpbuddy.co/" target="_blank" rel="external noopener noreferrer">Largo Project Website</a></li>
+				<li><a href="https://largo.readthedocs.io/" target="_blank" rel="external noopener noreferrer">Largo Documentation</a></li>
+				<li><a href="mailto:largo@wpbuddy.co">Contact Us</a></li>
+				<li><a href="https://largo.wpbuddy.co/support" target="_blank" rel="external noopener noreferrer">Help Desk</a></li>
+				<li><a href="https://largo.wpbuddy.co/support" target="_blank" rel="external noopener noreferrer">Knowledge Base</a></li>
 			</ul>
-			<p>Developers can also log issues on <a href="https://github.com/INN/Largo">our public github repository</a> and if you would like to be included in our Largo users\' group, <a href="http://inn.us1.list-manage1.com/subscribe?u=81670c9d1b5fbeba1c29f2865&id=913028b23c">sign up here</a>.</p>
+			<p>Developers can also log issues on <a href="https://github.com/WPBuddy/largo/issues">our public github repository</a></p>
 		</div>
 	';
 }
@@ -117,7 +117,7 @@ function largo_dash_admin_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_node( $args );
 
 	// Main Website
-	$args = array( 'id' => 'website', 'title' => 'Main Website', 'href' => 'https://largo.inn.org//', 'parent' => 'largo_admin_mega' );
+	$args = array( 'id' => 'website', 'title' => 'Main Website', 'href' => 'https://largo.wpbuddy.co/', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 	// Documentation
@@ -125,42 +125,42 @@ function largo_dash_admin_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_node( $args );
 
 	// Knowledge Base
-	$args = array( 'id' => 'knowledge_base', 'title' => 'Knowledge Base', 'href' => 'https://support.inn.org/', 'parent' => 'largo_admin_mega' );
+	$args = array( 'id' => 'knowledge_base', 'title' => 'Knowledge Base', 'href' => 'https://largo.wpbuddy.co/support', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 	// Member Help Desk
-	$args = array( 'id' => 'support', 'title' => 'Help Desk', 'href' => 'https://support.inn.org/', 'parent' => 'largo_admin_mega' );
+	$args = array( 'id' => 'support', 'title' => 'Help Desk', 'href' => 'https://largo.wpbuddy.co/support', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 	// Member Forums
-	$args = array( 'id' => 'user_forums', 'title' => 'Community Forums', 'href' => 'https://support.inn.org/', 'parent' => 'largo_admin_mega' );
+	$args = array( 'id' => 'user_forums', 'title' => 'Community Forums', 'href' => 'https://largo.wpbuddy.co/support', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 	// Largo on GitHub
-	$args = array( 'id' => 'github', 'title' => 'Largo on GitHub', 'href' => 'https://github.com/inn/largo', 'parent' => 'largo_admin_mega' );
+	$args = array( 'id' => 'github', 'title' => 'Largo on GitHub', 'href' => 'https://github.com/WPBuddy/largo', 'parent' => 'largo_admin_mega' );
 	$wp_admin_bar->add_node( $args );
 
 	// Largo on Twitter
 	$args = array( 'id' => 'twitter', 'title' => '@LargoProject on Twitter', 'href' => 'https://twitter.com/largoproject', 'parent' => 'largo_admin_mega');
 	$wp_admin_bar->add_node( $args );
 
-	// INN Nerds
-	$args = array( 'id' => 'inn_nerds', 'title' => 'INN Nerds', 'href' => 'https://labs.inn.org/', 'parent' => 'largo_admin_mega' );
-	$wp_admin_bar->add_node( $args );
-
-	// About INN
-	$args = array( 'id' => 'about_inn', 'title' => 'About INN', 'href' => 'https://inn.org', 'parent' => 'largo_admin_mega' );
-	$wp_admin_bar->add_node( $args );
-
-	// Donate
-	$args = array( 'id' => 'donate_inn', 'title' => 'Donate', 'href' => 'https://inn.org/donate/', 'parent' => 'largo_admin_mega' );
-	$wp_admin_bar->add_node( $args );
+// 	// INN Nerds
+// 	$args = array( 'id' => 'inn_nerds', 'title' => 'INN Nerds', 'href' => 'https://labs.inn.org/', 'parent' => 'largo_admin_mega' );
+// 	$wp_admin_bar->add_node( $args );
+//
+// 	// About INN
+// 	$args = array( 'id' => 'about_inn', 'title' => 'About INN', 'href' => 'https://inn.org', 'parent' => 'largo_admin_mega' );
+// 	$wp_admin_bar->add_node( $args );
+//
+// 	// Donate
+// 	$args = array( 'id' => 'donate_inn', 'title' => 'Donate', 'href' => 'https://inn.org/donate/', 'parent' => 'largo_admin_mega' );
+// 	$wp_admin_bar->add_node( $args );
 
 }
 
 // add a credit line to the admin footer
 function largo_admin_footer_text( $default_text ) {
-	return '<span id="footer-thankyou">This website powered by <a href="https://largo.inn.org/">Project Largo</a> from <a href="https://inn.org/">INN</a> and <a href="https://wordpress.org">WordPress</a>.</span>';
+	return '<span id="footer-thankyou">This website powered by <a href="https://largo.wpbuddy.co/">Project Largo</a> from <a href="https://wpbuddy.co/">WpBuddy.co</a> and <a href="https://wordpress.org">WordPress</a>.</span>';
 }
 add_filter( 'admin_footer_text', 'largo_admin_footer_text' );
 


### PR DESCRIPTION
Change links and other URL related items in theme dashboard and top navigation bar. Update to reflect new urls for various contact or guides for Largo theme
resolves issue #1644 