### PR TITLE
`largo_get_series_landing_page_by_series` check for term_exists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
 - Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1907](https://github.com/WPBuddy/largo/pull/1907) for [issue #1839](https://github.com/WPBuddy/largo/issues/1839).
 - Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1906](https://github.com/WPBuddy/largo/pull/1906) for [issue #1864](https://github.com/WPBuddy/largo/issues/1864).
+- Updates `largo_get_series_landing_page_by_series` to verify that `$series` exists using `term_exists()` before attempting to use it. [Pull request #1910](https://github.com/WPBuddy/largo/pull/1910) for [issue #1844](https://github.com/WPBuddy/largo/issues/1844).
 
 ### Potentially-breaking changes
 

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -384,7 +384,7 @@ add_filter( 'post_type_link', 'largo_series_landing_link', 22, 2 );
  * @return array An array of all WP_Post objects answering the description of this series. May be 0, 1 or conceivably many.
  */
 function largo_get_series_landing_page_by_series( $series ) {
-	if ( ! is_object( $series ) ) {
+	if ( ! is_object( $series ) && term_exists( $series ) ) {
 		if ( is_int( $series ) ) {
 			$series = get_term( $series, $taxonomy );
 		} else {


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates the `largo_get_series_landing_page_by_series` function to check `term_exists()` along with `! is_object()` before attempting to move forward with using the provided series.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1844

## Testing/Questions

Features that this PR affects:

- Series lists

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Has the `changelog.md` file been updated to reflect the updates in this PR?

Steps to test this PR:

1. Add the Largo Taxonomy List widget to a sidebar and set it to use series and enable thumbnails.
2. View the widget on the frontend and make sure it still works as expected.