### PR TITLE
1839 - Fix discrepancy between series footer widget name vs. what landing page looks for

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Update all npm packages to latest version; updated package.json command scripts to allow developers to quickly run grunt tasks [Pull request](https://github.com/WPBuddy/largo/pull/1899) fixes issue [#1540](https://github.com/WPBuddy/largo/issues/1540)
 - Fixes `Largo_Related::popularity_sort` sorting in the wrong order. [Pull request #1877](https://github.com/WPBuddy/largo/pull/1877) for [issue #1868](https://github.com/WPBuddy/largo/issues/1868) by [@pedroxido](https://github.com/pedroxido).
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
+- Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1839](https://github.com/WPBuddy/largo/pull/1839) for [issue #1907](https://github.com/WPBuddy/largo/issues/1907).
 
 ### Potentially-breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -40,7 +40,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Update all npm packages to latest version; updated package.json command scripts to allow developers to quickly run grunt tasks [Pull request](https://github.com/WPBuddy/largo/pull/1899) fixes issue [#1540](https://github.com/WPBuddy/largo/issues/1540)
 - Fixes `Largo_Related::popularity_sort` sorting in the wrong order. [Pull request #1877](https://github.com/WPBuddy/largo/pull/1877) for [issue #1868](https://github.com/WPBuddy/largo/issues/1868) by [@pedroxido](https://github.com/pedroxido).
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
-- Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1839](https://github.com/WPBuddy/largo/pull/1839) for [issue #1907](https://github.com/WPBuddy/largo/issues/1907).
+- Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1907](https://github.com/WPBuddy/largo/pull/1907) for [issue #1839](https://github.com/WPBuddy/largo/issues/1839).
 
 ### Potentially-breaking changes
 

--- a/series-landing.php
+++ b/series-landing.php
@@ -186,9 +186,7 @@ if ( 'none' != $opt['footer_style'] ) : ?>
 				echo apply_filters( 'the_content', $opt['footerhtml'] );
 			} else if ( 'widget' == $opt['footer_style'] && is_active_sidebar( largo_make_slug( $post->post_title )."_footer" ) ) { ?>
 				<aside id="sidebar-bottom">
-				<?php dynamic_sidebar( largo_make_slug( $post->post_title )."_footer" );
-				
-				var_dump(largo_make_slug( $post->post_title )."_footer");?>
+				<?php dynamic_sidebar( largo_make_slug( $post->post_title )."_footer" ); ?>
 				</aside>
 			<?php }
 		?>

--- a/series-landing.php
+++ b/series-landing.php
@@ -184,9 +184,11 @@ if ( 'none' != $opt['footer_style'] ) : ?>
 			wp_reset_postdata();
 			if ( 'custom' == $opt['footer_style']) {
 				echo apply_filters( 'the_content', $opt['footerhtml'] );
-			} else if ( 'widget' == $opt['footer_style'] && is_active_sidebar( $post->post_name . "_footer" ) ) { ?>
+			} else if ( 'widget' == $opt['footer_style'] && is_active_sidebar( largo_make_slug( $post->post_title )."_footer" ) ) { ?>
 				<aside id="sidebar-bottom">
-				<?php dynamic_sidebar( $post->post_name . "_footer" ); ?>
+				<?php dynamic_sidebar( largo_make_slug( $post->post_title )."_footer" );
+				
+				var_dump(largo_make_slug( $post->post_title )."_footer");?>
 				</aside>
 			<?php }
 		?>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates the `series-landing.php` template to search for `largo_make_slug( $post->post_title )."_footer")` as opposed to `$post->post_name . "_footer"` because when the sidebar is created, it's created by `largo_make_slug( $widget->post_title  )` here:
https://github.com/WPBuddy/largo/blob/825dce582300231d4723cad32e497b4824df5bc0/inc/wp-taxonomy-landing/functions/cftl-admin.php#L652


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1839

## Testing/Questions

Features that this PR affects:

- Series landing page footer widget areas

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Has the `changelog.md` file been updated to reflect the updates in this PR?

Steps to test this PR:

1. Add in series with an awkward title, such as `<center>CLARIFY:<br>The City Limits Accountability Reporting<br> Initiative For Youth</center>` (title we found the bug on)
2. Make sure that series footer area has "widget area" selected
3. Add a widget to the newly created footer widget area
4. View the series landing page and make sure the widget area shows as expected