### PR TITLE
#1904 landing page post order select field throwing error when adding new lp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Widget titles may now be set on the Largo Twitter and Largo Facebook widgets. Pull requests [#1822](https://github.com/INN/largo/pull/1822) by [@seanchayes](https://github.com/seanchayes) and [#1840](https://github.com/INN/largo/pull/1840) for issues [#1739](https://github.com/INN/largo/issues/1739) and [#1740](https://github.com/INN/largo/issues/1740).
 - Adds in `aria-page="current"` attribute to widget content anchors if the queried object ID matches the current post ID. [Pull request #1819](https://github.com/WPBuddy/largo/pull/1819) for [issue #1805](https://github.com/WPBuddy/largo/issues/1805) by [@seanchayes](https://github.com/seanchayes).
 - Removes meta tag `maximum-scale=1.0` to disable scaling. [Pull request #1811](https://github.com/WPBuddy/largo/pull/1811) for [issue #1785](https://github.com/WPBuddy/largo/issues/1785) by [@vanduc1102](https://github.com/vanduc1102)
-
+- Check that Landing Page $terms variable is not false and an array then check its length [Pull Request #1905](https://github.com/WPBuddy/largo/pull/1905) Fixes Issue [#1904](https://github.com/WPBuddy/largo/issues/1904)
 ### Potentially-breaking changes
 
 - Replace `#header-social` in CSS files with `.header-social` to mach updated markup. [Pull request #1826](https://github.com/WPBuddy/largo/pull/1826) for [issue #1781](https://github.com/WPBuddy/largo/issues/1781).

--- a/inc/wp-taxonomy-landing/functions/cftl-admin.php
+++ b/inc/wp-taxonomy-landing/functions/cftl-admin.php
@@ -446,14 +446,13 @@ function cftl_tax_landing_main($post) {
 	<div>
 		<?php
 			//allow 'custom' if we have a single term
-			$terms = get_the_terms( $post->ID, 'series');
 			/*
             * issue #1904
             * when trying to check the count of false we get an error
             * check its not false and is and array before trying to count it
             */
             $terms = get_the_terms( $post->ID, 'series');
-            if ($terms && is_array($terms) && count($terms) == 1) {
+            if ($terms && is_array($terms) && count($terms) >= 1) {
                 $series_id = $terms[0]->term_taxonomy_id;
             } else {
                 $series_id = 0;

--- a/inc/wp-taxonomy-landing/functions/cftl-admin.php
+++ b/inc/wp-taxonomy-landing/functions/cftl-admin.php
@@ -451,7 +451,7 @@ function cftl_tax_landing_main($post) {
             * when trying to check the count of false we get an error
             * check its not false and is and array before trying to count it
             */
-            $terms = get_the_terms( $post->ID, 'series');
+            $terms = get_the_terms( $post->ID, 'series' );
             if ($terms && is_array($terms) && count($terms) >= 1) {
                 $series_id = $terms[0]->term_taxonomy_id;
             } else {

--- a/inc/wp-taxonomy-landing/functions/cftl-admin.php
+++ b/inc/wp-taxonomy-landing/functions/cftl-admin.php
@@ -447,7 +447,17 @@ function cftl_tax_landing_main($post) {
 		<?php
 			//allow 'custom' if we have a single term
 			$terms = get_the_terms( $post->ID, 'series');
-			if (count($terms) == 1) $series_id = $terms[0]->term_taxonomy_id;
+			/*
+            * issue #1904
+            * when trying to check the count of false we get an error
+            * check its not false and is and array before trying to count it
+            */
+            $terms = get_the_terms( $post->ID, 'series');
+            if ($terms && is_array($terms) && count($terms) == 1) {
+                $series_id = $terms[0]->term_taxonomy_id;
+            } else {
+                $series_id = 0;
+            }
 		?>
 		<select name="post_order">
 			<?php


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

landing page post order select field throwing error when adding new lp the variable is sometimes false; need to make sure we check for that first

## Why
The select field for post order does not show up
For #1904 

## Testing/Questions
Pull fresh largo branch trunk down and have zero data on the site. Try to create a Landing Page
Features that this PR affects:

- Creating LP's

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [] Has the `changelog.md` file been updated to reflect the updates in this PR?
- [ ] 

Steps to test this PR:

1. <!-- list any configuration changes, settings, test content, or other things necessary to test this change. -->

## Additional information

WP Buddy Client requesting: (if applicable)

- [ ] Contributor has read WP Buddy's [GitHub code of conduct](https://github.com/WPBuddy/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] Contributor would like to be mentioned in the release notes as: (fill in this blank)
- [ ] Contributor agrees to the license terms of this repository.
