### PR TITLE
Adds in "DESC" case for Largo_Related get_series_posts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
 - Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1907](https://github.com/WPBuddy/largo/pull/1907) for [issue #1839](https://github.com/WPBuddy/largo/issues/1839).
 - Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1906](https://github.com/WPBuddy/largo/pull/1906) for [issue #1864](https://github.com/WPBuddy/largo/issues/1864).
+- Adds in case for "DESC" for `Largo_Related` series. [Pull request #1911](https://github.com/WPBuddy/largo/pull/1911) for [issue #1863](https://github.com/WPBuddy/largo/issues/1863).
 
 ### Potentially-breaking changes
 

--- a/inc/related-content.php
+++ b/inc/related-content.php
@@ -645,6 +645,8 @@ class Largo_Related {
 							case 'ASC':
 								$args['order'] = 'ASC';
 								break;
+							case 'DESC':
+								$args['order'] = 'DESC';
 							// 'series_custom' and 'featured' are custom ones, caught with largo_series_custom_order in inc/wp-taxonomy-landing/functions/cftl-series-order.php
 							case 'custom':
 								$args['orderby'] = 'series_custom';


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds in a `DESC` case in `Largo_Related` `get_series_posts` so that sorting the series posts from oldest to newest works as expected

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1863

## Testing/Questions

Features that this PR affects:

- Largo related posts widget

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Has the `changelog.md` file been updated to reflect the updates in this PR?

Steps to test this PR:

1. Create/find a series with multiple posts
2. Add the Largo Related widget to posts
3. View a post inside of a series and verify the series posts in the Largo related widget are sorting based off of their sort option in the landing page editor