### PR TITLE
#1776 - Fix largo_top_term title attribute output so that correct taxonomy label is used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Updates `widget-content.php` partial to only display thubmnail if `$thumb` is not empty. [Pull request #1897](https://github.com/WPBuddy/largo/pull/1897) for [issue #1784](https://github.com/WPBuddy/largo/issues/1784) by [@omnisite](https://github.com/omnisite).
 - Updates the `largo_save_avatar_field` function to use `WP_Filesystem` instead of `@file_get_contents`. [Pull request #1898](https://github.com/WPBuddy/largo/pull/1898) for [issue #1526](https://github.com/WPBuddy/largo/issues/1526) by [@omnisite](https://github.com/omnisite).
 - Refactors `largo_top_term` function to break out the getting / fetching of the term from the actual output for easier customization. [Pull request #1824](https://github.com/WPBuddy/largo/pull/1824) for [issue #1775](https://github.com/WPBuddy/largo/issues/1775), by [@seanchayes](https://github.com/seanchayes).
+- Replaces "category" string in `largo_top_term` title attribute with the singular name of the top term's taxonomy. [Pull request #1820](https://github.com/WPBuddy/largo/pull/1820) for [issue #1776](https://github.com/WPBuddy/largo/issues/1776), by [@seanchayes](https://github.com/seanchayes).
 
 ### Potentially-breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Updates `widget-content.php` partial to only display thubmnail if `$thumb` is not empty. [Pull request #1897](https://github.com/WPBuddy/largo/pull/1897) for [issue #1784](https://github.com/WPBuddy/largo/issues/1784) by [@omnisite](https://github.com/omnisite).
 - Updates the `largo_save_avatar_field` function to use `WP_Filesystem` instead of `@file_get_contents`. [Pull request #1898](https://github.com/WPBuddy/largo/pull/1898) for [issue #1526](https://github.com/WPBuddy/largo/issues/1526) by [@omnisite](https://github.com/omnisite).
 - Refactors `largo_top_term` function to break out the getting / fetching of the term from the actual output for easier customization. [Pull request #1824](https://github.com/WPBuddy/largo/pull/1824) for [issue #1775](https://github.com/WPBuddy/largo/issues/1775), by [@seanchayes](https://github.com/seanchayes).
-- Replaces "category" string in `largo_top_term` title attribute with the singular name of the top term's taxonomy. [Pull request #1820](https://github.com/WPBuddy/largo/pull/1820) for [issue #1776](https://github.com/WPBuddy/largo/issues/1776), by [@charmoney](https://github.com/charmoney).
+- Replaces "category" string in `largo_top_term` title attribute with the singular name of the top term's taxonomy. [Pull request #1903](https://github.com/WPBuddy/largo/pull/1903) for [issue #1776](https://github.com/WPBuddy/largo/issues/1776), by [@charmoney](https://github.com/charmoney).
 
 ### Potentially-breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Updates `widget-content.php` partial to only display thubmnail if `$thumb` is not empty. [Pull request #1897](https://github.com/WPBuddy/largo/pull/1897) for [issue #1784](https://github.com/WPBuddy/largo/issues/1784) by [@omnisite](https://github.com/omnisite).
 - Updates the `largo_save_avatar_field` function to use `WP_Filesystem` instead of `@file_get_contents`. [Pull request #1898](https://github.com/WPBuddy/largo/pull/1898) for [issue #1526](https://github.com/WPBuddy/largo/issues/1526) by [@omnisite](https://github.com/omnisite).
 - Refactors `largo_top_term` function to break out the getting / fetching of the term from the actual output for easier customization. [Pull request #1824](https://github.com/WPBuddy/largo/pull/1824) for [issue #1775](https://github.com/WPBuddy/largo/issues/1775), by [@seanchayes](https://github.com/seanchayes).
-- Replaces "category" string in `largo_top_term` title attribute with the singular name of the top term's taxonomy. [Pull request #1820](https://github.com/WPBuddy/largo/pull/1820) for [issue #1776](https://github.com/WPBuddy/largo/issues/1776), by [@seanchayes](https://github.com/seanchayes).
+- Replaces "category" string in `largo_top_term` title attribute with the singular name of the top term's taxonomy. [Pull request #1820](https://github.com/WPBuddy/largo/pull/1820) for [issue #1776](https://github.com/WPBuddy/largo/issues/1776), by [@charmoney](https://github.com/charmoney).
 
 ### Potentially-breaking changes
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -343,13 +343,17 @@ function largo_top_term( $options = array() ) {
 
 	$term_object = largo_get_top_term( $args );
 
+	// get the taxonomy object & labels
+	$taxonomy = get_taxonomy( $term_object->taxonomy );
+	$taxonomy_labels = get_taxonomy_labels( $taxonomy );
+
 	/*
 	 * If we get a term object use it to generate some text
 	 */
 	if ( is_a( $term_object, 'WP_Term' ) ) {
 		$icon = ( $args['use_icon'] ) ?  '<i class="icon-white icon-tag"></i>' : '' ;	//this will probably change to a callback largo_term_icon() someday
 
-		$link = ( $args['link'] ) ? array( '<a href="%2$s" title="Read %3$s in the %4$s category">','</a>' ) : array( '', '' ) ;
+		$link = ( $args['link'] ) ? array( '<a href="%2$s" title="Read %3$s in the %4$s %7$s">','</a>' ) : array( '', '' ) ;
 
 		$output = sprintf(
 			'<%1$s class="post-category-link _top_term_output %6$s">'.$link[0].'%5$s%4$s'.$link[1].'</%1$s>',
@@ -362,7 +366,8 @@ function largo_top_term( $options = array() ) {
 				'%1$s-%2$s',
 				$term_object->taxonomy,
 				$term_object->slug
-			)
+			),
+			$taxonomy_labels->singular_name ? strtolower( $taxonomy_labels->singular_name ) : 'category'
 		);
 	}
 


### PR DESCRIPTION
Originally done by @charmoney in #1820.
-------------------------------------------------------
Fixes #1776

## Changes

This pull request makes the following changes:

- Replace "category" string in largo_top_term title attribute with the singular name of the top term's taxonomy.

## Why

For #1776 

## Testing/Questions

Features that this PR affects:

- Top term link

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Didn't see anything in contributing.md specifying the branch. Hopefully.

Steps to test this PR:

1. Navigate to and/or create a Post with an assigned Top Term in on taxonomy
2. Hover over the top term link in the frontend. Verify the link title uses the taxonomy singular label.
3. Edit the Post to set a Top Term in a different taxonomy
4. Hover over the top term link in the frontend. Verify the link uses the new, correct taxonomy singular label.

## Additional information

INN Member/Labs Client requesting: (if applicable)

- [X ] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [ X] Contributor would like to be mentioned in the release notes as: Chris Harmoney (Cornershop Creative)
- [X ] Contributor agrees to the license terms of this repository.
