### PR TITLE
1864 - Functionality to filter core get_avatar() function and return custom Largo avatar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,7 +40,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Update all npm packages to latest version; updated package.json command scripts to allow developers to quickly run grunt tasks [Pull request](https://github.com/WPBuddy/largo/pull/1899) fixes issue [#1540](https://github.com/WPBuddy/largo/issues/1540)
 - Fixes `Largo_Related::popularity_sort` sorting in the wrong order. [Pull request #1877](https://github.com/WPBuddy/largo/pull/1877) for [issue #1868](https://github.com/WPBuddy/largo/issues/1868) by [@pedroxido](https://github.com/pedroxido).
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
-- Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1864](https://github.com/WPBuddy/largo/pull/1864) for [issue #1906](https://github.com/WPBuddy/largo/issues/1906).
+- Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1906](https://github.com/WPBuddy/largo/pull/1906) for [issue #1864](https://github.com/WPBuddy/largo/issues/1864).
 
 ### Potentially-breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Update all npm packages to latest version; updated package.json command scripts to allow developers to quickly run grunt tasks [Pull request](https://github.com/WPBuddy/largo/pull/1899) fixes issue [#1540](https://github.com/WPBuddy/largo/issues/1540)
 - Fixes `Largo_Related::popularity_sort` sorting in the wrong order. [Pull request #1877](https://github.com/WPBuddy/largo/pull/1877) for [issue #1868](https://github.com/WPBuddy/largo/issues/1868) by [@pedroxido](https://github.com/pedroxido).
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
+- Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1864](https://github.com/WPBuddy/largo/pull/1864) for [issue #1906](https://github.com/WPBuddy/largo/issues/1906).
 
 ### Potentially-breaking changes
 

--- a/inc/avatars.php
+++ b/inc/avatars.php
@@ -52,3 +52,54 @@ function largo_has_avatar( $email ) {
 	}
 	return false;
 }
+
+/**
+ * Filter the get_avatar function to allow it to return the custom
+ * largo_avatar metafield value if it exists.
+ * 
+ * @see: https://github.com/INN/largo/issues/1864
+ * 
+ * @param string $avatar HTML for the user's avatar
+ * @param mixed $id_or_email The (gr)avatar to retrieve
+ * @param array $args Arguements passed to get_avatar_url()
+ * 
+ * @return string $avatar HTML for the user's avatar
+ */
+function largo_get_avatar_custom_avatar( $avatar, $id_or_email, $args ) {
+
+    $user = false;
+
+    if ( is_numeric( $id_or_email ) ) {
+
+        $id = (int) $id_or_email;
+        $user = get_user_by( 'id' , $id );
+
+    } elseif ( is_object( $id_or_email ) ) {
+
+        if ( ! empty( $id_or_email->user_id ) ) {
+
+            $id = (int) $id_or_email->user_id;
+			$user = get_user_by( 'id' , $id );
+
+        }
+
+    } else {
+
+		$user = get_user_by( 'email', $id_or_email );	
+
+    }
+
+    if ( $user && is_object( $user ) ) {
+
+		if( function_exists( 'largo_has_avatar' ) && function_exists( 'largo_get_user_avatar_id' ) ) {
+			if( largo_has_avatar( $user->user_email ) ) {
+				$avatar = wp_get_attachment_image( largo_get_user_avatar_id( $user->ID ), 96, false, array( 'alt' => $user->display_name ) );
+			}
+		}
+
+    }
+
+	return $avatar;
+
+}
+add_filter( 'pre_get_avatar' , 'largo_get_avatar_custom_avatar', 10 , 3 );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds in new `largo_get_avatar_custom_avatar` function to be used on the `pre_get_avatar` filter to make sure WP is able to find any custom `largo_avatar` when searching for a user avatar.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1864

## Testing/Questions

Features that this PR affects:

- User avatars/profile pictures 

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Has the `changelog.md` file been updated to reflect the updates in this PR?
- [ ] Is there a better function name than `largo_get_avatar_custom_avatar`?

Steps to test this PR:

1. Add an avatar to a user profile
2. View that user profile and make sure the avatar/profile image still shows as expected