### PR TITLE
1842 Make widget background options filterable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@ Particular thanks go to outside contributor [@seanchayes](https://github.com/sea
 - Fixes `Undefined variable: feature_posts in partials/sticky-posts.php` on line 60. [Pull request #1814](https://github.com/WPBuddy/largo/pull/1814) for [issue #1765](https://github.com/WPBuddy/largo/issues/1765) by [@amnuts](https://github.com/amnuts).
 - Fixes an issue where Largo series landing pages would sometimes not find their assigned footer widget area. [Pull request #1907](https://github.com/WPBuddy/largo/pull/1907) for [issue #1839](https://github.com/WPBuddy/largo/issues/1839).
 - Fixes an issue where `largo_has_avatar()` would return `true` even if `get_avatar()` returned no avatar by adding a function to hook into the `pre_get_avatar` filter and making sure it uses the custom `largo_avatar` meta if available. [Pull request #1906](https://github.com/WPBuddy/largo/pull/1906) for [issue #1864](https://github.com/WPBuddy/largo/issues/1864).
+- Adds new `largo_widget_background_options` filter to allow developers to add to/create their own list of widget background options to be used. [Pull request #1912](https://github.com/WPBuddy/largo/pull/1912) for [issue #1842](https://github.com/WPBuddy/largo/issues/1842).
 
 ### Potentially-breaking changes
 

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -249,6 +249,44 @@ filter: **largo_post_social_more_social_links**
         }
         add_filter('largo_top_term_metabox_taxonomies', 'add_taxonomies');
 
+filter: **largo_widget_background_options**
+    *args: Array $widget_background_options*
+
+    Called in `largo_widget_custom_fields_form` to filter the array of background options that widgets can use.
+
+    Passed is an array, where each item in the array must contain a `value` and `label` key to indicate the background option value and text label. The default array in Largo is:
+
+    $widget_background_options = array(
+		0 => array(
+			'value' => 'default',
+			'label' => 'Default'
+		),
+		1 => array(
+			'value' => 'rev',
+			'label' => 'Reverse'
+		),
+		2 => array(
+			'value' => 'no-bg',
+			'label' => 'No Background'
+		)
+	);
+
+    Adding new background options is as simple as adding a new item to the array: ::
+
+        function add_new_background_option( $options ) {
+
+            $my_custom_option = array(
+                'value' => 'my-opt',
+                'label' => 'My Custom Option'
+            );
+
+            $options['my_custom_option'] = $my_custom_option;
+
+            return $options;
+            
+        }
+        add_filter( 'largo_widget_background_options', 'add_new_background_option' );
+
 
 Template Hooks
 --------------

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -254,7 +254,7 @@ filter: **largo_widget_background_options**
 
     Called in `largo_widget_custom_fields_form` to filter the array of background options that widgets can use.
 
-    Passed is an array, where each item in the array must contain a `value` and `label` key to indicate the background option value and text label. The default array in Largo is:
+    Passed is an array, where each item in the array must contain a `value` and `label` key to indicate the background option value and text label. The default array in Largo is: ::
 
         $widget_background_options = array(
             0 => array(

--- a/docs/developers/hooksfilters.rst
+++ b/docs/developers/hooksfilters.rst
@@ -256,20 +256,20 @@ filter: **largo_widget_background_options**
 
     Passed is an array, where each item in the array must contain a `value` and `label` key to indicate the background option value and text label. The default array in Largo is:
 
-    $widget_background_options = array(
-		0 => array(
-			'value' => 'default',
-			'label' => 'Default'
-		),
-		1 => array(
-			'value' => 'rev',
-			'label' => 'Reverse'
-		),
-		2 => array(
-			'value' => 'no-bg',
-			'label' => 'No Background'
-		)
-	);
+        $widget_background_options = array(
+            0 => array(
+                'value' => 'default',
+                'label' => 'Default'
+            ),
+            1 => array(
+                'value' => 'rev',
+                'label' => 'Reverse'
+            ),
+            2 => array(
+                'value' => 'no-bg',
+                'label' => 'No Background'
+            )
+        );
 
     Adding new background options is as simple as adding a new item to the array: ::
 

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -138,12 +138,31 @@ function largo_widget_custom_fields_form( $widget, $args, $instance ) {
 	$desktop = ! empty( $instance['hidden_desktop'] ) ? 'checked="checked"' : '';
 	$tablet = ! empty( $instance['hidden_tablet'] ) ? 'checked="checked"' : '';
 	$phone = ! empty( $instance['hidden_phone'] ) ? 'checked="checked"' : '';
+
+	$widget_background_options = array(
+		0 => array(
+			'value' => 'default',
+			'label' => 'Default'
+		),
+		1 => array(
+			'value' => 'rev',
+			'label' => 'Reverse'
+		),
+		2 => array(
+			'value' => 'no-bg',
+			'label' => 'No Background'
+		)
+	);
+
+	$widget_background_options = apply_filters( 'largo_widget_background_options', $widget_background_options, $widget_background_options );
 ?>
   <label for="<?php echo $widget->get_field_id( 'widget_class' ); ?>"><?php _e('Widget Background', 'largo'); ?></label>
   <select id="<?php echo $widget->get_field_id('widget_class'); ?>" name="<?php echo $widget->get_field_name('widget_class'); ?>" class="widefat" style="width:90%;">
-  	<option <?php selected( $instance['widget_class'], 'default'); ?> value="default"><?php _e('Default', 'largo'); ?></option>
-  	<option <?php selected( $instance['widget_class'], 'rev'); ?> value="rev"><?php _e('Reverse', 'largo'); ?></option>
-  	<option <?php selected( $instance['widget_class'], 'no-bg'); ?> value="no-bg"><?php _e('No Background', 'largo'); ?></option>
+	<?php
+		foreach( $widget_background_options as $background_option ) {
+			echo '<option '.selected( $instance['widget_class'], $background_option['value'] ).' value="'.$background_option['value'].'">'.__( $background_option['label'], 'largo').'</option>';
+		}
+	?>
   </select>
 
   <p style="margin:15px 0 10px 5px">


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds new `largo_widget_background_options` filter to allow developers to use a custom list for widget background options or add a few of their own to the existing list.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1842

## Testing/Questions

Features that this PR affects:

- Widget background options

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Has the `changelog.md` file been updated to reflect the updates in this PR?

Steps to test this PR:

1. Add a `Largo ...` widget to a widget area
2. Test all of the default backgrounds to ensure they work
3. Attempt to hook into the options list. Sample code to do so:
```
function test($opts){
	$my_custom_opt = array(
			'value' => 'howdy',
			'label' => 'Howdy Do'
	);
	$opts['my_custom_opt'] = $my_custom_opt;
	return $opts;
}
add_filter('largo_widget_background_options', 'test');
```
4. Verify you're able to see the updated options list and nothing is broken
5. Read the updated [hooks and filters doc](https://github.com/WPBuddy/largo/blob/ffb38eabf631a9e693869e14922ed2cda9a22b76/docs/developers/hooksfilters.rst) and verify the documentation for the new filter makes sense