### PR TITLE
Turn $options into key/val array so -1 is now the value for "all"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
 - Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1907](https://github.com/WPBuddy/largo/pull/1907) for [issue #1839](https://github.com/WPBuddy/largo/issues/1839).
 - Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1906](https://github.com/WPBuddy/largo/pull/1906) for [issue #1864](https://github.com/WPBuddy/largo/issues/1864).
+- Solves an issue where the "All" option for the series landing page "posts per page" setting wasn't saving or working as expected. [Pull request #1909](https://github.com/WPBuddy/largo/pull/1909) for [issue #1908](https://github.com/WPBuddy/largo/issues/1908).
 
 ### Potentially-breaking changes
 

--- a/inc/wp-taxonomy-landing/functions/cftl-admin.php
+++ b/inc/wp-taxonomy-landing/functions/cftl-admin.php
@@ -435,9 +435,9 @@ function cftl_tax_landing_main($post) {
 	<div>
 		<select name="per_page">
 			<?php
-				$options = array("5", "10", "15", "20", "30", "all");
-				foreach ($options as $opt) {
-					echo '<option value="', $opt, '"', selected( $fields['per_page'][0], $opt), '>', $opt, "</option>\n";
+				$options = array("5" => "5", "10" => "10", "15" => "15", "20" => "20", "30" => "30", "all" => "-1");
+				foreach ($options as $opt => $value) {
+					echo '<option value="', $value, '"', selected( $fields['per_page'][0], $value), '>', $opt, "</option>\n";
 				}
 			?>
 		</select>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates the `$options` array in `cftl-admin.php` to be a key/val array so that instead of "all" being the value for the "all" option and not actually working, `-1` can be the new value which is the correct WP Query way of saying "all"

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1908

## Testing/Questions

Features that this PR affects:

- Series landing pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Has the `changelog.md` file been updated to reflect the updates in this PR?

Steps to test this PR:

1. Create/find a series with >30 posts
2. Try out each "Posts per page" option and verify they all work as expected